### PR TITLE
Implement base components for the feature store

### DIFF
--- a/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
+++ b/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
@@ -16,30 +16,66 @@
  */
 package com.o19s.es.ltr;
 
+import ciir.umass.edu.learning.RankerFactory;
+import com.o19s.es.ltr.feature.store.index.Caches;
 import com.o19s.es.ltr.query.LtrQueryBuilder;
+import com.o19s.es.ltr.query.StoredLtrQueryBuilder;
+import com.o19s.es.ltr.ranker.parser.LtrRankerParserFactory;
 import com.o19s.es.ltr.ranker.ranklib.RankLibScriptEngine;
+import com.o19s.es.ltr.ranker.ranklib.RanklibModelParser;
+import com.o19s.es.ltr.utils.FeatureStoreProvider;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.plugins.SearchPlugin;
+import org.elasticsearch.script.NativeScriptFactory;
 import org.elasticsearch.script.ScriptEngineService;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
-import static java.util.Collections.singletonList;
-
 public class LtrQueryParserPlugin extends Plugin implements SearchPlugin, ScriptPlugin {
+    private final LtrRankerParserFactory parserFactory;
+    private final Caches caches;
+    // Lazy loaded
+    private RankerFactory ranklibFactory;
+
+    public LtrQueryParserPlugin(Settings settings) {
+        caches = new Caches(settings);
+        parserFactory = new LtrRankerParserFactory.Builder()
+                .register(RanklibModelParser.TYPE, () -> new RanklibModelParser(getRanklibFactory()))
+                .build();
+    }
+
     @Override
     public List<QuerySpec<?>> getQueries() {
-        return singletonList(new QuerySpec<>(LtrQueryBuilder.NAME, LtrQueryBuilder::new, LtrQueryBuilder::fromXContent));
+        return Arrays.asList(
+                new QuerySpec<>(LtrQueryBuilder.NAME, LtrQueryBuilder::new, LtrQueryBuilder::fromXContent),
+                new QuerySpec<>(StoredLtrQueryBuilder.NAME, StoredLtrQueryBuilder::new, StoredLtrQueryBuilder::fromXContent));
     }
 
     @Override
-    /**
-     * Returns a {@link ScriptEngineService} instance or <code>null</code> if this plugin doesn't add a new script engine
-     */
     public ScriptEngineService getScriptEngineService(Settings settings) {
-        return new RankLibScriptEngine(settings);
+        return new RankLibScriptEngine(settings, parserFactory);
     }
 
+    /**
+     * Returns a list of {@link NativeScriptFactory} instances.
+     */
+    @Override
+    public List<NativeScriptFactory> getNativeScripts() {
+        return Collections.singletonList(new FeatureStoreProvider.Factory(getFeatureStoreLoader()));
+    }
+
+    protected FeatureStoreProvider.FeatureStoreLoader getFeatureStoreLoader() {
+        return FeatureStoreProvider.defaultFeatureStoreLoad(caches, parserFactory);
+    }
+
+    private RankerFactory getRanklibFactory() {
+        if (ranklibFactory == null) {
+            ranklibFactory = new RankerFactory();
+        }
+        return  ranklibFactory;
+    }
 }

--- a/src/main/java/com/o19s/es/ltr/feature/FeatureSet.java
+++ b/src/main/java/com/o19s/es/ltr/feature/FeatureSet.java
@@ -17,8 +17,10 @@
 package com.o19s.es.ltr.feature;
 
 import org.apache.lucene.search.Query;
