### PR TITLE
Use ranklib plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,11 +189,11 @@ Viola! Periodically you'll want to retrain your model. Features may change or ju
 
 # Development
 
-### 1. Install [Ranklib-2.6.jar](https://sourceforge.net/projects/lemur/files/lemur/RankLib-2.6/RankLib-2.6.jar/download) in your local maven repo manually:
-Download the RankLib jar from the link above and use the following command to install it in your local Maven repo (the quotes around the command arguments will help Maven run without a pom file in the current directory.)
+### 1. Install [RanklibPlus.jar](https://github.com/o19s/ranklibplus) in your local maven repo manually:
+Download the RankLibPlus jar from the link above and use the following command to install it in your local Maven repo (the quotes around the command arguments will help Maven run without a pom file in the current directory.)
 
 ```
-mvn install:install-file "-DgroupId=edu.umass.ciir" "-DartifactId=RankLib" "-Dversion=2.6" "-Dpackaging=jar" "-Dfile=/path/to/downloaded/RankLib-2.6.jar"
+mvn install:install-file "-DgroupId=com.o19s" "-DartifactId=RankLibPlus" "-Dversion=0.1" "-Dpackaging=jar" "-Dfile=./RankLibPlus-0.1.0.jar"
 ```
 
 ### 2. Build with Gradle 2.13

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ repositories {
 }
 dependencies {
   compile 'org.elasticsearch:elasticsearch:5.1.1'
-  compile 'edu.umass.ciir:RankLib:2.6'
+  compile 'com.o19s:RankLibPlus:0.1'
   testCompile 'org.elasticsearch.test:framework:5.1.1'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 }
 
 group = 'org.elasticsearch.plugin.ingest'
-version = '0.0.3-alpha'
+version = '0.0.4-alpha'
 
 apply plugin: 'java'
 apply plugin: 'elasticsearch.esplugin'

--- a/src/main/java/com/o19s/es/ltr/query/NoopScorer.java
+++ b/src/main/java/com/o19s/es/ltr/query/NoopScorer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright [2016] Doug Turnbull
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.o19s.es.ltr.query;
 
 import org.apache.lucene.search.DocIdSetIterator;


### PR DESCRIPTION
Depend on [RankLibPlus](http://github.com/o19s/ranklibplus) instead of Ranklib. This resolves a nasty performance problem when loading models due to slow deserialization of LambdaMART models in RankLib.