### PR TITLE
Fix NaiveAdditiveDecisionTree

### DIFF
--- a/src/main/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTree.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTree.java
@@ -109,7 +109,7 @@ public class NaiveAdditiveDecisionTree extends DenseLtrRanker implements Account
             while (!n.isLeaf()) {
                 assert n instanceof Split;
                 Split s = (Split) n;
-                if (s.threshold >= scores[feature]) {
+                if (s.threshold >= scores[s.feature]) {
                     n = s.left;
                 } else {
                     n = s.right;

--- a/src/test/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTreeTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTreeTests.java
@@ -61,9 +61,9 @@ public class NaiveAdditiveDecisionTreeTests extends LuceneTestCase {
     public void testScore() throws IOException {
         NaiveAdditiveDecisionTree ranker = parseTreeModel("simple_tree.txt");
         LtrRanker.FeatureVector vector = ranker.newFeatureVector(null);
-        vector.setFeatureScore(0, 2);
+        vector.setFeatureScore(0, 1);
         vector.setFeatureScore(1, 2);
-        vector.setFeatureScore(2, 1);
+        vector.setFeatureScore(2, 3);
 
         float expected = 1.2F*3.4F + 3.2F*2.8F;
         assertEquals(expected, ranker.score(vector), Math.ulp(expected));

--- a/src/test/resources/com/o19s/es/ltr/ranker/dectree/simple_tree.txt
+++ b/src/test/resources/com/o19s/es/ltr/ranker/dectree/simple_tree.txt
@@ -1,22 +1,23 @@
 # first line after split is right
-# data point: feature1:2, feature2:2, feature3:1
+# data point: feature1:1, feature2:2, feature3:3
 - tree:3.4
   - split:feature1:2.3
     - output:3.2
-# win
+# right wins
     - split:feature2:2.2
       - split:feature3:3.2
-        - output:3.1
-        - output:4.1
-# win => output 1.2*3.4
+        - output:11
+        - output:17
+# left wins => output 1.2*3.4
       - output:1.2
 - tree:2.8
-  - split:feature2:2.1
-    - output:3.2
-# win
-    - split:feature2:2.2
+  - split:feature1:0.1
+# right wins
+    - split:feature2:1.8
+# right wins
       - split:feature3:3.2
-        - output:3.1
-        - output:4.1
-# win => output 3.2*2.8
-      - output:3.2
+        - output:10
+# left wins => output 3.2*2.8
+        - output:3.2
+      - output:15
+  - output:23


### PR DESCRIPTION
The split threshold was always compared to the feature value of the
root split.
Sadly the test was written in a way that did not catch the issue.
Fix the tests and the implementation.