### PR TITLE
Rewritten queries bug

### DIFF
--- a/src/main/java/com/o19s/es/ltr/query/LtrQuery.java
+++ b/src/main/java/com/o19s/es/ltr/query/LtrQuery.java
@@ -106,7 +106,8 @@ public class LtrQuery extends Query {
         protected LtrWeight(IndexSearcher searcher, boolean needsScores) throws IOException {
             super(LtrQuery.this);
             for (Query feature : _features) {
-                weights.add(searcher.createWeight(feature, needsScores));
+                Query rewritten = feature.rewrite(searcher.getIndexReader());
+                weights.add(searcher.createWeight(rewritten, needsScores));
             }
             this._needsScores = needsScores;
             this._similarity = searcher.getSimilarity(needsScores);


### PR DESCRIPTION
Some queries exist only to implement `rewrite` and return another query. In and of themselves they do not implement the needed functionality to be a  fully fledged query. This PR ensures that the ritual of calling rewrite before using a query is followed.

(most of the changes are restructuring tests to try with a different blend of features)