### PR TITLE
Fix the problem of parsing sample_judgements.txt in the demo

### DIFF
--- a/demo/judgments.py
+++ b/demo/judgments.py
@@ -53,6 +53,7 @@ def _judgmentsFromBody(lines):
 def judgmentsFromFile(filename):
     with open(filename) as f:
         qidToKeywords = _queriesFromHeader(f)
+    with open(filename) as f:
         for grade, qid, docId in _judgmentsFromBody(f):
             yield Judgment(grade=grade, qid=qid, keywords=qidToKeywords[qid], docId=docId)
 


### PR DESCRIPTION
The one-pass parsing of `sample_judgements.txt` skips the first judgement. Indeed, the function `_queriesFromHeader` breaks when it meets the first line not beginning with `#`. When the file handler is passed to `_judgmentsFromBody`, the first judgement is inevitably skipped. While it is possible to solve the problem by adding a blank line between the header and the body, the two-pass version is less error-prone. 