+import org.elasticsearch.index.query.QueryShardContext;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * A set of features.
@@ -35,7 +37,7 @@ public interface FeatureSet {
     /**
      * Parse and build lucene queries
      */
-    List<? extends Query> toQueries();
+    List<Query> toQueries(QueryShardContext context, Map<String, Object> params);
 
     /**
      * Retrieve feature ordinal by its name.

--- a/src/main/java/com/o19s/es/ltr/feature/PrebuiltFeature.java
+++ b/src/main/java/com/o19s/es/ltr/feature/PrebuiltFeature.java
@@ -21,8 +21,10 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Weight;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.index.query.QueryShardContext;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -44,7 +46,7 @@ public class PrebuiltFeature extends Query implements Feature {
     }
 
     @Override
-    public Query doToQuery() {
+    public Query doToQuery(QueryShardContext context, Map<String, Object> params) {
         return query;
     }
 

--- a/src/main/java/com/o19s/es/ltr/feature/PrebuiltFeatureSet.java
+++ b/src/main/java/com/o19s/es/ltr/feature/PrebuiltFeatureSet.java
@@ -18,24 +18,21 @@ package com.o19s.es.ltr.feature;
 
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.index.query.QueryShardContext;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
-import java.util.RandomAccess;
 import java.util.stream.IntStream;
 
 public class PrebuiltFeatureSet implements FeatureSet {
-    private final List<PrebuiltFeature> features;
+    private final List<Query> features;
     private final String name;
 
     public PrebuiltFeatureSet(@Nullable String name, List<PrebuiltFeature> features) {
         this.name = name;
-        features = Objects.requireNonNull(features);
-        if (!(features instanceof RandomAccess)) {
-            features = new ArrayList<>(features);
-        }
-        this.features = features;
+        this.features = new ArrayList<>(Objects.requireNonNull(features));
     }
 
     @Override
@@ -47,7 +44,7 @@ public class PrebuiltFeatureSet implements FeatureSet {
      * Parse and build lucene queries
      */
     @Override
-    public List<? extends Query> toQueries() {
+    public List<Query> toQueries(QueryShardContext context, Map<String, Object> params) {
         return features;
     }
 
@@ -62,12 +59,12 @@ public class PrebuiltFeatureSet implements FeatureSet {
 
     @Override
     public Feature feature(int ord) {
-        return features.get(ord);
+        return (PrebuiltFeature) features.get(ord);
     }
 
     @Override
     public PrebuiltFeature feature(String name) {
-        return features.get(featureOrdinal(name));
+        return (PrebuiltFeature) features.get(featureOrdinal(name));
     }
 
     @Override
@@ -85,7 +82,7 @@ public class PrebuiltFeatureSet implements FeatureSet {
         // would make sense to implement a Map to do this once
         // feature names are mandatory and unique.
         return IntStream.range(0, features.size())
-                .filter(i -> Objects.equals(features.get(i).name(), featureName))
+                .filter(i -> Objects.equals(((PrebuiltFeature)features.get(i)).name(), featureName))
                 .findFirst()
                 .orElse(-1);
     }

--- a/src/main/java/com/o19s/es/ltr/feature/store/FeatureStore.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/FeatureStore.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.feature.store;
+
+import java.io.IOException;
+
+/**
+ * A feature store
+ */
+public interface FeatureStore {
+    String getStoreName();
+    StoredFeature load(String id) throws IOException;
+    StoredFeatureSet loadSet(String id) throws IOException;
+    StoredLtrModel loadModel(String id) throws IOException;
+}

--- a/src/main/java/com/o19s/es/ltr/feature/store/StoredFeature.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/StoredFeature.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.feature.store;
+
+import com.o19s.es.ltr.feature.Feature;
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.QueryShardException;
+import org.elasticsearch.script.ExecutableScript;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptType;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
+import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_HEADER;
+import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+
+public class StoredFeature implements Feature, Accountable {
+    private static final long BASE_RAM_USED = RamUsageEstimator.shallowSizeOfInstance(StoredFeature.class);
+    private static final String DEFAULT_TEMPLATE_LANGUAGE = "mustache";
+    private final String name;
+    private final Collection<String> queryParams;
+    private final String templateLanguage;
+    private final String template;
+
+    private static final ObjectParser<ParsingState, Void> PARSER;
+
+    static {
+        PARSER = new ObjectParser<>("ltr_feature", ParsingState::new);
+        PARSER.declareString(ParsingState::setName, new ParseField("name"));
+        PARSER.declareStringArray(ParsingState::setQueryParams, new ParseField("params"));
+        PARSER.declareString(ParsingState::setTemplateLanguage, new ParseField("template_language"));
+        PARSER.declareField(ParsingState::setTemplate, (parser, value) -> {
+            if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
+                try (XContentBuilder builder = XContentFactory.contentBuilder(parser.contentType())) {
+                    return builder.copyCurrentStructure(parser).bytes().utf8ToString();
+                } catch (IOException e) {
+                    throw new ParsingException(parser.getTokenLocation(), "Could not parse inline template", e);
+                }
+            } else {
+                return parser.text();
+            }
+        }, new ParseField("template"), ObjectParser.ValueType.OBJECT_OR_STRING);
+    }
+
+    public StoredFeature(String name, Collection<String> params, String templateLanguage, String template) {
+        this.name = Objects.requireNonNull(name);
+        this.queryParams = Objects.requireNonNull(params);
+        this.templateLanguage = Objects.requireNonNull(templateLanguage);
+        this.template = Objects.requireNonNull(template);
+    }
+
+    public static StoredFeature parse(XContentParser parser) {
+        try {
+            ParsingState state = PARSER.apply(parser, null);
+            if (state.name == null) {
+                throw new ParsingException(parser.getTokenLocation(), "Field [name] is mandatory");
+            }
+            if (state.queryParams == null) {
+                state.queryParams = Collections.emptyList();
+            }
+            if (state.template == null) {
+                throw new ParsingException(parser.getTokenLocation(), "Field [template] is mandatory");
+            }
+            return new StoredFeature(state.name, Collections.unmodifiableCollection(state.queryParams),
+                    state.templateLanguage, state.template);
+        } catch (IllegalArgumentException iae) {
+            throw new ParsingException(parser.getTokenLocation(), iae.getMessage(), iae);
+        }
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public Query doToQuery(QueryShardContext context, Map<String, Object> params) {
+        boolean missingParam = queryParams.stream().anyMatch(x -> !params.containsKey(x));
+        if (missingParam) {
+            // Is it sane to do this?
+            // should we fail?
+            return new MatchNoDocsQuery();
+        }
+        ExecutableScript script = context.getExecutableScript(new Script(ScriptType.INLINE,
+                templateLanguage, template, params), ScriptContext.Standard.SEARCH);
+        Object source = script.run();
+
+        try {
+            XContentParser parser = createParser(source, context.getXContentRegistry());
+            QueryParseContext parserContext = context.newParseContext(parser);
+            QueryBuilder queryBuilder = parserContext.parseInnerQueryBuilder().orElseThrow(
+                    () -> new ParsingException(parser.getTokenLocation(), "ltr inner query cannot be empty"));
+            // XXX: QueryShardContext extends QueryRewriteContext (for now)
+            return QueryBuilder.rewriteQuery(queryBuilder, context).toQuery(context);
+        } catch (IOException|ParsingException|IllegalArgumentException e) {
+            // wrap common exceptions as well so we can attach the feature's name to the stack
+            throw new QueryShardException(context, "Cannot create query while parsing feature [" + name +"]", e);
+        }
+    }
+
+    private XContentParser createParser(Object source, NamedXContentRegistry registry) throws IOException {
+        if (source instanceof String) {
+            return XContentFactory.xContent((String) source).createParser(registry, (String) source);
+        } else if (source instanceof BytesReference) {
+            return XContentFactory.xContent((BytesReference) source).createParser(registry, (BytesReference) source);
+        } else if (source instanceof byte[]) {
+            return XContentFactory.xContent((byte[]) source).createParser(registry, (byte[]) source);
+        } else {
+            throw new IllegalArgumentException("Template engine returned an unsupported object type [" +
+                    source.getClass().getCanonicalName() + "]");
+        }
+    }
+
+    protected Collection<String> queryParams() {
+        return queryParams;
+    }
+
+    protected String templateLanguage() {
+        return templateLanguage;
+    }
+
+    protected String template() {
+        return template;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // rough estimation...
+        return BASE_RAM_USED +
+                (Character.BYTES * name.length()) + NUM_BYTES_ARRAY_HEADER +
+                queryParams.stream()
+                        .mapToLong(x -> (Character.BYTES * x.length()) +
+                                NUM_BYTES_OBJECT_REF + NUM_BYTES_OBJECT_HEADER + NUM_BYTES_ARRAY_HEADER).sum() +
+                (Character.BYTES * templateLanguage.length()) + NUM_BYTES_ARRAY_HEADER +
+                (Character.BYTES * template.length()) + NUM_BYTES_ARRAY_HEADER;
+    }
+
+    private static class ParsingState {
+        private String name;
+        private Collection<String> queryParams;
+        private String templateLanguage = DEFAULT_TEMPLATE_LANGUAGE;
+
+        private String template;
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        void setQueryParams(Collection<String> queryParams) {
+            this.queryParams = queryParams;
+        }
+
+        public void setTemplateLanguage(String templateLanguage) {
+            this.templateLanguage = templateLanguage;
+        }
+
+        void setTemplate(String template) {
+            this.template = template;
+        }
+    }
+}

--- a/src/main/java/com/o19s/es/ltr/feature/store/StoredFeatureSet.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/StoredFeatureSet.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.feature.store;
+
+import com.o19s.es.ltr.feature.Feature;
+import com.o19s.es.ltr.feature.FeatureSet;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.QueryShardContext;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.RandomAccess;
+
+import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
+import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_HEADER;
+import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+
+public class StoredFeatureSet implements FeatureSet, Accountable {
+    private final long BASE_RAM_USED = RamUsageEstimator.shallowSizeOfInstance(StoredFeatureSet.class);
+    private final String name;
+    private final Map<String, Integer> featureMap;
+    private final List<StoredFeature> features;
+
+    private static final ObjectParser<ParsingState, Void> PARSER;
+
+    static {
+        PARSER = new ObjectParser<>("ltr_feature", ParsingState::new);
+        PARSER.declareString(ParsingState::setName, new ParseField("name"));
+        PARSER.declareObjectArray(ParsingState::setFeatures,
+                (p, c) -> StoredFeature.parse(p),
+                new ParseField("features"));
+    }
+
+    public static StoredFeatureSet parse(XContentParser parser) {
+        try {
+            ParsingState state = PARSER.apply(parser, null);
+            if (state.name == null) {
+                throw new ParsingException(parser.getTokenLocation(), "Field [name] is mandatory");
+            }
+            if (state.features == null) {
+                throw new ParsingException(parser.getTokenLocation(), "Field [features] is mandatory");
+            }
+            if (state.features.isEmpty()) {
+                throw new ParsingException(parser.getTokenLocation(), "At least one feature must be defined in [features]");
+            }
+            return new StoredFeatureSet(state.name, state.features);
+        } catch (IllegalArgumentException iae) {
+            throw new ParsingException(parser.getTokenLocation(), iae.getMessage(), iae);
+        }
+    }
+
+    public StoredFeatureSet(String name, List<StoredFeature> features) {
+        this.name = Objects.requireNonNull(name);
+        features = Objects.requireNonNull(features);
+        if (!(features instanceof RandomAccess)) {
+            features = new ArrayList<>(features);
+        }
+        this.features = features;
+        featureMap = new HashMap<>();
+        int ordinal = -1;
+        for (StoredFeature feature : features) {
+            ordinal++;
+            if (featureMap.put(feature.name(), ordinal) != null) {
+                throw new IllegalArgumentException("Feature [" + feature.name() + "] defined twice in this set: " +
+                        "feature names must be unique in a set.");
+            }
+        }
+
+    }
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public List<Query> toQueries(QueryShardContext context, Map<String, Object> params) {
+        List<Query> queries = new ArrayList<>(features.size());
+        for(Feature feature : features) {
+            queries.add(feature.doToQuery(context, params));
+        }
+        return queries;
+    }
+
+    @Override
+    public int featureOrdinal(String featureName) {
+        Integer ordinal = featureMap.get(featureName);
+        if (ordinal == null) {
+            throw new IllegalArgumentException("Unknown feature [" + featureName + "]");
+        }
+        return ordinal;
+    }
+
+    @Override
+    public StoredFeature feature(int ord) {
+        return features.get(ord);
+    }
+
+    @Override
+    public StoredFeature feature(String featureName) {
+        return features.get(featureOrdinal(featureName));
+    }
+
+    @Override
+    public boolean hasFeature(String featureName) {
+        return featureMap.containsKey(featureName);
+    }
+
+    @Override
+    public int size() {
+        return features.size();
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return BASE_RAM_USED +
+                featureMap.size() * NUM_BYTES_OBJECT_REF + NUM_BYTES_OBJECT_HEADER + NUM_BYTES_ARRAY_HEADER +
+                features.stream().mapToLong(StoredFeature::ramBytesUsed).sum();
+    }
+
+    private static class ParsingState {
+        private String name;
+        private List<StoredFeature> features;
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public void setFeatures(List<StoredFeature> features) {
+            this.features = features;
+        }
+    }
+}

--- a/src/main/java/com/o19s/es/ltr/feature/store/StoredLtrModel.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/StoredLtrModel.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.feature.store;
+
+import com.o19s.es.ltr.feature.LtrModel;
+import com.o19s.es.ltr.ranker.LtrRanker;
+import com.o19s.es.ltr.ranker.parser.LtrRankerParser;
+import com.o19s.es.ltr.ranker.parser.LtrRankerParserFactory;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
+import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_HEADER;
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
+
+public class StoredLtrModel implements LtrModel, Accountable {
+    private static final long BASE_RAM_USED = RamUsageEstimator.shallowSizeOfInstance(StoredLtrModel.class);
+    private final String name;
+    private final StoredFeatureSet featureSet;
+    private final LtrRanker ranker;
+
+    private static final ObjectParser<ParsingState, Void> PARSER;
+    static {
+        PARSER = new ObjectParser<>("ltr_model", ParsingState::new);
+        PARSER.declareString(ParsingState::setName, new ParseField("name"));
+        PARSER.declareObject(ParsingState::setFeatureSet,
+                (parser, ctx) -> StoredFeatureSet.parse(parser),
+                new ParseField("feature_set"));
+        PARSER.declareObject(ParsingState::setRankingModel, LtrModelDefinition.PARSER,
+                new ParseField("model"));
+    }
+
+    public StoredLtrModel(String name, StoredFeatureSet featureSet, LtrRanker ranker) {
+        this.name = name;
+        this.featureSet = featureSet;
+        this.ranker = ranker;
+    }
+
+    public static StoredLtrModel parse(XContentParser parser, LtrRankerParserFactory factory) {
+        try {
+            ParsingState state = PARSER.apply(parser, null);
+            if (state.name == null) {
+                throw new ParsingException(parser.getTokenLocation(), "Field [name] is mandatory");
+            }
+            if (state.featureSet == null) {
+                throw new ParsingException(parser.getTokenLocation(), "Field [feature_set] is mandatory");
+            }
+            if (state.rankingModel == null) {
+                throw new ParsingException(parser.getTokenLocation(), "Field [model] is mandatory");
+            }
+            LtrRankerParser modelParser = factory.getParser(state.rankingModel.type);
+            LtrRanker ranker = modelParser.parse(state.featureSet, state.rankingModel.definition);
+            return new StoredLtrModel(state.name, state.featureSet, ranker);
+        } catch (IllegalArgumentException iae) {
+            throw new ParsingException(parser.getTokenLocation(), iae.getMessage(), iae);
+        }
+    }
+
+    /**
+     * Name of the model
+     */
+    @Override
+    public String name() {
+        return name;
+    }
+
+    /**
+     * Return the {@link LtrRanker} implementation used by this model
+     */
+    @Override
+    public LtrRanker ranker() {
+        return ranker;
+    }
+
+    /**
+     * The set of features used by this model
+     */
+    @Override
+    public StoredFeatureSet featureSet() {
+        return featureSet;
+    }
+
+    /**
+     * Return the memory usage of this object in bytes. Negative values are illegal.
+     */
+    @Override
+    public long ramBytesUsed() {
+        return BASE_RAM_USED + name.length() * Character.BYTES + NUM_BYTES_ARRAY_HEADER
+                + featureSet.ramBytesUsed()
+                + (ranker instanceof Accountable ?
+                ((Accountable)ranker).ramBytesUsed() : featureSet.size() * NUM_BYTES_OBJECT_HEADER);
+    }
+
+    private static class ParsingState {
+        String name;
+        StoredFeatureSet featureSet;
+        LtrModelDefinition rankingModel;
+
+        void setName(String name) {
+            this.name = name;
+        }
+
+        void setFeatureSet(StoredFeatureSet featureSet) {
+            this.featureSet = featureSet;
+        }
+
+        void setRankingModel(LtrModelDefinition rankingModel) {
+            this.rankingModel = rankingModel;
+        }
+    }
+
+    private static class LtrModelDefinition {
+        final String type;
+        final String definition;
+
+        private static final ConstructingObjectParser<LtrModelDefinition, Void> PARSER;
+        static {
+            PARSER = new ConstructingObjectParser<>("model",
+                    x -> new LtrModelDefinition((String) x[0], (String) x[1]));
+            PARSER.declareString(constructorArg(),
+                    new ParseField("type"));
+            PARSER.declareString(constructorArg(),
+                    new ParseField("definition"));
+        }
+
+        LtrModelDefinition(String type, String definition) {
+            this.type = type;
+            this.definition = definition;
+        }
+    }
+}

--- a/src/main/java/com/o19s/es/ltr/feature/store/index/CachedFeatureStore.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/index/CachedFeatureStore.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.feature.store.index;
+
+import com.o19s.es.ltr.feature.store.FeatureStore;
+import com.o19s.es.ltr.feature.store.StoredFeature;
+import com.o19s.es.ltr.feature.store.StoredFeatureSet;
+import com.o19s.es.ltr.feature.store.StoredLtrModel;
+import org.elasticsearch.common.CheckedFunction;
+import org.elasticsearch.common.cache.Cache;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Cache layer on top of an {@link IndexFeatureStore}
+ */
+public class CachedFeatureStore implements FeatureStore {
+    private final FeatureStore inner;
+    private final Caches caches;
+
+    public CachedFeatureStore(FeatureStore inner, Caches caches) {
+        this.inner = inner;
+        this.caches = caches;
+    }
+
+    @Override
+    public String getStoreName() {
+        return inner.getStoreName();
+    }
+
+    @Override
+    public StoredFeature load(String id) throws IOException {
+        return innerLoad(id, caches.featureCache(), inner::load);
+    }
+
+    @Override
+    public StoredFeatureSet loadSet(String id) throws IOException {
+        return innerLoad(id, caches.featureSetCache(), inner::loadSet);
+    }
+
+    @Override
+    public StoredLtrModel loadModel(String id) throws IOException {
+        return innerLoad(id, caches.modelCache(), inner::loadModel);
+    }
+
+    StoredFeature getCachedFeature(String id) {
+        return innerGet(id, caches.featureCache());
+    }
+
+    StoredFeatureSet getCachedFeatureSet(String id) {
+        return innerGet(id, caches.featureSetCache());
+    }
+
+    StoredLtrModel getCachedModel(String id) {
+        return innerGet(id, caches.modelCache());
+    }
+
+    public long totalWeight() {
+        return featuresWeight() + featureSetWeight() + modelWeight();
+    }
+
+    public long featuresWeight() {
+        return caches.featureCache().weight();
+    }
+
+    public long featureSetWeight() {
+        return caches.featureSetCache().weight();
+    }
+
+    public long modelWeight() {
+        return caches.modelCache().weight();
+    }
+
+    private <T> T innerLoad(String id, Cache<Caches.CacheKey, T> cache, CheckedFunction<String, T, IOException> loader) throws IOException {
+        try {
+            return cache.computeIfAbsent(new Caches.CacheKey(inner.getStoreName(), id), (k) -> loader.apply(k.getId()));
+        } catch (ExecutionException e) {
+            throw new IOException(e.getMessage(), e.getCause());
+        }
+    }
+
+    private <T> T innerGet(String id, Cache<Caches.CacheKey, T> cache) {
+        return cache.get(new Caches.CacheKey(inner.getStoreName(), id));
+    }
+}

--- a/src/main/java/com/o19s/es/ltr/feature/store/index/Caches.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/index/Caches.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.feature.store.index;
+
+import com.o19s.es.ltr.feature.store.StoredFeature;
+import com.o19s.es.ltr.feature.store.StoredFeatureSet;
+import com.o19s.es.ltr.feature.store.StoredLtrModel;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.cache.Cache;
+import org.elasticsearch.common.cache.CacheBuilder;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.monitor.jvm.JvmInfo;
+
+import java.util.Iterator;
+import java.util.Objects;
+
+/**
+ * Store various caches used by the plugin
+ */
+public class Caches {
+    private final Cache<CacheKey, StoredFeature> featureCache;
+    private final Cache<CacheKey, StoredFeatureSet> featureSetCache;
+    private final Cache<CacheKey, StoredLtrModel> modelCache;
+    private final long maxWeight;
+
+    public Caches(TimeValue expireAfterWrite, TimeValue expireAfterAccess, long maxWeight) {
+        this.featureCache = CacheBuilder.<CacheKey, StoredFeature>builder()
+                .setExpireAfterWrite(expireAfterWrite)
+                .setExpireAfterAccess(expireAfterAccess)
+                .setMaximumWeight(maxWeight)
+                .weigher((s, w) -> w.ramBytesUsed())
+                .build();
+        this.featureSetCache = CacheBuilder.<CacheKey, StoredFeatureSet>builder()
+                .setExpireAfterWrite(expireAfterWrite)
+                .setExpireAfterAccess(expireAfterAccess)
+                .weigher((s, w) -> w.ramBytesUsed())
+                .setMaximumWeight(maxWeight)
+                .build();
+        this.modelCache = CacheBuilder.<CacheKey, StoredLtrModel>builder()
+                .setExpireAfterWrite(expireAfterWrite)
+                .setExpireAfterAccess(expireAfterAccess)
+                .weigher((s, w) -> w.ramBytesUsed())
+                .setMaximumWeight(maxWeight)
+                .build();
+        this.maxWeight = maxWeight;
+    }
+
+    public Caches(Settings settings) {
+        // TODO: use settings
+        this(TimeValue.timeValueMinutes(10),
+                TimeValue.timeValueMinutes(2),
+                Math.min(JvmInfo.jvmInfo().getMem().getHeapMax().getBytes()/10, RamUsageEstimator.ONE_MB*10));
+    }
+
+    public void evict(String index) {
+        evict(index, featureCache);
+        evict(index, featureSetCache);
+        evict(index, modelCache);
+    }
+
+    private void evict(String index, Cache<CacheKey, ?> cache) {
+        Iterator<CacheKey> ite = cache.keys().iterator();
+        while(ite.hasNext()) {
+            if(ite.next().storeName.equals(index)) {
+                ite.remove();
+            }
+        }
+    }
+
+    public Cache<CacheKey, StoredFeature> featureCache() {
+        return featureCache;
+    }
+
+    public Cache<CacheKey, StoredFeatureSet> featureSetCache() {
+        return featureSetCache;
+    }
+
+    public Cache<CacheKey, StoredLtrModel> modelCache() {
+        return modelCache;
+    }
+
+    public long getMaxWeight() {
+        return maxWeight;
+    }
+
+    public static class CacheKey {
+        private final String storeName;
+        private final String id;
+
+        public CacheKey(String storeName, String id) {
+            this.storeName = Objects.requireNonNull(storeName);
+            this.id = Objects.requireNonNull(id);
+        }
+
+        public String getStoreName() {
+            return storeName;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            CacheKey cacheKey = (CacheKey) o;
+
+            if (!storeName.equals(cacheKey.storeName)) return false;
+            return id.equals(cacheKey.id);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = storeName.hashCode();
+            result = 31 * result + id.hashCode();
+            return result;
+        }
+    }
+}

--- a/src/main/java/com/o19s/es/ltr/feature/store/index/IndexFeatureStore.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/index/IndexFeatureStore.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.feature.store.index;
+
+import com.o19s.es.ltr.feature.store.FeatureStore;
+import com.o19s.es.ltr.feature.store.StoredFeature;
+import com.o19s.es.ltr.feature.store.StoredFeatureSet;
+import com.o19s.es.ltr.feature.store.StoredLtrModel;
+import com.o19s.es.ltr.ranker.parser.LtrRankerParserFactory;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class IndexFeatureStore implements FeatureStore {
+    private static final String FEATURE_TYPE = "features";
+    private static final String FEATURE_SET_TYPE = "featureset";
+    private static final String MODEL_TYPE = "model";
+
+    private final String index;
+    private final Client client;
+    private final LtrRankerParserFactory parserFactory;
+
+    public IndexFeatureStore(String index, Client client, LtrRankerParserFactory factory) {
+        this.index = Objects.requireNonNull(index);
+        this.client = Objects.requireNonNull(client);
+        this.parserFactory = Objects.requireNonNull(factory);
+    }
+
+    @Override
+    public String getStoreName() {
+        return index;
+    }
+
+    @Override
+    public StoredFeature load(String id) throws IOException {
+        return getAndParse(FEATURE_TYPE, id, StoredFeature::parse);
+    }
+
+    @Override
+    public StoredFeatureSet loadSet(String id) throws IOException {
+        return getAndParse(id, FEATURE_SET_TYPE, StoredFeatureSet::parse);
+    }
+
+    @Override
+    public StoredLtrModel loadModel(String id) throws IOException {
+        return getAndParse(id, FEATURE_SET_TYPE, (parser) -> StoredLtrModel.parse(parser, parserFactory));
+    }
+
+    private <T> T getAndParse(String type, String id, Function<XContentParser, T> parser) throws IOException {
+        return parser.apply(json(internalGet(type, id).get().getSourceAsBytes()));
+    }
+
+    public GetResponse getFeature(String id) {
+        return internalGet(id, FEATURE_TYPE).get();
+    }
+
+    public GetResponse getFeatureSet(String id) {
+        return internalGet(id, FEATURE_SET_TYPE).get();
+    }
+
+    public GetResponse getModel(String id) {
+        return internalGet(id, MODEL_TYPE).get();
+    }
+
+    private Supplier<GetResponse> internalGet(String type, String id) {
+        return () -> client.prepareGet(index, type, id).get();
+    }
+
+    private XContentParser json(byte[] json) throws IOException {
+        // No need to have a full featured {@link NamedXContentRegistry}, we use
+        // {@link org.elasticsearch.common.xcontent.XContentBuilder#copyCurrentStructure(org.elasticsearch.common.xcontent.XContentParser)}
+        // which simply copy the content structure without parsing it
+        return XContentFactory.xContent(json).createParser(NamedXContentRegistry.EMPTY, json);
+    }
+}

--- a/src/main/java/com/o19s/es/ltr/query/NoopScorer.java
+++ b/src/main/java/com/o19s/es/ltr/query/NoopScorer.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * Created by doug on 2/3/17.
  */
 public class NoopScorer extends Scorer {
-    private DocIdSetIterator _noopIter;
+    private final DocIdSetIterator _noopIter;
     /**
      * Constructs a Scorer
      *

--- a/src/main/java/com/o19s/es/ltr/query/StoredLtrQueryBuilder.java
+++ b/src/main/java/com/o19s/es/ltr/query/StoredLtrQueryBuilder.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.query;
+
+import com.o19s.es.ltr.feature.store.FeatureStore;
+import com.o19s.es.ltr.feature.store.StoredLtrModel;
+import com.o19s.es.ltr.utils.FeatureStoreProvider;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.io.stream.NamedWriteable;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.AbstractQueryBuilder;
+import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.index.query.QueryShardContext;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * sltr query, build a ltr query based on a stored model.
+ */
+public class StoredLtrQueryBuilder extends AbstractQueryBuilder<StoredLtrQueryBuilder> implements NamedWriteable {
+    public static final String DEFAULT_FEATURE_STORE = "ltr_default_store";
+    public static final String NAME = "sltr";
+    public static final ParseField MODEL_NAME = new ParseField("model");
+    public static final ParseField STORE_NAME = new ParseField("store");
+    public static final ParseField PARAMS = new ParseField("params");
+
+    private String modelName;
+    private String storeName = DEFAULT_FEATURE_STORE;
+    private Map<String, Object> params;
+
+    private static final ObjectParser<StoredLtrQueryBuilder, Void> PARSER;
+
+    static {
+        PARSER = new ObjectParser<>(NAME, StoredLtrQueryBuilder::new);
+        PARSER.declareString(StoredLtrQueryBuilder::modelName, MODEL_NAME);
+        PARSER.declareString(StoredLtrQueryBuilder::storeName, STORE_NAME);
+        PARSER.declareField(StoredLtrQueryBuilder::params, XContentParser::map,
+                PARAMS, ObjectParser.ValueType.OBJECT);
+        declareStandardFields(PARSER);
+    }
+
+    public StoredLtrQueryBuilder() {}
+    public StoredLtrQueryBuilder(StreamInput input) throws IOException {
+        super(input);
+        modelName = input.readString();
+        params = input.readMap();
+        storeName = input.readString();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(modelName);
+        out.writeMap(params);
+        out.writeString(storeName);
+    }
+
+    public static Optional<StoredLtrQueryBuilder> fromXContent(QueryParseContext context) throws IOException {
+        XContentParser parser = context.parser();
+        final StoredLtrQueryBuilder builder;
+        try {
+            builder = PARSER.parse(context.parser(), null);
+        } catch (IllegalArgumentException iae) {
+            throw new ParsingException(parser.getTokenLocation(), iae.getMessage(), iae);
+        }
+        if (builder.modelName() == null) {
+            throw new ParsingException(parser.getTokenLocation(), "Field [" + MODEL_NAME + "] is mandatory.");
+        }
+        if (builder.storeName() == null) {
+            throw new ParsingException(parser.getTokenLocation(), "Field [" + STORE_NAME + "] cannot be null.");
+        }
+        if (builder.params() == null) {
+            throw new ParsingException(parser.getTokenLocation(), "Field [" + PARAMS + "] is mandatory.");
+        }
+        return Optional.of(builder);
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder builder, Params p) throws IOException {
+        builder.startObject(NAME);
+        builder.field(MODEL_NAME.getPreferredName(), modelName);
+        if (!DEFAULT_FEATURE_STORE.equals(storeName)) {
+            builder.field(STORE_NAME.getPreferredName(), storeName);
+        }
+        if (this.params != null && !this.params.isEmpty()) {
+            builder.field(PARAMS.getPreferredName(), this.params);
+        }
+        printBoostAndQueryName(builder);
+        builder.endObject();
+    }
+
+    @Override
+    protected RankerQuery doToQuery(QueryShardContext context) throws IOException {
+        FeatureStore store = FeatureStoreProvider.findFeatureStore(storeName, context);
+        StoredLtrModel model = store.loadModel(modelName);
+        return RankerQuery.build(model, context, params);
+    }
+
+    @Override
+    protected boolean doEquals(StoredLtrQueryBuilder other) {
+        return Objects.equals(modelName, other.modelName) &&
+                Objects.equals(storeName, other.storeName) &&
+                Objects.equals(params, other.params);
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(modelName, storeName, params);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    public String modelName() {
+        return modelName;
+    }
+
+    public StoredLtrQueryBuilder modelName(String modelName) {
+        this.modelName = Objects.requireNonNull(modelName);
+        return this;
+    }
+
+    public String storeName() {
+        return storeName;
+    }
+
+    public StoredLtrQueryBuilder storeName(String storeName) {
+        this.storeName = Objects.requireNonNull(storeName);
+        return this;
+    }
+
+    public Map<String, Object> params() {
+        return params;
+    }
+
+    public StoredLtrQueryBuilder params(Map<String, Object> params) {
+        this.params = Objects.requireNonNull(params);
+        return this;
+    }
+}

--- a/src/main/java/com/o19s/es/ltr/ranker/linear/LinearRanker.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/linear/LinearRanker.java
@@ -18,6 +18,8 @@ package com.o19s.es.ltr.ranker.linear;
 
 import com.o19s.es.ltr.ranker.DenseFeatureVector;
 import com.o19s.es.ltr.ranker.DenseLtrRanker;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 
 import java.util.Objects;
 
@@ -25,7 +27,7 @@ import java.util.Objects;
  * Simple linear ranker that applies a dot product based
  * on the provided weights array.
  */
-public class LinearRanker extends DenseLtrRanker {
+public class LinearRanker extends DenseLtrRanker implements Accountable {
     private final float[] weights;
 
     public LinearRanker(float[] weights) {
@@ -50,5 +52,13 @@ public class LinearRanker extends DenseLtrRanker {
     @Override
     protected int size() {
         return weights.length;
+    }
+
+    /**
+     * Return the memory usage of this object in bytes. Negative values are illegal.
+     */
+    @Override
+    public long ramBytesUsed() {
+        return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + RamUsageEstimator.sizeOf(weights);
     }
 }

--- a/src/main/java/com/o19s/es/ltr/ranker/parser/LtrRankerParser.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/parser/LtrRankerParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,24 +14,17 @@
  * limitations under the License.
  */
 
-package com.o19s.es.ltr.feature;
+package com.o19s.es.ltr.ranker.parser;
 
-import org.apache.lucene.search.Query;
-import org.elasticsearch.index.query.QueryShardContext;
-
-import java.util.Map;
+import com.o19s.es.ltr.feature.FeatureSet;
+import com.o19s.es.ltr.ranker.LtrRanker;
 
 /**
- * A feature that can be transformed into a lucene query
+ * A model parser (don't have to be thread-safe)
  */
-public interface Feature {
+public interface LtrRankerParser {
     /**
-     * The feature name
+     * Parse the model with the given FeatureSet
      */
-    String name();
-
-    /**
-     * Transform this feature into a lucene query
-     */
-    Query doToQuery(QueryShardContext context, Map<String, Object> params);
+    LtrRanker parse(FeatureSet set, String model);
 }

--- a/src/main/java/com/o19s/es/ltr/ranker/parser/LtrRankerParserFactory.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/parser/LtrRankerParserFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.ranker.parser;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * LtrModel parser registry
+ */
+public class LtrRankerParserFactory {
+    private final Map<String, Supplier<LtrRankerParser>> parsers;
+
+    private LtrRankerParserFactory(Map<String, Supplier<LtrRankerParser>> parsers) {
+        this.parsers = parsers;
+    }
+
+    /**
+     *
+     * @param type type or content-type like string defining the model format
+     * @return a model parser
+     * @throws IllegalArgumentException if the type is not supported
+     */
+    public LtrRankerParser getParser(String type) {
+        Supplier<LtrRankerParser> supplier = parsers.get(type);
+        if (supplier == null) {
+            throw new IllegalArgumentException("Unsupported LtrRanker format/type [" + type + "]");
+        }
+        return supplier.get();
+    }
+
+    public static class Builder {
+        private final Map<String, Supplier<LtrRankerParser>> registry = new HashMap<>();
+
+        public Builder register(String type, Supplier<LtrRankerParser> parser) {
+            if (registry.put(type, parser) != null) {
+                throw new RuntimeException("Cannot register LtrRankerParser: [" + type + "] already registered.");
+            }
+            return this;
+        }
+
+        public LtrRankerParserFactory build() {
+            return new LtrRankerParserFactory(Collections.unmodifiableMap(registry));
+        }
+    }
+}

--- a/src/main/java/com/o19s/es/ltr/ranker/ranklib/RankLibScriptEngine.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/ranklib/RankLibScriptEngine.java
@@ -16,8 +16,8 @@
  */
 package com.o19s.es.ltr.ranker.ranklib;
 
-import ciir.umass.edu.learning.Ranker;
-import ciir.umass.edu.learning.RankerFactory;
+import com.o19s.es.ltr.ranker.LtrRanker;
+import com.o19s.es.ltr.ranker.parser.LtrRankerParserFactory;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.settings.Settings;
@@ -29,6 +29,7 @@ import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Created by doug on 12/30/16.
@@ -42,14 +43,14 @@ import java.util.Map;
  */
 public class RankLibScriptEngine extends AbstractComponent implements ScriptEngineService {
 
-    private RankerFactory rankerFactory;
+    private final LtrRankerParserFactory factory;
 
     public static final String NAME = "ranklib";
     public static final String EXTENSION = "ranklib";
 
-    public RankLibScriptEngine(Settings settings) {
+    public RankLibScriptEngine(Settings settings, LtrRankerParserFactory factory) {
         super(settings);
-        rankerFactory = new RankerFactory();
+        this.factory = Objects.requireNonNull(factory);
     }
 
 
@@ -71,12 +72,13 @@ public class RankLibScriptEngine extends AbstractComponent implements ScriptEngi
 
     @Override
     public Object compile(String scriptName, String scriptSource, Map<String, String> params) {
-        return (Object) rankerFactory.loadRankerFromString(scriptSource);
+        // XXX: does not support feature set.
+        return factory.getParser(RanklibModelParser.TYPE).parse(null, scriptSource);
     }
 
     @Override
     public ExecutableScript executable(CompiledScript compiledScript, @Nullable Map<String, Object> vars) {
-        return new RankLibExecutableScript((Ranker)compiledScript.compiled());
+        return new RankLibExecutableScript((LtrRanker)compiledScript.compiled());
     }
 
     @Override
@@ -91,15 +93,15 @@ public class RankLibScriptEngine extends AbstractComponent implements ScriptEngi
 
     public class RankLibExecutableScript implements ExecutableScript {
 
-        Ranker _ranker;
+        LtrRanker _ranker;
 
-        public RankLibExecutableScript(Ranker ranker) {
+        public RankLibExecutableScript(LtrRanker ranker) {
             _ranker = ranker;
         }
 
         @Override
         public void setNextVar(String name, Object value) {
-            _ranker = (Ranker)(value);
+            _ranker = (LtrRanker) (value);
 
         }
 

--- a/src/main/java/com/o19s/es/ltr/ranker/ranklib/RanklibModelParser.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/ranklib/RanklibModelParser.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright [2017] Doug Turnbull, Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.ranker.ranklib;
+
+import ciir.umass.edu.learning.RankerFactory;
+import com.o19s.es.ltr.feature.FeatureSet;
+import com.o19s.es.ltr.ranker.LtrRanker;
+import com.o19s.es.ltr.ranker.parser.LtrRankerParser;
+
+/**
+ * Load a ranklib model from a script file, mostly a wrapper around the
+ * existing script that complies with the {@link LtrRankerParser} interface
+ */
+public class RanklibModelParser implements LtrRankerParser {
+    public static final String TYPE = "model/ranklib";
+    private final RankerFactory factory;
+
+    public RanklibModelParser(RankerFactory factory) {
+        this.factory = factory;
+    }
+
+    @Override
+    public LtrRanker parse(FeatureSet set, String model) {
+        return new RanklibRanker(factory.loadRankerFromString(model));
+    }
+}

--- a/src/main/java/com/o19s/es/ltr/utils/FeatureStoreProvider.java
+++ b/src/main/java/com/o19s/es/ltr/utils/FeatureStoreProvider.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.utils;
+
+import com.o19s.es.ltr.feature.store.FeatureStore;
+import com.o19s.es.ltr.feature.store.index.CachedFeatureStore;
+import com.o19s.es.ltr.feature.store.index.Caches;
+import com.o19s.es.ltr.feature.store.index.IndexFeatureStore;
+import com.o19s.es.ltr.ranker.parser.LtrRankerParserFactory;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.script.AbstractExecutableScript;
+import org.elasticsearch.script.ExecutableScript;
+import org.elasticsearch.script.NativeScriptEngineService;
+import org.elasticsearch.script.NativeScriptFactory;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Hack to contruct the CachedFeatureStore based on some context availabe in
+ * {@link org.elasticsearch.index.query.QueryBuilder#toQuery(QueryShardContext)}
+ * and the Caches built when {@link com.o19s.es.ltr.LtrQueryParserPlugin} is initialized.
+ *
+ * TODO: investigate cleaner ways to do this.
+ */
+public class FeatureStoreProvider extends AbstractExecutableScript {
+    private static final String NAME = "_ltr_internals:" + FeatureStoreProvider.class.getSimpleName();
+
+    private final FeatureStore store;
+
+    private FeatureStoreProvider(FeatureStore store) {
+        this.store = store;
+    }
+
+    /**
+     * Executes the script.
+     */
+    @Override
+    public FeatureStore run() {
+        return store;
+    }
+
+    public static class Factory implements NativeScriptFactory {
+        private final FeatureStoreLoader loader;
+
+        public Factory(FeatureStoreLoader loader) {
+            this.loader = loader;
+        }
+
+        @Override
+        public ExecutableScript newScript(Map<String, Object> params) {
+            String storeName = (String) params.get("store");
+            Client client = (Client) params.get("client");
+
+            if (storeName == null || client == null) {
+                throw new RuntimeException(NAME + " is an internal script and must not be used directly.");
+            }
+
+            return new FeatureStoreProvider(loader.load(storeName, client));
+        }
+
+        @Override
+        public boolean needsScores() {
+            return false;
+        }
+
+        @Override
+        public String getName() {
+            return NAME;
+        }
+    }
+
+    public static FeatureStore findFeatureStore(String storeName, QueryShardContext context) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("store", storeName);
+        params.put("client", context.getClient());
+        Script script = new Script(ScriptType.INLINE, NativeScriptEngineService.NAME, NAME, params);
+        return (FeatureStore) context.getExecutableScript(script, ScriptContext.Standard.SEARCH).run();
+    }
+
+    @FunctionalInterface
+    public interface FeatureStoreLoader {
+        FeatureStore load(String storeName, Client client);
+    }
+
+    public static FeatureStoreLoader defaultFeatureStoreLoad(Caches caches, LtrRankerParserFactory factory) {
+        return (storeName, client) -> new CachedFeatureStore(new IndexFeatureStore(storeName, client, factory), caches);
+    }
+}

--- a/src/test/java/com/o19s/es/ltr/LtrTestUtils.java
+++ b/src/test/java/com/o19s/es/ltr/LtrTestUtils.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr;
+
+import com.o19s.es.ltr.feature.store.StoredFeature;
+import com.o19s.es.ltr.feature.store.StoredFeatureSet;
+import com.o19s.es.ltr.feature.store.StoredFeatureSetParserTests;
+import com.o19s.es.ltr.feature.store.StoredLtrModel;
+import com.o19s.es.ltr.ranker.LtrRanker;
+import com.o19s.es.ltr.ranker.dectree.NaiveAdditiveDecisionTreeTests;
+import com.o19s.es.ltr.ranker.linear.LinearRankerTests;
+import org.apache.lucene.util.TestUtil;
+
+import java.io.IOException;
+
+import static org.apache.lucene.util.LuceneTestCase.random;
+
+public class LtrTestUtils {
+
+    public static StoredFeature randomFeature() throws IOException {
+        return StoredFeatureSetParserTests.buildRandomFeature();
+    }
+
+    public static StoredFeatureSet randomFeatureSet() throws IOException {
+        return StoredFeatureSetParserTests.buildRandomFeatureSet();
+    }
+
+    public static StoredLtrModel buildRandomModel() throws IOException {
+        StoredFeatureSet set = StoredFeatureSetParserTests.buildRandomFeatureSet();
+        LtrRanker ranker;
+        ranker = buildRandomRanker(set.size());
+        return new StoredLtrModel(TestUtil.randomSimpleString(random(), 5, 10), set, ranker);
+    }
+
+    public static LtrRanker buildRandomRanker(int fSize) {
+        LtrRanker ranker;
+        if (random().nextBoolean()) {
+            ranker = LinearRankerTests.generateRandomRanker(fSize);
+        } else {
+            ranker = NaiveAdditiveDecisionTreeTests.generateRandomDecTree(fSize, TestUtil.nextInt(random(), 1, 50),
+                    5, 50, null);
+        }
+        return ranker;
+    }
+}

--- a/src/test/java/com/o19s/es/ltr/MockMustachePlugin.java
+++ b/src/test/java/com/o19s/es/ltr/MockMustachePlugin.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.ScriptPlugin;
+import org.elasticsearch.script.CompiledScript;
+import org.elasticsearch.script.ExecutableScript;
+import org.elasticsearch.script.ScriptEngineService;
+import org.elasticsearch.script.SearchScript;
+import org.elasticsearch.search.lookup.SearchLookup;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Very simple Script plugin to mock mustaphe
+ * This is not even close to the real mustaphe but should cover the simple
+ * cases needed for testing the query builders.
+ */
+public class MockMustachePlugin extends Plugin implements ScriptPlugin {
+    @Override
+    public ScriptEngineService getScriptEngineService(Settings settings) {
+        return new ScriptEngineService() {
+            @Override
+            public String getType() {
+                return "mustache";
+            }
+
+            @Override
+            public String getExtension() {
+                return "mustache";
+            }
+
+            @Override
+            public Object compile(String scriptName, String scriptSource, Map<String, String> params) {
+                return CompiledTemplate.compile(scriptSource);
+            }
+
+            @Override
+            public ExecutableScript executable(CompiledScript compiledScript, Map<String, Object> vars) {
+                return new ExecutableScript() {
+                    @Override
+                    public void setNextVar(String name, Object value) {
+                    }
+
+                    @Override
+                    public Object run() {
+                        return ((CompiledTemplate)compiledScript.compiled()).apply(vars);
+                    }
+                };
+            }
+
+            @Override
+            public SearchScript search(CompiledScript compiledScript, SearchLookup lookup, Map<String, Object> vars) {
+                return null;
+            }
+
+            @Override
+            public boolean isInlineScriptEnabled() {
+                return true;
+            }
+
+            @Override
+            public void close() throws IOException {
+            }
+        };
+    }
+
+    private static class CompiledTemplate {
+        static final Pattern VAR_PATTERN = Pattern.compile("\\Q{{\\E([a-zA-Z0-9_.-]+)\\Q}}\\E");
+        private final List<BiConsumer<StringBuilder, Map<String,Object>>> chunks;
+
+        private CompiledTemplate(List<BiConsumer<StringBuilder, Map<String, Object>>> chunks) {
+            this.chunks = chunks;
+        }
+
+        private static CompiledTemplate compile(String template) {
+            List<BiConsumer<StringBuilder, Map<String,Object>>> chunks = new ArrayList<>();
+            Matcher m = VAR_PATTERN.matcher(template);
+            int so = 0;
+            while (m.find()) {
+                int offset = m.start();
+                if (offset > so) {
+                    chunks.add(new StringChunk(template.subSequence(so, offset)));
+                }
+                chunks.add(new VarChunk(m.group(1)));
+                so = m.end();
+            }
+            if (so < template.length()) {
+                chunks.add(new StringChunk(template.subSequence(so, template.length())));
+            }
+            return new CompiledTemplate(chunks);
+        }
+
+        String apply(Map<String,Object> params) {
+            StringBuilder sb = new StringBuilder();
+            for (BiConsumer<StringBuilder, Map<String,Object>> chunk : chunks) {
+                chunk.accept(sb, params);
+            }
+            return sb.toString();
+        }
+    }
+
+    public static class StringChunk implements BiConsumer<StringBuilder, Map<String,Object>> {
+        private final CharSequence sub;
+
+        public StringChunk(CharSequence sub) {
+            this.sub = sub;
+        }
+
+        @Override
+        public void accept(StringBuilder sb, Map<String, Object> params) {
+            sb.append(sub);
+        }
+    }
+
+    public static class VarChunk implements BiConsumer<StringBuilder, Map<String,Object>> {
+        private final String var;
+
+        public VarChunk(String var) {
+            this.var = var;
+        }
+
+        @Override
+        public void accept(StringBuilder sb, Map<String, Object> params) {
+            Object o = params.get(var);
+            if (o == null) {
+                throw new IllegalArgumentException("Param [" + var + "] defined in the template but not found in the params.");
+            }
+            String value;
+            if (o instanceof String) {
+                value = ((String)o).replace("\\", "\\\\");
+                value = value.replace("\"", "\\\"");
+            } else if(o instanceof Number) {
+                value = String.valueOf(o);
+            } else {
+                throw new IllegalArgumentException("Param [" + var +"] is not a simple type, only strings and numbers are allowed.");
+            }
+            sb.append(value);
+        }
+    }
+}

--- a/src/test/java/com/o19s/es/ltr/feature/store/MemStore.java
+++ b/src/test/java/com/o19s/es/ltr/feature/store/MemStore.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.feature.store;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * in memory test store
+ */
+public class MemStore implements FeatureStore {
+    private final Map<String, StoredFeature> features = new HashMap<>();
+    private final Map<String, StoredFeatureSet> sets = new HashMap<>();
+    private final Map<String, StoredLtrModel> models = new HashMap<>();
+
+    @Override
+    public String getStoreName() {
+        return "memstore";
+    }
+
+    @Override
+    public StoredFeature load(String id) throws IOException {
+        StoredFeature feature = features.get(id);
+        if (feature == null) {
+            throw new IllegalArgumentException("Feature [" + id + "] not found");
+        }
+        return feature;
+    }
+
+    @Override
+    public StoredFeatureSet loadSet(String id) throws IOException {
+        StoredFeatureSet set = sets.get(id);
+        if (set == null) {
+            throw new IllegalArgumentException("Feature [" + id + "] not found");
+        }
+        return set;
+    }
+
+    @Override
+    public StoredLtrModel loadModel(String id) throws IOException {
+        StoredLtrModel model = models.get(id);
+        if (model == null) {
+            throw new IllegalArgumentException("Feature [" + id + "] not found");
+        }
+        return model;
+    }
+
+    public void add(StoredFeature feature) {
+        features.put(feature.name(), feature);
+    }
+
+    public void add(StoredFeatureSet set) {
+        sets.put(set.name(), set);
+    }
+
+    public void add(StoredLtrModel model) {
+        models.put(model.name(), model);
+    }
+
+    public void clear() {
+        features.clear();
+        sets.clear();
+        models.clear();
+    }
+}

--- a/src/test/java/com/o19s/es/ltr/feature/store/StoredFeatureParserTests.java
+++ b/src/test/java/com/o19s/es/ltr/feature/store/StoredFeatureParserTests.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.feature.store;
+
+import org.apache.lucene.util.LuceneTestCase;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.index.query.MatchQueryBuilder;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.elasticsearch.common.xcontent.NamedXContentRegistry.EMPTY;
+import static org.elasticsearch.common.xcontent.json.JsonXContent.jsonXContent;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+
+public class StoredFeatureParserTests extends LuceneTestCase {
+    static final ToXContent.Params NOT_PRETTY;
+    static {
+        Map<String, String> params = new HashMap<>();
+        params.put("pretty", "false");
+        NOT_PRETTY = new ToXContent.MapParams(params);
+    }
+
+    public void testParseFeatureAsJson() throws IOException {
+        String featureString = generateTestFeature();
+
+        StoredFeature feature = parse(featureString);
+        assertEquals("testFeature", feature.name());
+        assertArrayEquals(Arrays.asList("param1", "param2").toArray(), feature.queryParams().toArray());
+        assertEquals("mustache", feature.templateLanguage());
+        assertEquals(new MatchQueryBuilder("match_field", "match_word").toString(NOT_PRETTY), feature.template());
+    }
+
+    public static String generateTestFeature() {
+        return "{\n" +
+                    "\"name\": \"testFeature\",\n" +
+                    "\"params\": [\"param1\", \"param2\"],\n" +
+                    "\"template_language\": \"mustache\",\n" +
+                    "\"template\": \n" +
+                    new MatchQueryBuilder("match_field", "match_word").toString() +
+                    "\n}\n";
+    }
+
+    public void testParseFeatureAsString() throws IOException {
+        String featureString = "{\n" +
+                "\"name\": \"testFeature\",\n" +
+                "\"params\": [\"param1\", \"param2\"],\n" +
+                "\"template_language\": \"mustache\",\n" +
+                "\"template\": \"" +
+                new MatchQueryBuilder("match_field", "match_word").toString(NOT_PRETTY)
+                        .replace("\"", "\\\"") +
+                "\"\n}\n";
+
+        StoredFeature feature = parse(featureString);
+        assertEquals("testFeature", feature.name());
+        assertArrayEquals(Arrays.asList("param1", "param2").toArray(), feature.queryParams().toArray());
+        assertEquals("mustache", feature.templateLanguage());
+        assertEquals(new MatchQueryBuilder("match_field", "match_word").toString(NOT_PRETTY),
+                feature.template());
+    }
+
+    public void testParseErrorOnMissingName() throws IOException {
+        String featureString = "{\n" +
+                "\"params\":[\"param1\",\"param2\"]," +
+                "\"template_language\":\"mustache\",\n" +
+                "\"template\": \n" +
+                new MatchQueryBuilder("match_field", "match_word").toString() +
+                "}";
+        assertThat(expectThrows(ParsingException.class, () -> parse(featureString)).getMessage(),
+                equalTo("Field [name] is mandatory"));
+    }
+
+    public void testParseErrorOnMissingTemplate() throws IOException {
+        String featureString = "{\n" +
+                "\"name\":\"testFeature\"," +
+                "\"params\":[\"param1\",\"param2\"]," +
+                "\"template_language\":\"mustache\"\n" +
+                "}";
+        assertThat(expectThrows(ParsingException.class, () -> parse(featureString)).getMessage(),
+                equalTo("Field [template] is mandatory"));
+    }
+
+    public void testParseErrorOnUnknownField() throws IOException {
+        String featureString = "{\n" +
+                "\"name\":\"testFeature\"," +
+                "\"params\":[\"param1\",\"param2\"]," +
+                "\"template_language\":\"mustache\",\n" +
+                "\n\"bogusField\":\"oops\"," +
+                "\"template\": \n" +
+                new MatchQueryBuilder("match_field", "match_word").toString() +
+                "}";
+        assertThat(expectThrows(ParsingException.class, () -> parse(featureString)).getMessage(),
+                containsString("bogusField"));
+    }
+
+    public void testParseWithoutParams() throws IOException {
+        String featureString = "{\n" +
+                "\"name\":\"testFeature\"," +
+                "\"template_language\":\"mustache\",\n" +
+                "\"template\": \n" +
+                new MatchQueryBuilder("match_field", "match_word").toString() +
+                "}";
+        StoredFeature feat = parse(featureString);
+        assertTrue(feat.queryParams().isEmpty());
+    }
+
+    public void testParseWithEmptyParams() throws IOException {
+        String featureString = "{\n" +
+                "\"name\":\"testFeature\"," +
+                "\"params\":[]," +
+                "\"template_language\":\"mustache\",\n" +
+                "\"template\": \n" +
+                new MatchQueryBuilder("match_field", "match_word").toString() +
+                "}";
+        StoredFeature feat = parse(featureString);
+        assertTrue(feat.queryParams().isEmpty());
+    }
+
+    public void testRamBytesUsed() throws IOException, InterruptedException {
+        String featureString = "{\n" +
+                "\"name\":\"testFeature\"," +
+                "\"params\":[\"param1\",\"param2\"]," +
+                "\"template_language\":\"mustache\",\n" +
+                "\"template\":\"" +
+                new MatchQueryBuilder("match_field", "match_word").toString(NOT_PRETTY).replace("\"", "\\\"") +
+                "\"}";
+        StoredFeature feature = parse(featureString);
+        long approxSize = featureString.length()*Character.BYTES;
+        assertThat(feature.ramBytesUsed(),
+                allOf(greaterThan((long) (approxSize*0.66)),
+                    lessThan((long) (approxSize*1.33))));
+    }
+
+    static StoredFeature parse(String featureString) throws IOException {
+        return StoredFeature.parse(jsonXContent.createParser(EMPTY, featureString));
+    }
+}

--- a/src/test/java/com/o19s/es/ltr/feature/store/StoredFeatureSetParserTests.java
+++ b/src/test/java/com/o19s/es/ltr/feature/store/StoredFeatureSetParserTests.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.feature.store;
+
+import org.apache.lucene.util.LuceneTestCase;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.index.query.MatchQueryBuilder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import static org.apache.lucene.util.TestUtil.randomRealisticUnicodeString;
+import static org.apache.lucene.util.TestUtil.randomSimpleString;
+import static org.elasticsearch.common.xcontent.NamedXContentRegistry.EMPTY;
+import static org.elasticsearch.common.xcontent.json.JsonXContent.jsonXContent;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+
+public class StoredFeatureSetParserTests extends LuceneTestCase {
+
+    public void testParse() throws IOException {
+        List<StoredFeature> features = new ArrayList<>();
+        String setString = generateRandomFeatureSet("my_set", features::add);
+        StoredFeatureSet set = parse(setString);
+        assertEquals("my_set", set.name());
+        assertEquals(features.size(), set.size());
+        long ramSize = 0;
+        for (int i = 0; i < features.size(); i++) {
+            StoredFeature expected = features.get(i);
+            StoredFeature actual = set.feature(i);
+            assertEquals(expected.name(), actual.name());
+            assertEquals(expected.templateLanguage(), actual.templateLanguage());
+            assertArrayEquals(expected.queryParams().toArray(), actual.queryParams().toArray());
+            assertEquals(expected.template(), actual.template());
+            assertEquals(expected.ramBytesUsed(), actual.ramBytesUsed());
+            assertEquals(i, set.featureOrdinal(actual.name()));
+            assertTrue(set.hasFeature(actual.name()));
+            assertSame(actual, set.feature(actual.name()));
+            ramSize += actual.ramBytesUsed();
+        }
+        assertFalse(set.hasFeature(unkownName()));
+        assertThat(expectThrows(IllegalArgumentException.class,
+                () -> set.feature(unkownName())).getMessage(),
+                containsString("Unknown feature"));
+
+        assertThat(set.ramBytesUsed(), allOf(greaterThan((long) (ramSize*0.66)), lessThan((long) (ramSize*1.33))));
+    }
+
+    public void testParseErrorOnDups() throws IOException {
+        String set = "{\"name\" : \"my_set\",\n" +
+                "\"features\": [\n" +
+                StoredFeatureParserTests.generateTestFeature() + "," +
+                StoredFeatureParserTests.generateTestFeature() +
+                "]}";
+        assertThat(expectThrows(ParsingException.class,
+                () -> parse(set)).getMessage(),
+                containsString("feature names must be unique in a set"));
+    }
+
+    public void testParseErrorOnMissingName() throws IOException {
+        String missingName = "{" +
+                "\"features\": [\n" +
+                StoredFeatureParserTests.generateTestFeature() +
+                "]}";
+        assertThat(expectThrows(ParsingException.class,
+                () -> parse(missingName)).getMessage(),
+                equalTo("Field [name] is mandatory"));
+    }
+
+    public void testParseErrorOnMissingSet() throws IOException {
+        String missingName = "{ \"name\": \"my_set\"}";
+        assertThat(expectThrows(ParsingException.class,
+                () -> parse(missingName)).getMessage(),
+                equalTo("Field [features] is mandatory"));
+    }
+
+    public void testParseErrorOnEmptySet() throws IOException {
+        String missingName = "{ \"name\": \"my_set\"," +
+                "\"features\": []}";
+
+        assertThat(expectThrows(ParsingException.class,
+                () -> parse(missingName)).getMessage(),
+                equalTo("At least one feature must be defined in [features]"));
+    }
+
+    public void testParseErrorOnExtraField() throws IOException {
+        String set = "{\"name\" : \"my_set\",\n" +
+                "\"random_field\": \"oops\"," +
+                "\"features\": [\n" +
+                StoredFeatureParserTests.generateTestFeature() +
+                "]}";
+        assertThat(expectThrows(ParsingException.class,
+                () -> parse(set)).getMessage(),
+                containsString("unknown field [random_field], parser not found"));
+    }
+
+    private static StoredFeatureSet parse(String missingName) throws IOException {
+        return StoredFeatureSet.parse(jsonXContent.createParser(EMPTY, missingName));
+    }
+
+    public static StoredFeature buildRandomFeature() throws IOException {
+        return StoredFeatureParserTests.parse(generateRandomFeature());
+    }
+
+    private static String generateRandomFeature() {
+        return "{\n" +
+                "\"name\": \"" + rName()+ "\",\n" +
+                "\"params\": [\"" + rName() + "\", \"" + rName() + "\"],\n" +
+                "\"template_language\": \"" + rName() + "\",\n" +
+                "\"template\": \n" +
+                new MatchQueryBuilder(rName(), randomRealisticUnicodeString(random())).toString() +
+                "\n}\n";
+    }
+
+    private static String rName() {
+        return randomSimpleString(random(), 5, 10);
+    }
+
+    private static String unkownName() {
+        // cannot be known, size is out [5,10] generated by rName()
+        return randomSimpleString(random(), 4);
+    }
+
+    public static StoredFeatureSet buildRandomFeatureSet() throws IOException {
+        return parse(generateRandomFeatureSet(null));
+    }
+
+    public static String generateRandomFeatureSet() throws IOException {
+        return generateRandomFeatureSet(null);
+    }
+
+    public static String generateRandomFeatureSet(Consumer<StoredFeature> features) throws IOException {
+        return generateRandomFeatureSet(randomSimpleString(random(),5, 10), features);
+    }
+    public static String generateRandomFeatureSet(String name, Consumer<StoredFeature> features) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\"name\" : \"")
+                .append(name)
+                .append("\",\n");
+        sb.append("\"features\":[");
+        int nbFeat = random().nextInt(20)+1;
+        boolean first = true;
+        // Simply avoid adding the same feature twice because of random string
+        Set<String> addedFeatures = new HashSet<>();
+        while(nbFeat-->0) {
+            String featureString = generateRandomFeature();
+            StoredFeature feature = StoredFeature.parse(jsonXContent.createParser(EMPTY, featureString));
+            if (!addedFeatures.add(feature.name())) {
+                continue;
+            }
+            if (!first) {
+                sb.append(",");
+            }
+            first = false;
+            sb.append(featureString);
+            if (features != null) {
+                features.accept(feature);
+            }
+        }
+        sb.append("]}");
+        return sb.toString();
+    }
+}

--- a/src/test/java/com/o19s/es/ltr/feature/store/StoredLtrModelParserTests.java
+++ b/src/test/java/com/o19s/es/ltr/feature/store/StoredLtrModelParserTests.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.feature.store;
+
+import com.o19s.es.ltr.ranker.LtrRanker;
+import com.o19s.es.ltr.ranker.linear.LinearRanker;
+import com.o19s.es.ltr.ranker.parser.LtrRankerParserFactory;
+import org.apache.lucene.util.LuceneTestCase;
+import org.elasticsearch.common.ParsingException;
+
+import java.io.IOException;
+
+import static org.elasticsearch.common.xcontent.NamedXContentRegistry.EMPTY;
+import static org.elasticsearch.common.xcontent.json.JsonXContent.jsonXContent;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class StoredLtrModelParserTests extends LuceneTestCase {
+    private LtrRanker ranker;
+    private LtrRankerParserFactory factory;
+
+    public void setUp() throws Exception {
+        super.setUp();
+        ranker = new LinearRanker(new float[]{1F,2F,3F});
+        factory = new LtrRankerParserFactory.Builder()
+                .register("model/dummy", () -> (set, model) -> ranker)
+                .build();
+    }
+
+    public void testParse() throws IOException {
+        String modelString = "{\n" +
+                " \"name\":\"my_model\",\n" +
+                " \"feature_set\":" +
+                StoredFeatureSetParserTests.generateRandomFeatureSet() +
+                "," +
+                " \"model\": {\n" +
+                "   \"type\": \"model/dummy\",\n" +
+                "   \"definition\": \"completely ignored\"\n"+
+                " }" +
+                "}";
+        StoredLtrModel model = parse(modelString);
+        assertEquals("my_model", model.name());
+        assertSame(ranker, model.ranker());
+        assertTrue(model.featureSet().size() > 0);
+    }
+
+    public void testParseFailureOnMissingName() throws IOException {
+        String modelString = "{\n" +
+                " \"feature_set\":" +
+                StoredFeatureSetParserTests.generateRandomFeatureSet() +
+                "," +
+                " \"model\": {\n" +
+                "   \"type\": \"model/dummy\",\n" +
+                "   \"definition\": \"completely ignored\"\n"+
+                " }" +
+                "}";
+        assertThat(expectThrows(ParsingException.class, () -> parse(modelString)).getMessage(),
+            equalTo("Field [name] is mandatory"));
+    }
+
+    public void testParseFailureOnMissingModel() throws IOException {
+        String modelString = "{\n" +
+                " \"name\":\"my_model\",\n" +
+                " \"feature_set\":" +
+                StoredFeatureSetParserTests.generateRandomFeatureSet() +
+                "}";
+        assertThat(expectThrows(ParsingException.class, () -> parse(modelString)).getMessage(),
+                equalTo("Field [model] is mandatory"));
+    }
+
+    public void testParseFailureOnMissingFeatureSet() throws IOException {
+        String modelString = "{\n" +
+                " \"name\":\"my_model\",\n" +
+                " \"model\": {\n" +
+                "   \"type\": \"model/dummy\",\n" +
+                "   \"definition\": \"completely ignored\"\n"+
+                " }" +
+                "}";
+        assertThat(expectThrows(ParsingException.class, () -> parse(modelString)).getMessage(),
+                equalTo("Field [feature_set] is mandatory"));
+    }
+
+    public void testParseFailureOnBogusField() throws IOException {
+        String modelString = "{\n" +
+                " \"name\":\"my_model\",\n" +
+                " \"bogusField\": \"foo\",\n" +
+                " \"feature_set\":" +
+                StoredFeatureSetParserTests.generateRandomFeatureSet() +
+                "," +
+                " \"model\": {\n" +
+                "   \"type\": \"model/dummy\",\n" +
+                "   \"definition\": \"completely ignored\"\n"+
+                " }" +
+                "}";
+        assertThat(expectThrows(ParsingException.class, () -> parse(modelString)).getMessage(),
+                containsString("bogusField"));
+    }
+
+    private StoredLtrModel parse(String missingName) throws IOException {
+        return StoredLtrModel.parse(jsonXContent.createParser(EMPTY, missingName),
+                factory);
+    }
+
+}

--- a/src/test/java/com/o19s/es/ltr/feature/store/index/CachedFeatureStoreTests.java
+++ b/src/test/java/com/o19s/es/ltr/feature/store/index/CachedFeatureStoreTests.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.feature.store.index;
+
+import com.o19s.es.ltr.LtrTestUtils;
+import com.o19s.es.ltr.feature.store.MemStore;
+import com.o19s.es.ltr.feature.store.StoredFeature;
+import com.o19s.es.ltr.feature.store.StoredFeatureSet;
+import com.o19s.es.ltr.feature.store.StoredLtrModel;
+import org.apache.lucene.util.LuceneTestCase;
+import org.apache.lucene.util.TestUtil;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+
+public class CachedFeatureStoreTests extends LuceneTestCase {
+    private final MemStore memStore = new MemStore();
+    private final Caches caches = new Caches(Settings.EMPTY);
+
+    public void testStoreName() {
+        CachedFeatureStore store = new CachedFeatureStore(memStore, caches);
+        assertSame(memStore.getStoreName(), store.getStoreName());
+    }
+
+    public void testCachedFeature() throws IOException {
+        StoredFeature feat = LtrTestUtils.randomFeature();
+        memStore.add(feat);
+        CachedFeatureStore store = new CachedFeatureStore(memStore, caches);
+        assertNull(store.getCachedFeature(feat.name()));
+        store.load(feat.name());
+        assertNotNull(store.getCachedFeature(feat.name()));
+        assertEquals(feat.ramBytesUsed(), store.featuresWeight());
+        assertEquals(feat.ramBytesUsed(), store.totalWeight());
+        assertThat(expectThrows(IOException.class, () -> store.load("unk")).getCause(),
+            instanceOf(IllegalArgumentException.class));
+    }
+
+    public void testCachedFeatureSet() throws IOException {
+        StoredFeatureSet set = LtrTestUtils.randomFeatureSet();
+        memStore.add(set);
+        CachedFeatureStore store = new CachedFeatureStore(memStore, caches);
+        assertNull(store.getCachedFeatureSet(set.name()));
+        store.loadSet(set.name());
+        assertNotNull(store.getCachedFeatureSet(set.name()));
+        assertEquals(set.ramBytesUsed(), store.featureSetWeight());
+        assertEquals(set.ramBytesUsed(), store.totalWeight());
+        assertThat(expectThrows(IOException.class, () -> store.loadSet("unk")).getCause(),
+                instanceOf(IllegalArgumentException.class));
+    }
+
+    public void testCachedModelSet() throws IOException {
+        StoredLtrModel model = LtrTestUtils.buildRandomModel();
+        memStore.add(model);
+        CachedFeatureStore store = new CachedFeatureStore(memStore, caches);
+        assertNull(store.getCachedModel(model.name()));
+        store.loadModel(model.name());
+        assertNotNull(store.getCachedModel(model.name()));
+        assertEquals(model.ramBytesUsed(), store.modelWeight());
+        assertEquals(model.ramBytesUsed(), store.totalWeight());
+        assertThat(expectThrows(IOException.class, () -> store.loadModel("unk")).getCause(),
+                instanceOf(IllegalArgumentException.class));
+    }
+
+    public void testWontBlowUp() throws IOException {
+        Caches caches = new Caches(TimeValue.timeValueHours(1), TimeValue.timeValueHours(1), 100000);
+        CachedFeatureStore store = new CachedFeatureStore(memStore, caches);
+        long curWeight = store.modelWeight();
+        long maxWeight = caches.getMaxWeight();
+        long maxIter = 1000;
+        while (true) {
+            StoredLtrModel model = LtrTestUtils.buildRandomModel();
+            memStore.add(model);
+            if (curWeight + model.ramBytesUsed() > maxWeight) {
+                store.loadModel(model.name());
+                assertTrue(store.modelWeight() < maxWeight);
+                break;
+            }
+            assertTrue(maxIter-- > 0);
+            memStore.clear();
+            curWeight = store.modelWeight();
+        }
+    }
+
+    public void testExpirationOnWrite() throws IOException, InterruptedException {
+        Caches caches = new Caches(TimeValue.timeValueMillis(100), TimeValue.timeValueHours(1), 1000000);
+        CachedFeatureStore store = new CachedFeatureStore(memStore, caches);
+        StoredLtrModel model = LtrTestUtils.buildRandomModel();
+        memStore.add(model);
+        store.loadModel(model.name());
+        assertNotNull(store.getCachedModel(model.name()));
+        Thread.sleep(500);
+        caches.modelCache().refresh();
+        assertNull(store.getCachedModel(model.name()));
+    }
+
+    public void testExpirationOnGet() throws IOException, InterruptedException {
+        Caches caches = new Caches(TimeValue.timeValueHours(1), TimeValue.timeValueMillis(100), 1000000);
+        CachedFeatureStore store = new CachedFeatureStore(memStore, caches);
+        StoredLtrModel model = LtrTestUtils.buildRandomModel();
+        memStore.add(model);
+        store.loadModel(model.name()); // fill cache
+        store.loadModel(model.name()); // access cache
+        assertNotNull(store.getCachedModel(model.name()));
+        Thread.sleep(500);
+        caches.modelCache().refresh();
+        assertNull(store.getCachedModel(model.name()));
+    }
+
+    public void testFullEviction() throws IOException {
+        int pass = TestUtil.nextInt(random(), 10, 100);
+        CachedFeatureStore cachedFeatureStore = new CachedFeatureStore(memStore, caches);
+        while (pass-- > 0) {
+            StoredFeature feat = LtrTestUtils.randomFeature();
+            memStore.add(feat);
+            cachedFeatureStore.load(feat.name());
+
+            StoredFeatureSet set = LtrTestUtils.randomFeatureSet();
+            memStore.add(set);
+            cachedFeatureStore.loadSet(set.name());
+
+            StoredLtrModel model = LtrTestUtils.buildRandomModel();
+            memStore.add(model);
+            cachedFeatureStore.loadModel(model.name());
+        }
+        caches.evict(memStore.getStoreName());
+        assertEquals(0, cachedFeatureStore.totalWeight());
+    }
+}

--- a/src/test/java/com/o19s/es/ltr/query/LtrEsQueryTests.java
+++ b/src/test/java/com/o19s/es/ltr/query/LtrEsQueryTests.java
@@ -23,8 +23,6 @@ import org.elasticsearch.test.ESIntegTestCase;
 import java.util.Collection;
 import java.util.Collections;
 
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-
 /**
  * Created by doug on 12/29/16.
  */

--- a/src/test/java/com/o19s/es/ltr/query/StoredLtrQueryBuilderTests.java
+++ b/src/test/java/com/o19s/es/ltr/query/StoredLtrQueryBuilderTests.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.query;
+
+import com.o19s.es.ltr.LtrQueryParserPlugin;
+import com.o19s.es.ltr.MockMustachePlugin;
+import com.o19s.es.ltr.feature.store.MemStore;
+import com.o19s.es.ltr.feature.store.StoredFeature;
+import com.o19s.es.ltr.feature.store.StoredFeatureSet;
+import com.o19s.es.ltr.feature.store.StoredLtrModel;
+import com.o19s.es.ltr.ranker.LtrRanker;
+import com.o19s.es.ltr.ranker.linear.LinearRanker;
+import com.o19s.es.ltr.utils.FeatureStoreProvider;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.query.MatchQueryBuilder;
+import org.elasticsearch.index.query.functionscore.FieldValueFactorFunctionBuilder;
+import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.test.AbstractQueryTestCase;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+
+public class StoredLtrQueryBuilderTests extends AbstractQueryTestCase<StoredLtrQueryBuilder> {
+    private static final MemStore store = new MemStore();
+
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return Arrays.asList(TestPlugin.class, MockMustachePlugin.class);
+    }
+
+    /**
+     * Returns a set of object names that won't trigger any exception (uncluding their children) when testing that unknown
+     * objects cause parse exceptions through {@link #testUnknownObjectException()}. Default is an empty set. Can be overridden
+     * by subclasses that test queries which contain objects that get parsed on the data nodes (e.g. score functions) or objects
+     * that can contain arbitrary content (e.g. documents for percolate or more like this query, params for scripts). In such
+     * cases no exception would get thrown.
+     */
+    @Override
+    protected Set<String> getObjectsHoldingArbitraryContent() {
+        return Collections.singletonMap(StoredLtrQueryBuilder.PARAMS.getPreferredName(), null).keySet();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        store.clear();
+        StoredFeature feature1 = new StoredFeature("match1", Collections.singletonList("query_string"),
+                "mustache",
+                new MatchQueryBuilder("field1", "{{query_string}}").toString());
+        StoredFeature feature2 = new StoredFeature("match2", Collections.singletonList("query_string"),
+                "mustache",
+                new MatchQueryBuilder("field2", "{{query_string}}").toString());
+        StoredFeature feature3 = new StoredFeature("score3", Collections.emptyList(),
+                "mustache",
+                new FunctionScoreQueryBuilder(new FieldValueFactorFunctionBuilder("scorefield2")
+                        .factor(1.2F)
+                        .modifier(FieldValueFactorFunction.Modifier.LN2P)
+                        .missing(0F)).toString());
+        StoredFeatureSet set = new StoredFeatureSet("set1", Arrays.asList(feature1, feature2, feature3));
+        LtrRanker ranker = new LinearRanker(new float[]{0.1F, 0.2F, 0.3F});
+        StoredLtrModel model = new StoredLtrModel("model1", set, ranker);
+        store.add(model);
+    }
+
+    /**
+     * Create the query that is being tested
+     */
+    @Override
+    protected StoredLtrQueryBuilder doCreateTestQueryBuilder() {
+        StoredLtrQueryBuilder builder = new StoredLtrQueryBuilder();
+        builder.modelName("model1");
+        Map<String, Object> params = new HashMap<>();
+        params.put("query_string", "a wonderful query");
+        builder.params(params);
+        return builder;
+    }
+
+    @Override
+    protected void doAssertLuceneQuery(StoredLtrQueryBuilder queryBuilder,
+                                       Query query, SearchContext context) throws IOException {
+        assertThat(query, instanceOf(RankerQuery.class));
+        RankerQuery rquery = (RankerQuery) query;
+        Iterator<Query> ite = rquery.stream().iterator();
+        assertTrue(ite.hasNext());
+        Query featureQuery1 = ite.next();
+        assertTrue(ite.hasNext());
+        Query featureQuery2 = ite.next();
+        assertTrue(ite.hasNext());
+        Query featureQuery3 = ite.next();
+    }
+
+    @Override
+    protected boolean isCachable(StoredLtrQueryBuilder queryBuilder) {
+        // This query is not cachable as it needs a ScriptService
+        // see QueryShardContext#failIfFrozen()
+        return false;
+    }
+
+    // Hack to inject our MemStore
+    public static class TestPlugin extends LtrQueryParserPlugin {
+        public TestPlugin(Settings settings) {
+            super(settings);
+        }
+
+        @Override
+        protected FeatureStoreProvider.FeatureStoreLoader getFeatureStoreLoader() {
+            // Ignore storeName for tests
+            return (name, client) -> store;
+        }
+    }
+}

--- a/src/test/java/com/o19s/es/ltr/ranker/DenseLtrRankerTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/DenseLtrRankerTests.java
@@ -23,10 +23,10 @@ public class DenseLtrRankerTests extends LuceneTestCase {
         int modelSize = random().nextInt(10);
         DummyDenseRanker ranker = new DummyDenseRanker(modelSize);
         LtrRanker.FeatureVector vector = ranker.newFeatureVector(null);
+        assertNotNull(vector);
         for(int i = 0; i < modelSize; i++) {
             assertEquals(0, vector.getFeatureScore(0), Math.ulp(0));
         }
-        assertTrue(vector instanceof DenseFeatureVector);
         float[] points = ((DenseFeatureVector) vector).scores;
         assertEquals(points.length, 2);
 

--- a/src/test/java/com/o19s/es/ltr/ranker/parser/LtrRankerParserFactoryTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/parser/LtrRankerParserFactoryTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.ranker.parser;
+
+import org.apache.lucene.util.LuceneTestCase;
+
+import static org.hamcrest.CoreMatchers.containsString;
+
+public class LtrRankerParserFactoryTests extends LuceneTestCase {
+    public void testGetParser() {
+        LtrRankerParser parser = (set, model) -> null;
+        LtrRankerParserFactory factory = new LtrRankerParserFactory.Builder()
+                .register("model/test", () -> parser)
+                .build();
+        assertSame(parser, factory.getParser("model/test"));
+        assertThat(expectThrows(IllegalArgumentException.class,
+                () -> factory.getParser("model/foobar")).getMessage(),
+                containsString("Unsupported LtrRanker format/type [model/foobar]"));
+    }
+
+    public void testDeclareMultiple() {
+        LtrRankerParser parser = (set, model) -> null;
+        LtrRankerParserFactory.Builder builder = new LtrRankerParserFactory.Builder()
+                .register("model/test", () -> parser);
+        expectThrows(RuntimeException.class,
+                () -> builder.register("model/test", () -> parser));
+    }
+
+}


### PR DESCRIPTION
Implement the stored version of the feature/set/model interfaces with their
json parsing logic.
Extracted LtrRanker parsing logic into a LtrRankerParser interface.
Implemented a CachedFeatureStore wrapper.
Added various test utils to generate random features, sets and models.
Added a StoredLtrQueryBuiler implementation that takes a model name
and a set of parameters.
Had to mockup mustache with a naive template engine because mustache is not
available during AbstractQueryBuilder tests.
Hopefully this is last giant patch, following patches should be smaller:
- add more LtrRankerParser implementations
- add a REST api on top the IndexFeatureStore
- add a logging API

closes #37