### PR TITLE
Features not computed for missing terms

### DIFF
--- a/src/main/java/com/o19s/es/ltr/query/LtrQuery.java
+++ b/src/main/java/com/o19s/es/ltr/query/LtrQuery.java
@@ -155,6 +155,8 @@ public class LtrQuery extends Query {
                 Scorer subScorer = w.scorer(context);
                 if (subScorer != null) {
                     scorers.add(subScorer);
+                } else {
+                    scorers.add(new NoopScorer(w, context.reader().maxDoc()));
                 }
             }
             if (scorers.isEmpty()) {

--- a/src/main/java/com/o19s/es/ltr/query/NoopScorer.java
+++ b/src/main/java/com/o19s/es/ltr/query/NoopScorer.java
@@ -1,0 +1,44 @@
+package com.o19s.es.ltr.query;
+
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+
+import java.io.IOException;
+
+/**
+ * Created by doug on 2/3/17.
+ */
+public class NoopScorer extends Scorer {
+    private DocIdSetIterator _noopIter;
+    /**
+     * Constructs a Scorer
+     *
+     * @param weight The scorers <code>Weight</code>.
+     */
+    protected NoopScorer(Weight weight, int maxDocs) {
+        super(weight);
+        _noopIter = DocIdSetIterator.all(maxDocs);
+
+    }
+
+    @Override
+    public int docID() {
+        return _noopIter.docID();
+    }
+
+    @Override
+    public float score() throws IOException {
+        return 0;
+    }
+
+    @Override
+    public int freq() throws IOException {
+        return 0;
+    }
+
+    @Override
+    public DocIdSetIterator iterator() {
+        return _noopIter;
+    }
+}

--- a/src/test/java/com/o19s/es/ltr/query/LtrQueryTests.java
+++ b/src/test/java/com/o19s/es/ltr/query/LtrQueryTests.java
@@ -246,6 +246,17 @@ public class LtrQueryTests extends LuceneTestCase {
     }
 
 
+    public void testNoMatchQueries() throws IOException {
+        String userQuery = "brown cow";
+
+        Term[] termsToBlend = new Term[]{new Term("field",  userQuery.split(" ")[0])};
+
+        Query blended = BlendedTermQuery.booleanBlendedQuery(termsToBlend, false);
+        List<Query> features = Arrays.asList(new Query[] {new TermQuery(new Term("field",  "missingterm")), blended});
+
+        checkModelWithFeatures(features);
+    }
+
     @After
     public void closeStuff() throws IOException {
         indexReaderUnderTest.close();


### PR DESCRIPTION
Sometimes leaf IndexReaders don't include a term, so there's no scorer returned by the weight. This PR takes care this case by injecting a NoopScorer when null is returned. (test included)