### PR TITLE
LtrQueryBuilder should support the rewrite step

### DIFF
--- a/src/main/java/com/o19s/es/ltr/feature/Feature.java
+++ b/src/main/java/com/o19s/es/ltr/feature/Feature.java
@@ -17,9 +17,6 @@
 package com.o19s.es.ltr.feature;
 
 import org.apache.lucene.search.Query;
-import org.elasticsearch.index.query.QueryShardContext;
-
-import java.util.Map;
 
 /**
  * A feature that can be transformed into a lucene query
@@ -33,5 +30,5 @@ public interface Feature {
     /**
      * Transform this feature into a lucene query
      */
-    Query doToQuery(QueryShardContext context, Map<String, Object> params);
+    Query doToQuery();
 }

--- a/src/main/java/com/o19s/es/ltr/feature/FeatureSet.java
+++ b/src/main/java/com/o19s/es/ltr/feature/FeatureSet.java
@@ -17,10 +17,8 @@
 package com.o19s.es.ltr.feature;
 
 import org.apache.lucene.search.Query;
-import org.elasticsearch.index.query.QueryShardContext;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * A set of features.
@@ -37,7 +35,7 @@ public interface FeatureSet {
     /**
      * Parse and build lucene queries
      */
-    List<? extends Query> toQueries(QueryShardContext context, Map<String, Object> params);
+    List<? extends Query> toQueries();
 
     /**
      * Retrieve feature ordinal by its name.

--- a/src/main/java/com/o19s/es/ltr/feature/PrebuiltFeature.java
+++ b/src/main/java/com/o19s/es/ltr/feature/PrebuiltFeature.java
@@ -21,10 +21,8 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Weight;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.index.query.QueryShardContext;
 
 import java.io.IOException;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -46,7 +44,7 @@ public class PrebuiltFeature extends Query implements Feature {
     }
 
     @Override
-    public Query doToQuery(QueryShardContext context, Map<String, Object> params) {
+    public Query doToQuery() {
         return query;
     }
 

--- a/src/main/java/com/o19s/es/ltr/feature/PrebuiltFeatureSet.java
+++ b/src/main/java/com/o19s/es/ltr/feature/PrebuiltFeatureSet.java
@@ -18,11 +18,9 @@ package com.o19s.es.ltr.feature;
 
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.index.query.QueryShardContext;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.RandomAccess;
 import java.util.stream.IntStream;
@@ -49,7 +47,7 @@ public class PrebuiltFeatureSet implements FeatureSet {
      * Parse and build lucene queries
      */
     @Override
-    public List<? extends Query> toQueries(QueryShardContext context, Map<String, Object> params) {
+    public List<? extends Query> toQueries() {
         return features;
     }
 

--- a/src/main/java/com/o19s/es/ltr/query/RankerQuery.java
+++ b/src/main/java/com/o19s/es/ltr/query/RankerQuery.java
@@ -18,7 +18,6 @@ package com.o19s.es.ltr.query;
 
 import com.o19s.es.ltr.feature.Feature;
 import com.o19s.es.ltr.feature.FeatureSet;
-import com.o19s.es.ltr.feature.LtrModel;
 import com.o19s.es.ltr.feature.PrebuiltLtrModel;
 import com.o19s.es.ltr.ranker.LtrRanker;
 import org.apache.lucene.index.IndexReader;
@@ -30,13 +29,10 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
-import org.elasticsearch.index.query.QueryShardContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.RandomAccess;
 import java.util.Set;
@@ -66,23 +62,11 @@ public class RankerQuery extends Query {
      * @return the lucene query
      */
     public static RankerQuery build(PrebuiltLtrModel model) {
-        return build(model, null, Collections.emptyMap());
+        return build(model.ranker(), model.featureSet());
     }
 
-    /**
-     * Build a RankerQuery.
-     *
-     * @param model The model
-     * @param context the context used to parse features into lucene queries
-     * @param params the query params
-     * @return the lucene query
-     */
-    public static RankerQuery build(LtrModel model, QueryShardContext context, Map<String, Object> params) {
-        return build(model.ranker(), model.featureSet(), context, params);
-    }
-
-    private static RankerQuery build(LtrRanker ranker, FeatureSet features, QueryShardContext context, Map<String, Object> params) {
-        List<? extends Query> queries = features.toQueries(context, params);
+    private static RankerQuery build(LtrRanker ranker, FeatureSet features) {
+        List<? extends Query> queries = features.toQueries();
         return new RankerQuery(queries, features, ranker);
     }
 

--- a/src/test/java/com/o19s/es/ltr/query/LtrQueryBuilderTests.java
+++ b/src/test/java/com/o19s/es/ltr/query/LtrQueryBuilderTests.java
@@ -18,14 +18,23 @@ package com.o19s.es.ltr.query;
 
 import com.o19s.es.ltr.LtrQueryParserPlugin;
 import org.apache.lucene.search.Query;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.index.query.TermsQueryBuilder;
+import org.elasticsearch.index.query.WrapperQueryBuilder;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.AbstractQueryTestCase;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 
@@ -186,7 +195,47 @@ public class LtrQueryBuilderTests extends AbstractQueryTestCase<LtrQueryBuilder>
         return queryBuilder;
     }
 
+    /**
+     * This test ensures that queries that need to be rewritten have dedicated tests.
+     * These queries must override this method accordingly.
+     */
+    @Override
+    public void testMustRewrite() throws IOException {
+        Script script = new Script(ScriptType.INLINE, "ranklib", simpleModel, Collections.emptyMap());
+        List<QueryBuilder> features = new ArrayList<>();
+        boolean mustRewrite = false;
+        int idx = 0;
+        if (randomBoolean()) {
+            idx++;
+            features.add(new TermQueryBuilder("test", "test"));
+        }
+        if (randomBoolean()) {
+            mustRewrite = true;
+            features.add(new WrapperQueryBuilder(new TermsQueryBuilder("foo", "feat").toString()));
+        }
+        if (randomBoolean()) {
+            features.add(new TermQueryBuilder("test", "test"));
+        }
 
+        LtrQueryBuilder builder = new LtrQueryBuilder(script, features);
+        QueryBuilder rewritten = builder.rewrite(createShardContext());
+        if (mustRewrite == false && features.isEmpty()) {
+            // if it's empty we rewrite to match all
+            assertEquals(rewritten, new MatchAllQueryBuilder());
+        } else {
+            LtrQueryBuilder rewrite = (LtrQueryBuilder) rewritten;
+            if (mustRewrite) {
+                assertNotSame(rewrite, builder);
+                if (builder.features().isEmpty() == false) {
+                    assertEquals(builder.features().size(), rewrite.features().size());
+                    assertSame(builder.rankerScript(), rewrite.rankerScript());
+                    assertEquals(new TermsQueryBuilder("foo", "1st feat"), rewrite.features().get(idx));
+                }
+            } else {
+                assertSame(rewrite, builder);
+            }
+        }
+    }
 
     @Override
     protected void doAssertLuceneQuery(LtrQueryBuilder queryBuilder, Query query, SearchContext context) throws IOException {


### PR DESCRIPTION
It was missed but is needed by some queries because they'll fail
if they are not rewritten.
This changes my mind concerning the model I'm not sure now
that it's reasonable to consider that FeatureSet.toQueries()
will accept a QueryShardContext and a map of params, it's likely
that templating will happen before.