### PR TITLE
Add feature logging

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -83,7 +83,7 @@ The log entries are appendend to a search hit field named `_ltrlog` with a sub f
         "_id" : "1",
         "_score": 1.3862944,
         "fields" : {
-          "_ltrlog": {
+          "_ltrlog": [{
             "log_entry1": {
               "feature1": 1.232,
               "feature2": 0,
@@ -95,7 +95,7 @@ The log entries are appendend to a search hit field named `_ltrlog` with a sub f
               "feature3": 2.324,
               "feature4": 0.3234
             }
-          }
+          }]
         }
       },
       {
@@ -104,7 +104,7 @@ The log entries are appendend to a search hit field named `_ltrlog` with a sub f
         "_id" : "4",
         "_score": 1.2324,
         "fields" : {
-          "_ltrlog": {
+          "_ltrlog": [{
             "log_entry1": {
               "feature1": 1.112,
               "feature2": 3.234,
@@ -115,7 +115,7 @@ The log entries are appendend to a search hit field named `_ltrlog` with a sub f
               "feature1": 1.112,
               "feature2": 3.234
             }
-          }
+          }]
         }
       }
     ]

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,137 @@
+# Feature Logging
+
+To extract feature scores of a feature set or a model the `ltr_log` search extension.
+The `ltr_log` extension is able to capture feature values of a `sltr` query use inside the main search query when
+`named` or used inside a `rescore_query`.
+
+Example to output the feature scores for the feature set `my_feature_set` and for the model `my_model`:
+
+```json
+{
+  "query" : {
+    "bool" : {
+      "must" : {
+        "sltr" : {
+          "params" : {
+            "query_string" : "a search query"
+          },
+          "featureset": "my_feature_set",
+          "_name": "logged_featureset"
+        },
+        "filter": {
+          "ids" : {
+            "type" : "my_type",
+            "values" : ["1", "4"]
+          }
+        }
+      }
+    }
+  },
+  "rescore": [
+    {
+      "window_size": 3,
+      "query": {
+        "rescore_query": {
+          "sltr": {
+            "params" : {
+              "query_string" : "a search query"
+            },
+            "model": "my_model"
+          }
+        }
+      }
+    }
+  ],
+  "size": 3,
+  "ext": {
+    "ltr_log" : {
+      "log_specs": [
+        {
+          "name": "log_entry1",
+          "named_query": "logged_featureset",
+          "missing_as_zero": true
+        },
+        {
+          "name": "log_entry2",
+          "rescore_index": 0,
+          "missing_as_zero": false
+        }
+      ]
+    }
+  }
+}
+```
+
+The log entries are appendend to a search hit field named `_ltrlog` with a sub field per log entry.
+
+```json
+{
+  "took": 1,
+  "timed_out": false,
+  "_shards":{
+    "total" : 2,
+    "successful" : 3,
+    "failed" : 0
+  },
+  "hits":{
+    "total" : 3,
+    "max_score": 1.3862944,
+    "hits" : [
+      {
+        "_index" : "my_index",
+        "_type" : "my_type",
+        "_id" : "1",
+        "_score": 1.3862944,
+        "fields" : {
+          "_ltrlog": {
+            "log_entry1": {
+              "feature1": 1.232,
+              "feature2": 0,
+              "feature3": 2.324,
+              "feature4": 0.3234
+            },
+            "log_entry2": {
+              "feature1": 1.232,
+              "feature3": 2.324,
+              "feature4": 0.3234
+            }
+          }
+        }
+      },
+      {
+        "_index" : "my_index",
+        "_type" : "my_type",
+        "_id" : "4",
+        "_score": 1.2324,
+        "fields" : {
+          "_ltrlog": {
+            "log_entry1": {
+              "feature1": 1.112,
+              "feature2": 3.234,
+              "feature3": 0,
+              "feature4": 0
+            },
+            "log_entry2": {
+              "feature1": 1.112,
+              "feature2": 3.234
+            }
+          }
+        }
+      }
+    ]
+  }
+}
+
+```
+
+A `log_spec` is defined with the following fields:
+- `name`: the name of the entry in the `_ltrlog` field (defaults to the name of the `named_query` or `rescore[index]`).
+- `named_query`: the name of the `sltr` to capture
+- `rescore_index`: the index of the query to capture in the list of rescore queries
+- `missing_as_zero`: produce a 0 for missing features (when the feature does not match) (defaults to `false\`)
+
+Either `named_query` or `rescore_index` must be set.
+
+Note that feature collection happens during the fetch phase. The `sltr` feature queries are executed again on the list
+of returned documents. When logging features on top of an existing `model` its ranker is disabled for performance
+reasons.

--- a/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
+++ b/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
@@ -35,6 +35,8 @@ import com.o19s.es.ltr.feature.store.StoredFeatureSet;
 import com.o19s.es.ltr.feature.store.StoredLtrModel;
 import com.o19s.es.ltr.feature.store.index.Caches;
 import com.o19s.es.ltr.feature.store.index.IndexFeatureStore;
+import com.o19s.es.ltr.logging.LoggingFetchSubPhase;
+import com.o19s.es.ltr.logging.LoggingSearchExtBuilder;
 import com.o19s.es.ltr.query.LtrQueryBuilder;
 import com.o19s.es.ltr.query.StoredLtrQueryBuilder;
 import com.o19s.es.ltr.ranker.parser.LinearRankerParser;
@@ -71,6 +73,7 @@ import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.script.NativeScriptFactory;
 import org.elasticsearch.script.ScriptEngineService;
 import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
 
@@ -81,6 +84,7 @@ import java.util.List;
 import java.util.function.Supplier;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
 
 public class LtrQueryParserPlugin extends Plugin implements SearchPlugin, ScriptPlugin, ActionPlugin {
@@ -103,6 +107,17 @@ public class LtrQueryParserPlugin extends Plugin implements SearchPlugin, Script
         return asList(
                 new QuerySpec<>(LtrQueryBuilder.NAME, LtrQueryBuilder::new, LtrQueryBuilder::fromXContent),
                 new QuerySpec<>(StoredLtrQueryBuilder.NAME, StoredLtrQueryBuilder::new, StoredLtrQueryBuilder::fromXContent));
+    }
+
+    @Override
+    public List<FetchSubPhase> getFetchSubPhases(FetchPhaseConstructionContext context) {
+        return singletonList(new LoggingFetchSubPhase());
+    }
+
+    @Override
+    public List<SearchExtSpec<?>> getSearchExts() {
+        return singletonList(
+                new SearchExtSpec<>(LoggingSearchExtBuilder.NAME, LoggingSearchExtBuilder::new, LoggingSearchExtBuilder::parse));
     }
 
     @Override

--- a/src/main/java/com/o19s/es/ltr/feature/store/CompiledLtrModel.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/CompiledLtrModel.java
@@ -29,10 +29,10 @@ public class CompiledLtrModel implements LtrModel, Accountable {
     private static final long BASE_RAM_USED = RamUsageEstimator.shallowSizeOfInstance(StoredLtrModel.class);
 
     private final String name;
-    private final StoredFeatureSet set;
+    private final FeatureSet set;
     private final LtrRanker ranker;
 
-    public CompiledLtrModel(String name, StoredFeatureSet set, LtrRanker ranker) {
+    public CompiledLtrModel(String name, FeatureSet set, LtrRanker ranker) {
         this.name = name;
         this.set = set;
         this.ranker = ranker;
@@ -68,7 +68,7 @@ public class CompiledLtrModel implements LtrModel, Accountable {
     @Override
     public long ramBytesUsed() {
         return BASE_RAM_USED + name.length() * Character.BYTES + NUM_BYTES_ARRAY_HEADER
-                + set.ramBytesUsed()
+                + (set instanceof Accountable ? ((Accountable)set).ramBytesUsed() : set.size() * NUM_BYTES_OBJECT_HEADER)
                 + (ranker instanceof Accountable ?
                 ((Accountable)ranker).ramBytesUsed() : set.size() * NUM_BYTES_OBJECT_HEADER);
     }

--- a/src/main/java/com/o19s/es/ltr/logging/LoggingFetchSubPhase.java
+++ b/src/main/java/com/o19s/es/ltr/logging/LoggingFetchSubPhase.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.logging;
+
+import com.o19s.es.ltr.feature.FeatureSet;
+import com.o19s.es.ltr.query.RankerQuery;
+import com.o19s.es.ltr.ranker.LogLtrRanker;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.search.SearchHitField;
+import org.elasticsearch.search.fetch.FetchPhaseExecutionException;
+import org.elasticsearch.search.fetch.FetchSubPhase;
+import org.elasticsearch.search.internal.InternalSearchHit;
+import org.elasticsearch.search.internal.InternalSearchHitField;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.rescore.QueryRescorer;
+import org.elasticsearch.search.rescore.RescoreSearchContext;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class LoggingFetchSubPhase implements FetchSubPhase {
+    @Override
+    public void hitsExecute(SearchContext context, InternalSearchHit[] hits) {
+        LoggingSearchExtBuilder ext = (LoggingSearchExtBuilder) context.getSearchExt(LoggingSearchExtBuilder.NAME);
+        if (ext == null) {
+            return;
+        }
+
+        // Use a boolean query with all the models to log
+        // This way reuse existing code to advance through multiple scorers/iterators
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        List<HitLogConsumer> loggers = new ArrayList<>();
+        Map<String, Query> namedQueries = context.parsedQuery().namedFilters();
+        ext.logSpecsStream().filter((l) -> l.getNamedQuery() != null).forEach((l) -> {
+            Tuple<RankerQuery, HitLogConsumer> query = extractQuery(l, namedQueries);
+            builder.add(new BooleanClause(query.v1(), BooleanClause.Occur.MUST));
+            loggers.add(query.v2());
+        });
+
+        ext.logSpecsStream().filter((l) -> l.getRescoreIndex() != null).forEach((l) -> {
+            Tuple<RankerQuery, HitLogConsumer> query = extractRescore(l, context.rescore());
+            builder.add(new BooleanClause(query.v1(), BooleanClause.Occur.MUST));
+            loggers.add(query.v2());
+        });
+
+
+        try {
+            doLog(builder.build(), loggers, context.searcher(), hits);
+        } catch (IOException e) {
+            throw new FetchPhaseExecutionException(context, e.getMessage(), e);
+        }
+    }
+
+    void doLog(BooleanQuery query, List<HitLogConsumer> loggers, IndexSearcher searcher, InternalSearchHit[] hits) throws IOException {
+        // Reorder hits by id so we can scan all the docs belonging to the same
+        // segment by reusing the same scorer.
+        InternalSearchHit[] reordered = new InternalSearchHit[hits.length];
+        System.arraycopy(hits, 0, reordered, 0, hits.length);
+        Arrays.sort(reordered, Comparator.comparingInt(InternalSearchHit::docId));
+
+        int hitUpto = 0;
+        int readerUpto = -1;
+        int endDoc = 0;
+        int docBase = 0;
+        Scorer scorer = null;
+        Weight weight = searcher.createNormalizedWeight(query, true);
+        // Loop logic borrowed from lucene QueryRescorer
+        while (hitUpto < reordered.length) {
+            InternalSearchHit hit = reordered[hitUpto];
+            int docID = hit.docId();
+            loggers.forEach((l) -> l.nextDoc(hit));
+            LeafReaderContext readerContext = null;
+            while (docID >= endDoc) {
+                readerUpto++;
+                readerContext = searcher.getTopReaderContext().leaves().get(readerUpto);
+                endDoc = readerContext.docBase + readerContext.reader().maxDoc();
+            }
+
+            if (readerContext != null) {
+                // We advanced to another segment:
+                docBase = readerContext.docBase;
+                scorer = weight.scorer(readerContext);
+            }
+
+            if(scorer != null) {
+                int targetDoc = docID - docBase;
+                int actualDoc = scorer.docID();
+                if (actualDoc < targetDoc) {
+                    actualDoc = scorer.iterator().advance(targetDoc);
+                }
+                if (actualDoc == targetDoc) {
+                    // Scoring will trigger log collection
+                    scorer.score();
+                }
+            }
+
+            hitUpto++;
+        }
+    }
+
+    private Tuple<RankerQuery, HitLogConsumer> extractQuery(LoggingSearchExtBuilder.LogSpec logSpec, Map<String, Query> namedQueries) {
+        Query q = namedQueries.get(logSpec.getNamedQuery());
+        if (q == null) {
+            throw new IllegalArgumentException("No query named [" + logSpec.getNamedQuery() + "] found");
+        }
+        if (!(q instanceof RankerQuery)) {
+            throw new IllegalArgumentException("Query named [" + logSpec.getNamedQuery() +
+                    "] must be a [sltr] query [" + q.getClass().getSimpleName() + "] found");
+        }
+        RankerQuery query = (RankerQuery) q;
+        return toLogger(logSpec, query);
+    }
+
+    private Tuple<RankerQuery, HitLogConsumer> extractRescore(LoggingSearchExtBuilder.LogSpec logSpec,
+                                                              List<RescoreSearchContext> contexts) {
+        if (logSpec.getRescoreIndex() >= contexts.size()) {
+            throw new IllegalArgumentException("rescore index [" + logSpec.getRescoreIndex()+"] is out of bounds, only " +
+                    "[" + contexts.size() + "] rescore context(s) are available");
+        }
+        RescoreSearchContext context = contexts.get(logSpec.getRescoreIndex());
+        if (!(context instanceof QueryRescorer.QueryRescoreContext)) {
+            throw new IllegalArgumentException("Expected a [QueryRescoreContext] but found a " +
+                    "[" + context.getClass().getSimpleName() + "] " +
+                    "at index [" + logSpec.getRescoreIndex() + "]");
+        }
+        QueryRescorer.QueryRescoreContext qrescore = (QueryRescorer.QueryRescoreContext) context;
+        if (!(qrescore.query() instanceof RankerQuery)) {
+            throw new IllegalArgumentException("Expected a [sltr] query but found a " +
+                    "[" + qrescore.query().getClass().getSimpleName() + "] " +
+                    "at index [" + logSpec.getRescoreIndex() + "]");
+        }
+
+        RankerQuery query = (RankerQuery) qrescore.query();
+        return toLogger(logSpec, query);
+    }
+
+    Tuple<RankerQuery, HitLogConsumer> toLogger(LoggingSearchExtBuilder.LogSpec logSpec, RankerQuery query) {
+        HitLogConsumer consumer = new HitLogConsumer(logSpec.getLoggerName(), query.featureSet(), logSpec.isMissingAsZero());
+        // Use a null ranker, we don't care about the final score here so don't spend time on it.
+        query = query.toLoggerQuery(consumer, true);
+
+        return new Tuple<>(query, consumer);
+    }
+
+    static class HitLogConsumer implements LogLtrRanker.LogConsumer {
+        private static final String FIELD_NAME = "_ltrlog";
+        private final String name;
+        private final FeatureSet set;
+        private final Map<String, Float> initialLog;
+        private Map<String, Float> currentLog;
+
+        HitLogConsumer(String name, FeatureSet set, boolean missingAsZero) {
+            this.name = name;
+            this.set = set;
+            Map<String, Float> ini = new HashMap<>();
+            if (missingAsZero) {
+                for (int i = 0; i < set.size(); i++) {
+                    ini.put(set.feature(i).name(), 0F);
+                }
+            }
+            initialLog = Collections.unmodifiableMap(ini);
+        }
+
+        @Override
+        public void accept(int featureOrdinal, float score) {
+            currentLog.put(set.feature(featureOrdinal).name(), score);
+        }
+
+        void nextDoc(InternalSearchHit hit) {
+            if (hit.fieldsOrNull() == null) {
+                hit.fields(new HashMap<>());
+            }
+            SearchHitField logs = hit.getFields()
+                    .computeIfAbsent(FIELD_NAME,(k) -> newLogField());
+            Map<String, Map<String, Float>> entries = logs.getValue();
+            currentLog = new HashMap<>(initialLog);
+            entries.put(name, currentLog);
+        }
+
+        SearchHitField newLogField() {
+            List<Object> logList = Collections.singletonList(new HashMap<String, Map<String, Float>>());
+            return new InternalSearchHitField(FIELD_NAME, logList);
+        }
+    }
+}

--- a/src/main/java/com/o19s/es/ltr/logging/LoggingSearchExtBuilder.java
+++ b/src/main/java/com/o19s/es/ltr/logging/LoggingSearchExtBuilder.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.logging;
+
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.SearchExtBuilder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+public class LoggingSearchExtBuilder extends SearchExtBuilder {
+    public static final String NAME = "ltr_log";
+
+    private static final ObjectParser<LoggingSearchExtBuilder, Void> PARSER;
+    private static ParseField LOG_SPECS = new ParseField("log_specs");
+
+    static {
+        PARSER = new ObjectParser<>(NAME, LoggingSearchExtBuilder::new);
+        PARSER.declareObjectArray(LoggingSearchExtBuilder::setLogSpecs, LogSpec::parse, LOG_SPECS);
+    }
+    private List<LogSpec> logSpecs;
+
+    public LoggingSearchExtBuilder() {}
+
+    public LoggingSearchExtBuilder(StreamInput input) throws IOException {
+        logSpecs = input.readList(LogSpec::new);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeList(logSpecs);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    public static LoggingSearchExtBuilder parse(XContentParser parser) throws IOException {
+        try {
+            LoggingSearchExtBuilder ext = PARSER.parse(parser, null);
+            if (ext.logSpecs == null || ext.logSpecs.isEmpty()) {
+                throw new ParsingException(parser.getTokenLocation(), "[" + NAME + "] should define at least one [" +
+                    LOG_SPECS + "]");
+            }
+            return ext;
+        } catch(IllegalArgumentException iae) {
+            throw new ParsingException(parser.getTokenLocation(), iae.getMessage(), iae);
+        }
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(LOG_SPECS.getPreferredName(), logSpecs);
+        return builder.endObject();
+    }
+
+    public Stream<LogSpec> logSpecsStream() {
+        return logSpecs.stream();
+    }
+
+    private void setLogSpecs(List<LogSpec> logSpecs) {
+        this.logSpecs = logSpecs;
+    }
+
+    public LoggingSearchExtBuilder addQueryLogging(String name, String namedQuery, boolean missingAsZero) {
+        addLogSpec(new LogSpec(name, Objects.requireNonNull(namedQuery), missingAsZero));
+        return this;
+    }
+
+    public LoggingSearchExtBuilder addRescoreLogging(String name, int rescoreIndex, boolean missingAsZero) {
+        addLogSpec(new LogSpec(name, rescoreIndex, missingAsZero));
+        return this;
+    }
+
+    private void addLogSpec(LogSpec spec) {
+        if (logSpecs == null) {
+            logSpecs = new ArrayList<>();
+        }
+        logSpecs.add(spec);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.getClass(), logSpecs);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof LoggingSearchExtBuilder)) {
+            return false;
+        }
+        LoggingSearchExtBuilder o = (LoggingSearchExtBuilder) obj;
+        return Objects.equals(logSpecs, o.logSpecs);
+    }
+
+    public static class LogSpec implements Writeable, ToXContentObject {
+        private static final ParseField LOGGER_NAME = new ParseField("name");
+        private static final ParseField NAMED_QUERY = new ParseField("named_query");
+        private static final ParseField RESCORE_INDEX = new ParseField("rescore_index");
+        private static final ParseField MISSING_AS_ZERO = new ParseField("missing_as_zero");
+
+        private static final ObjectParser<LogSpec, Void> PARSER;
+
+        static {
+            PARSER = new ObjectParser<>("spec", LogSpec::new);
+            PARSER.declareString(LogSpec::setLoggerName, LOGGER_NAME);
+            PARSER.declareString(LogSpec::setNamedQuery, NAMED_QUERY);
+            PARSER.declareInt(LogSpec::setRescoreIndex, RESCORE_INDEX);
+            PARSER.declareBoolean(LogSpec::setMissingAsZero, MISSING_AS_ZERO);
+        }
+        private String loggerName;
+        private String namedQuery;
+        private Integer rescoreIndex;
+        private boolean missingAsZero;
+
+        private LogSpec() {}
+
+        LogSpec(@Nullable String loggerName, String namedQuery, boolean missingAsZero) {
+            this.loggerName = loggerName;
+            this.namedQuery = Objects.requireNonNull(namedQuery);
+            this.missingAsZero = missingAsZero;
+        }
+
+        LogSpec(@Nullable String loggerName, int rescoreIndex, boolean missingAsZero) {
+            this.loggerName = loggerName;
+            this.rescoreIndex = rescoreIndex;
+            this.missingAsZero = missingAsZero;
+        }
+
+        private LogSpec(StreamInput input) throws IOException {
+            loggerName = input.readOptionalString();
+            namedQuery = input.readOptionalString();
+            rescoreIndex = input.readOptionalVInt();
+            missingAsZero = input.readBoolean();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeOptionalString(loggerName);
+            out.writeOptionalString(namedQuery);
+            out.writeOptionalVInt(rescoreIndex);
+            out.writeBoolean(missingAsZero);
+        }
+
+        private static LogSpec parse(XContentParser parser, Void context) throws IOException {
+            try {
+                LogSpec spec = PARSER.parse(parser, null);
+                if (spec.namedQuery == null && spec.rescoreIndex == null) {
+                    throw new ParsingException(parser.getTokenLocation(), "Either " +
+                            "[" + NAMED_QUERY + "] or [" + RESCORE_INDEX + "] must be set.");
+                }
+                if (spec.rescoreIndex != null && spec.rescoreIndex < 0) {
+                    throw new ParsingException(parser.getTokenLocation(), "[" + RESCORE_INDEX + "] must be a non-negative integer.");
+                }
+                return spec;
+            } catch (IllegalArgumentException iae) {
+                throw new ParsingException(parser.getTokenLocation(), iae.getMessage(), iae);
+            }
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            if (loggerName != null) {
+                builder.field(LOGGER_NAME.getPreferredName(), loggerName);
+            }
+            if (namedQuery != null) {
+                builder.field(NAMED_QUERY.getPreferredName(), namedQuery);
+            } else if (rescoreIndex != null) {
+                builder.field(RESCORE_INDEX.getPreferredName(), rescoreIndex);
+            }
+            if (missingAsZero) {
+                builder.field(MISSING_AS_ZERO.getPreferredName(), missingAsZero);
+            }
+            return builder.endObject();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            LogSpec logSpec = (LogSpec) o;
+
+            if (missingAsZero != logSpec.missingAsZero) return false;
+            if (loggerName != null ? !loggerName.equals(logSpec.loggerName) : logSpec.loggerName != null) return false;
+            if (namedQuery != null ? !namedQuery.equals(logSpec.namedQuery) : logSpec.namedQuery != null) return false;
+            return rescoreIndex != null ? rescoreIndex.equals(logSpec.rescoreIndex) : logSpec.rescoreIndex == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = loggerName != null ? loggerName.hashCode() : 0;
+            result = 31 * result + (namedQuery != null ? namedQuery.hashCode() : 0);
+            result = 31 * result + (rescoreIndex != null ? rescoreIndex.hashCode() : 0);
+            result = 31 * result + (missingAsZero ? 1 : 0);
+            return result;
+        }
+
+        public String getNamedQuery() {
+            return namedQuery;
+        }
+
+        private void setNamedQuery(String namedQuery) {
+            this.namedQuery = namedQuery;
+        }
+
+        public Integer getRescoreIndex() {
+            return rescoreIndex;
+        }
+
+        private void setRescoreIndex(Integer rescoreIndex) {
+            this.rescoreIndex = rescoreIndex;
+        }
+
+        public String getLoggerName() {
+            if (loggerName != null) {
+                return loggerName;
+            }
+            return namedQuery != null ? namedQuery : "rescore[" + rescoreIndex + "]";
+        }
+
+        private void setLoggerName(String loggerName) {
+            this.loggerName = loggerName;
+        }
+
+        public boolean isMissingAsZero() {
+            return missingAsZero;
+        }
+
+        private void setMissingAsZero(boolean missingAsZero) {
+            this.missingAsZero = missingAsZero;
+        }
+    }
+}

--- a/src/main/java/com/o19s/es/ltr/query/NoopScorer.java
+++ b/src/main/java/com/o19s/es/ltr/query/NoopScorer.java
@@ -37,6 +37,11 @@ public class NoopScorer extends Scorer {
 
     }
 
+    public NoopScorer(Weight weight, DocIdSetIterator iterator) {
+        super(weight);
+        _noopIter = iterator;
+    }
+
     @Override
     public int docID() {
         return _noopIter.docID();

--- a/src/main/java/com/o19s/es/ltr/query/StoredLtrQueryBuilder.java
+++ b/src/main/java/com/o19s/es/ltr/query/StoredLtrQueryBuilder.java
@@ -60,6 +60,7 @@ public class StoredLtrQueryBuilder extends AbstractQueryBuilder<StoredLtrQueryBu
     static {
         PARSER = new ObjectParser<>(NAME, StoredLtrQueryBuilder::new);
         PARSER.declareString(StoredLtrQueryBuilder::modelName, MODEL_NAME);
+        PARSER.declareString(StoredLtrQueryBuilder::featureSetName, FEATURESET_NAME);
         PARSER.declareString(StoredLtrQueryBuilder::storeName, STORE_NAME);
         PARSER.declareField(StoredLtrQueryBuilder::params, XContentParser::map,
                 PARAMS, ObjectParser.ValueType.OBJECT);
@@ -103,7 +104,12 @@ public class StoredLtrQueryBuilder extends AbstractQueryBuilder<StoredLtrQueryBu
     @Override
     protected void doXContent(XContentBuilder builder, Params p) throws IOException {
         builder.startObject(NAME);
-        builder.field(MODEL_NAME.getPreferredName(), modelName);
+        if (modelName != null) {
+            builder.field(MODEL_NAME.getPreferredName(), modelName);
+        }
+        if (featureSetName != null) {
+            builder.field(FEATURESET_NAME.getPreferredName(), featureSetName);
+        }
         if (storeName != null) {
             builder.field(STORE_NAME.getPreferredName(), storeName);
         }
@@ -134,13 +140,14 @@ public class StoredLtrQueryBuilder extends AbstractQueryBuilder<StoredLtrQueryBu
     @Override
     protected boolean doEquals(StoredLtrQueryBuilder other) {
         return Objects.equals(modelName, other.modelName) &&
+                Objects.equals(featureSetName, other.featureSetName) &&
                 Objects.equals(storeName, other.storeName) &&
                 Objects.equals(params, other.params);
     }
 
     @Override
     protected int doHashCode() {
-        return Objects.hash(modelName, storeName, params);
+        return Objects.hash(modelName, featureSetName, storeName, params);
     }
 
     @Override

--- a/src/main/java/com/o19s/es/ltr/query/StoredLtrQueryBuilder.java
+++ b/src/main/java/com/o19s/es/ltr/query/StoredLtrQueryBuilder.java
@@ -16,8 +16,11 @@
 
 package com.o19s.es.ltr.query;
 
+import com.o19s.es.ltr.feature.FeatureSet;
 import com.o19s.es.ltr.feature.store.CompiledLtrModel;
 import com.o19s.es.ltr.feature.store.FeatureStore;
+import com.o19s.es.ltr.feature.store.index.IndexFeatureStore;
+import com.o19s.es.ltr.ranker.linear.LinearRanker;
 import com.o19s.es.ltr.utils.FeatureStoreProvider;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
@@ -32,11 +35,10 @@ import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.query.QueryShardContext;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-
-import static com.o19s.es.ltr.feature.store.index.IndexFeatureStore.DEFAULT_STORE;
 
 /**
  * sltr query, build a ltr query based on a stored model.
@@ -44,11 +46,13 @@ import static com.o19s.es.ltr.feature.store.index.IndexFeatureStore.DEFAULT_STOR
 public class StoredLtrQueryBuilder extends AbstractQueryBuilder<StoredLtrQueryBuilder> implements NamedWriteable {
     public static final String NAME = "sltr";
     public static final ParseField MODEL_NAME = new ParseField("model");
+    public static final ParseField FEATURESET_NAME = new ParseField("featureset");
     public static final ParseField STORE_NAME = new ParseField("store");
     public static final ParseField PARAMS = new ParseField("params");
 
     private String modelName;
-    private String storeName = DEFAULT_STORE;
+    private String featureSetName;
+    private String storeName;
     private Map<String, Object> params;
 
     private static final ObjectParser<StoredLtrQueryBuilder, Void> PARSER;
@@ -65,16 +69,18 @@ public class StoredLtrQueryBuilder extends AbstractQueryBuilder<StoredLtrQueryBu
     public StoredLtrQueryBuilder() {}
     public StoredLtrQueryBuilder(StreamInput input) throws IOException {
         super(input);
-        modelName = input.readString();
+        modelName = input.readOptionalString();
+        featureSetName = input.readOptionalString();
         params = input.readMap();
-        storeName = input.readString();
+        storeName = input.readOptionalString();
     }
 
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeString(modelName);
+        out.writeOptionalString(modelName);
+        out.writeOptionalString(featureSetName);
         out.writeMap(params);
-        out.writeString(storeName);
+        out.writeOptionalString(storeName);
     }
 
     public static Optional<StoredLtrQueryBuilder> fromXContent(QueryParseContext context) throws IOException {
@@ -85,11 +91,8 @@ public class StoredLtrQueryBuilder extends AbstractQueryBuilder<StoredLtrQueryBu
         } catch (IllegalArgumentException iae) {
             throw new ParsingException(parser.getTokenLocation(), iae.getMessage(), iae);
         }
-        if (builder.modelName() == null) {
-            throw new ParsingException(parser.getTokenLocation(), "Field [" + MODEL_NAME + "] is mandatory.");
-        }
-        if (builder.storeName() == null) {
-            throw new ParsingException(parser.getTokenLocation(), "Field [" + STORE_NAME + "] cannot be null.");
+        if (builder.modelName() == null && builder.featureSetName() == null) {
+            throw new ParsingException(parser.getTokenLocation(), "Either [" + MODEL_NAME + "] or [" + FEATURESET_NAME + "] must be set.");
         }
         if (builder.params() == null) {
             throw new ParsingException(parser.getTokenLocation(), "Field [" + PARAMS + "] is mandatory.");
@@ -101,7 +104,7 @@ public class StoredLtrQueryBuilder extends AbstractQueryBuilder<StoredLtrQueryBu
     protected void doXContent(XContentBuilder builder, Params p) throws IOException {
         builder.startObject(NAME);
         builder.field(MODEL_NAME.getPreferredName(), modelName);
-        if (!DEFAULT_STORE.equals(storeName)) {
+        if (storeName != null) {
             builder.field(STORE_NAME.getPreferredName(), storeName);
         }
         if (this.params != null && !this.params.isEmpty()) {
@@ -113,9 +116,19 @@ public class StoredLtrQueryBuilder extends AbstractQueryBuilder<StoredLtrQueryBu
 
     @Override
     protected RankerQuery doToQuery(QueryShardContext context) throws IOException {
-        FeatureStore store = FeatureStoreProvider.findFeatureStore(storeName, context);
-        CompiledLtrModel model = store.loadModel(modelName);
-        return RankerQuery.build(model, context, params);
+        String indexName = storeName != null ? IndexFeatureStore.indexName(storeName) : IndexFeatureStore.DEFAULT_STORE;
+        FeatureStore store = FeatureStoreProvider.findFeatureStore(indexName, context);
+        if (modelName != null) {
+            CompiledLtrModel model = store.loadModel(modelName);
+            return RankerQuery.build(model, context, params);
+        } else {
+            FeatureSet set = store.loadSet(featureSetName);
+            float[] weitghs = new float[set.size()];
+            Arrays.fill(weitghs, 1F);
+            LinearRanker ranker = new LinearRanker(weitghs);
+            CompiledLtrModel model = new CompiledLtrModel("linear", set, ranker);
+            return RankerQuery.build(model, context, params);
+        }
     }
 
     @Override
@@ -144,12 +157,21 @@ public class StoredLtrQueryBuilder extends AbstractQueryBuilder<StoredLtrQueryBu
         return this;
     }
 
+    public String featureSetName() {
+        return featureSetName;
+    }
+
+    public StoredLtrQueryBuilder featureSetName(String featureSetName) {
+        this.featureSetName = featureSetName;
+        return this;
+    }
+
     public String storeName() {
         return storeName;
     }
 
     public StoredLtrQueryBuilder storeName(String storeName) {
-        this.storeName = Objects.requireNonNull(storeName);
+        this.storeName = storeName;
         return this;
     }
 

--- a/src/main/java/com/o19s/es/ltr/ranker/LogLtrRanker.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/LogLtrRanker.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.ranker;
+
+public class LogLtrRanker implements LtrRanker {
+    private LogConsumer logger;
+    private final LtrRanker ranker;
+
+    public LogLtrRanker(LtrRanker ranker, LogConsumer consumer) {
+        this.ranker = ranker;
+        this.logger = consumer;
+    }
+
+    public LogLtrRanker(LogConsumer consumer, int modelSize) {
+        this.ranker = new NullRanker(modelSize);
+        this.logger = consumer;
+    }
+
+    @Override
+    public String name() {
+        return "log(" + ranker.name() + ")";
+    }
+
+    @Override
+    public FeatureVector newFeatureVector(FeatureVector reuse) {
+        final VectorWrapper wrapper;
+        if (reuse == null) {
+            wrapper = new VectorWrapper(logger);
+        } else {
+            assert reuse instanceof VectorWrapper;
+            wrapper = (VectorWrapper) reuse;
+        }
+        wrapper.reset(ranker);
+        return wrapper;
+    }
+
+    @Override
+    public float score(FeatureVector point) {
+        assert point instanceof VectorWrapper;
+        return ranker.score(((VectorWrapper) point).inner);
+    }
+
+    private static class VectorWrapper implements FeatureVector {
+        private FeatureVector inner;
+        private LogConsumer logger;
+
+        VectorWrapper(LogConsumer consumer) {
+            this.logger = consumer;
+        }
+
+        @Override
+        public void setFeatureScore(int featureId, float score) {
+            inner.setFeatureScore(featureId, score);
+            logger.accept(featureId, score);
+        }
+
+        @Override
+        public float getFeatureScore(int featureId) {
+            return inner.getFeatureScore(featureId);
+        }
+
+        void reset(LtrRanker ranker) {
+            this.inner = ranker.newFeatureVector(inner);
+            logger.reset();
+        }
+    }
+
+    @FunctionalInterface
+    public interface LogConsumer {
+        void accept(int featureOrdinal, float score);
+        default void reset() {}
+    }
+}

--- a/src/main/java/com/o19s/es/ltr/ranker/NullRanker.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/NullRanker.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.ranker;
+
+public class NullRanker extends DenseLtrRanker {
+    private final int modelSize;
+
+    public NullRanker(int modelSize) {
+        this.modelSize = modelSize;
+    }
+
+    @Override
+    public String name() {
+        return "null_ranker";
+    }
+
+    @Override
+    public float score(FeatureVector point) {
+        return 0F;
+    }
+
+    @Override
+    protected float score(DenseFeatureVector vector) {
+        return 0F;
+    }
+
+    @Override
+    protected int size() {
+        return modelSize;
+    }
+}

--- a/src/main/java/com/o19s/es/ltr/ranker/linear/LinearRanker.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/linear/LinearRanker.java
@@ -21,6 +21,7 @@ import com.o19s.es.ltr.ranker.DenseLtrRanker;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -52,6 +53,21 @@ public class LinearRanker extends DenseLtrRanker implements Accountable {
     @Override
     protected int size() {
         return weights.length;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        LinearRanker ranker = (LinearRanker) o;
+
+        return Arrays.equals(weights, ranker.weights);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(weights);
     }
 
     /**

--- a/src/test/java/com/o19s/es/ltr/logging/LoggingFetchSubPhaseTests.java
+++ b/src/test/java/com/o19s/es/ltr/logging/LoggingFetchSubPhaseTests.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.logging;
+
+import com.o19s.es.ltr.feature.PrebuiltFeature;
+import com.o19s.es.ltr.feature.PrebuiltFeatureSet;
+import com.o19s.es.ltr.feature.PrebuiltLtrModel;
+import com.o19s.es.ltr.query.RankerQuery;
+import com.o19s.es.ltr.ranker.LtrRanker;
+import com.o19s.es.ltr.ranker.linear.LinearRankerTests;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FloatDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.SimpleCollector;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.LuceneTestCase;
+import org.apache.lucene.util.TestUtil;
+import org.elasticsearch.common.lucene.search.function.CombineFunction;
+import org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction;
+import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
+import org.elasticsearch.common.text.Text;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.fielddata.plain.SortedNumericDVIndexFieldData;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.internal.InternalSearchHit;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction.Modifier.LN2P;
+import static org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType.FLOAT;
+
+public class LoggingFetchSubPhaseTests extends LuceneTestCase {
+    public static final float FACTOR = 1.2F;
+    private static Directory directory;
+    private static IndexSearcher searcher;
+    private static Map<String,Document> docs;
+
+
+    @BeforeClass
+    public static void init() throws Exception {
+        directory = newDirectory(random());
+
+        try(IndexWriter writer = new IndexWriter(directory, newIndexWriterConfig(new StandardAnalyzer()))) {
+            int nDoc = TestUtil.nextInt(random(), 20, 100);
+            docs = new HashMap<>();
+            for (int i = 0; i < nDoc; i++) {
+                Document d = buildDoc(random().nextBoolean() ? "foo" : "bar", random().nextFloat());
+                writer.addDocument(d);
+                if (random().nextInt(4) == 0) {
+                    writer.commit();
+                }
+                docs.put(d.get("id"), d);
+            }
+            writer.commit();
+        }
+        IndexReader reader = closeAfterSuite(DirectoryReader.open(directory));
+        searcher = new IndexSearcher(reader);
+    }
+
+    @AfterClass
+    public static void cleanup() throws IOException {
+        try {
+            searcher.getIndexReader().close();
+        } finally {
+            directory.close();
+        }
+    }
+
+    public void testLogging() throws IOException {
+        RankerQuery query1 = buildQuery("foo");
+        RankerQuery query2 = buildQuery("bar");
+        LoggingFetchSubPhase.HitLogConsumer logger1 = new LoggingFetchSubPhase.HitLogConsumer("logger1", query1.featureSet(), true);
+        LoggingFetchSubPhase.HitLogConsumer logger2 = new LoggingFetchSubPhase.HitLogConsumer("logger2", query2.featureSet(), false);
+        query1 = query1.toLoggerQuery(logger1, true);
+        query2 = query2.toLoggerQuery(logger2, true);
+        BooleanQuery query = new BooleanQuery.Builder()
+                .add(new BooleanClause(query1, BooleanClause.Occur.MUST))
+                .add(new BooleanClause(query2, BooleanClause.Occur.MUST))
+                .build();
+        LoggingFetchSubPhase subPhase = new LoggingFetchSubPhase();
+        InternalSearchHit[] hits = selectRandomHits();
+        subPhase.doLog(query, Arrays.asList(logger1, logger2), searcher, hits);
+        for (SearchHit hit : hits) {
+            assertTrue(docs.containsKey(hit.getId()));
+            Document d = docs.get(hit.getId());
+            assertTrue(hit.getFields().containsKey("_ltrlog"));
+            Map<String, Map<String, Float>> logs = hit.getFields().get("_ltrlog").getValue();
+            assertTrue(logs.containsKey("logger1"));
+            assertTrue(logs.containsKey("logger2"));
+
+            Map<String, Float> log1 = logs.get("logger1");
+            Map<String, Float> log2 = logs.get("logger2");
+            if (d.get("text").equals("foo")) {
+                assertTrue(log1.containsKey("text_feat"));
+                assertFalse(log2.containsKey("text_feat"));
+                assertTrue(log1.get("text_feat") > 0F);
+            } else {
+                assertEquals("bar", d.get("text"));
+                assertTrue(log1.containsKey("text_feat"));
+                assertTrue(log2.containsKey("text_feat"));
+                assertTrue(log2.get("text_feat") > 0F);
+                assertEquals(0F, log1.get("text_feat"), 0F);
+            }
+            int bits = (int)(long) d.getField("score").numericValue();
+            float rawScore = Float.intBitsToFloat(bits);
+            double expectedScore = rawScore*FACTOR;
+            expectedScore = Math.log1p(expectedScore+1);
+            assertEquals((float) expectedScore, log1.get("score_feat"), Math.ulp((float)expectedScore));
+            assertEquals((float) expectedScore, log2.get("score_feat"), Math.ulp((float)expectedScore));
+        }
+    }
+
+    public InternalSearchHit[] selectRandomHits() throws IOException {
+        int minHits = TestUtil.nextInt(random(), 5, 10);
+        int maxHits = TestUtil.nextInt(random(), minHits, minHits+10);
+        List<InternalSearchHit> hits = new ArrayList<>(maxHits);
+        searcher.search(new MatchAllDocsQuery(), new SimpleCollector() {
+            LeafReaderContext context;
+
+            @Override
+            protected void doSetNextReader(LeafReaderContext context) throws IOException {
+                super.doSetNextReader(context);
+                this.context = context;
+            }
+
+            @Override
+            public void collect(int doc) throws IOException {
+                if (hits.size() < minHits || (random().nextBoolean() && hits.size() < maxHits)) {
+                    Document d = context.reader().document(doc);
+                    String id = d.get("id");
+                    InternalSearchHit hit = new InternalSearchHit(doc+context.docBase, id,
+                            new Text("text"), random().nextBoolean() ? new HashMap<>() : null);
+                    hits.add(hit);
+                }
+            }
+
+            @Override
+            public boolean needsScores() {
+                return false;
+            }
+        });
+        assert hits.size() >= minHits;
+        Collections.shuffle(hits, random());
+        return hits.toArray(new InternalSearchHit[hits.size()]);
+    }
+
+    public static Document buildDoc(String text, float value) throws IOException {
+        String id = UUID.randomUUID().toString();
+        Document d = new Document();
+        d.add(newStringField("id", id, Field.Store.YES));
+        d.add(newStringField("text", text, Field.Store.NO));
+        d.add(new FloatDocValuesField("score", value));
+        return d;
+    }
+
+    public RankerQuery buildQuery(String text) {
+        List<PrebuiltFeature> features = new ArrayList<>(2);
+        features.add(new PrebuiltFeature("text_feat", new TermQuery(new Term("text", text))));
+        features.add(new PrebuiltFeature("score_feat", buildFunctionScore()));
+        PrebuiltFeatureSet set = new PrebuiltFeatureSet("my_set", features);
+        LtrRanker ranker = LinearRankerTests.generateRandomRanker(set.size());
+        return RankerQuery.build(new PrebuiltLtrModel("my_model", ranker, set));
+
+    }
+
+    public Query buildFunctionScore() {
+        return new FunctionScoreQuery(new MatchAllDocsQuery(),
+                new FieldValueFactorFunction("score", FACTOR, LN2P, 0D,
+                        new SortedNumericDVIndexFieldData(new Index("test", "123"),
+                                "score", FLOAT)), 0F, CombineFunction.MULTIPLY, Float.MAX_VALUE);
+    }
+}

--- a/src/test/java/com/o19s/es/ltr/logging/LoggingIT.java
+++ b/src/test/java/com/o19s/es/ltr/logging/LoggingIT.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.logging;
+
+import com.o19s.es.ltr.action.BaseIntegrationTest;
+import com.o19s.es.ltr.feature.store.StoredFeature;
+import com.o19s.es.ltr.feature.store.StoredFeatureSet;
+import com.o19s.es.ltr.feature.store.StoredLtrModel;
+import com.o19s.es.ltr.query.StoredLtrQueryBuilder;
+import com.o19s.es.ltr.ranker.parser.LinearRankerParserTests;
+import org.apache.lucene.util.TestUtil;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction;
+import org.elasticsearch.common.lucene.search.function.FiltersFunctionScoreQuery;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.functionscore.FieldValueFactorFunctionBuilder;
+import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.rescore.QueryRescorerBuilder;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
+
+public class LoggingIT extends BaseIntegrationTest {
+    public static final float FACTOR = 1.2F;
+
+    public void prepareModels() throws Exception {
+        List<StoredFeature> features = new ArrayList<>(3);
+        features.add(new StoredFeature("text_feature1", Collections.singletonList("query"), "mustache",
+                QueryBuilders.matchQuery("field1", "{{query}}").toString()));
+        features.add(new StoredFeature("text_feature2", Collections.singletonList("query"), "mustache",
+                QueryBuilders.matchQuery("field2", "{{query}}").toString()));
+        features.add(new StoredFeature("numeric_feature1", Collections.singletonList("query"), "mustache",
+                new FunctionScoreQueryBuilder(QueryBuilders.matchAllQuery(), new FieldValueFactorFunctionBuilder("scorefield1")
+                        .factor(FACTOR)
+                        .modifier(FieldValueFactorFunction.Modifier.LN2P)
+                        .missing(0F)).scoreMode(FiltersFunctionScoreQuery.ScoreMode.MULTIPLY).toString()));
+
+        StoredFeatureSet set = new StoredFeatureSet("my_set", features);
+        addElement(set);
+        StoredLtrModel model = new StoredLtrModel("my_model", set,
+                new StoredLtrModel.LtrModelDefinition("model/linear",
+                        LinearRankerParserTests.generateRandomModelString(set), true));
+        addElement(model);
+    }
+    public void testFailures() throws Exception {
+        prepareModels();
+        buildIndex();
+        Map<String, Object> params = new HashMap<>();
+        params.put("query", "found");
+        QueryBuilder query = QueryBuilders.matchQuery("field1", "found").queryName("not_sltr");
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(query)
+                .fetchSource(false)
+                .size(10)
+                .ext(Collections.singletonList(
+                        new LoggingSearchExtBuilder()
+                                .addQueryLogging("first_log", "test", false)));
+
+        assertExcWithMessage(() -> client().prepareSearch("test_index")
+                .setTypes("test")
+                .setSource(sourceBuilder).get(), IllegalArgumentException.class, "No query named [test] found");
+
+        SearchSourceBuilder sourceBuilder2 = new SearchSourceBuilder().query(query)
+                .fetchSource(false)
+                .size(10)
+                .ext(Collections.singletonList(
+                        new LoggingSearchExtBuilder()
+                                .addQueryLogging("first_log", "not_sltr", false)));
+
+        assertExcWithMessage(() -> client().prepareSearch("test_index")
+                .setTypes("test")
+                .setSource(sourceBuilder2).get(), IllegalArgumentException.class, "Query named [not_sltr] must be a " +
+                "[sltr] query [TermQuery] found");
+
+        SearchSourceBuilder sourceBuilder3 = new SearchSourceBuilder().query(query)
+                .fetchSource(false)
+                .size(10)
+                .ext(Collections.singletonList(
+                        new LoggingSearchExtBuilder()
+                                .addRescoreLogging("first_log", 0, false)));
+        assertExcWithMessage(() -> client().prepareSearch("test_index")
+                .setTypes("test")
+                .setSource(sourceBuilder3).get(), IllegalArgumentException.class, "rescore index [0] is out of bounds, " +
+                "only [0]");
+
+        SearchSourceBuilder sourceBuilder4 = new SearchSourceBuilder().query(query)
+                .fetchSource(false)
+                .size(10)
+                .addRescorer(new QueryRescorerBuilder(QueryBuilders.matchAllQuery()))
+                .ext(Collections.singletonList(
+                        new LoggingSearchExtBuilder()
+                                .addRescoreLogging("first_log", 0, false)));
+        assertExcWithMessage(() -> client().prepareSearch("test_index")
+                .setTypes("test")
+                .setSource(sourceBuilder4).get(), IllegalArgumentException.class, "Expected a [sltr] query but found " +
+                "a [MatchAllDocsQuery] at index [0]");
+    }
+
+    private void assertExcWithMessage(ThrowingRunnable r, Class<? extends Exception> exc, String msg) {
+        Throwable e = expectThrows(Throwable.class, r);
+        e = ExceptionsHelper.unwrap(e, exc);
+        assertNotNull(e);
+        assertThat(e, instanceOf(IllegalArgumentException.class));
+        assertThat(e.getMessage(), containsString(msg));
+
+    }
+
+    public void testLog() throws Exception {
+        prepareModels();
+        Map<String, Doc> docs = buildIndex();
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("query", "found");
+        List<String> idsColl = new ArrayList<>(docs.keySet());
+        Collections.shuffle(idsColl, random());
+        String[] ids = idsColl.subList(0, TestUtil.nextInt(random(), 5, 15)).toArray(new String[0]);
+        StoredLtrQueryBuilder sbuilder = new StoredLtrQueryBuilder()
+                .featureSetName("my_set")
+                .params(params)
+                .queryName("test");
+
+        StoredLtrQueryBuilder sbuilder_rescore = new StoredLtrQueryBuilder()
+                .featureSetName("my_set")
+                .params(params)
+                .queryName("test_rescore");
+
+        QueryBuilder query = QueryBuilders.boolQuery().must(sbuilder).filter(QueryBuilders.idsQuery("test").addIds(ids));
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(query)
+                .fetchSource(false)
+                .size(10)
+                .addRescorer(new QueryRescorerBuilder(sbuilder_rescore))
+                .ext(Collections.singletonList(
+                        new LoggingSearchExtBuilder()
+                                .addQueryLogging("first_log", "test", false)
+                                .addRescoreLogging("second_log", 0, true)));
+
+        SearchResponse resp = client().prepareSearch("test_index").setTypes("test").setSource(sourceBuilder).get();
+        assertSearchHits(docs, resp);
+        sbuilder.featureSetName(null);
+        sbuilder.modelName("my_model");
+        sbuilder_rescore.featureSetName(null);
+        sbuilder_rescore.modelName("my_model");
+
+        SearchResponse resp2 = client().prepareSearch("test_index").setTypes("test").setSource(sourceBuilder).get();
+        assertSearchHits(docs, resp2);
+    }
+
+    protected void assertSearchHits(Map<String, Doc> docs, SearchResponse resp) {
+        for (SearchHit hit: resp.getHits()) {
+            assertTrue(hit.getFields().containsKey("_ltrlog"));
+            Map<String, Map<String, Float>> logs = hit.getFields().get("_ltrlog").getValue();
+            assertTrue(logs.containsKey("first_log"));
+            assertTrue(logs.containsKey("second_log"));
+
+            Map<String, Float> log1 = logs.get("first_log");
+            Map<String, Float> log2 = logs.get("second_log");
+            Doc d = docs.get(hit.getId());
+            if (d.field1.equals("found")) {
+                assertTrue(log1.containsKey("text_feature1"));
+                assertTrue(log2.containsKey("text_feature1"));
+                assertTrue(log1.get("text_feature1") > 0F);
+                assertTrue(log2.get("text_feature1") > 0F);
+                assertFalse(log1.containsKey("text_feature2"));
+                assertTrue(log2.containsKey("text_feature2"));
+                assertEquals(0F, log2.get("text_feature2"), 0F);
+            } else {
+                assertTrue(log1.containsKey("text_feature2"));
+                assertTrue(log2.containsKey("text_feature2"));
+                assertTrue(log1.get("text_feature2") > 0F);
+                assertTrue(log2.get("text_feature2") > 0F);
+                assertFalse(log1.containsKey("text_feature1"));
+                assertTrue(log2.containsKey("text_feature1"));
+                assertEquals(0F, log2.get("text_feature1"), 0F);
+            }
+            float score = (float) Math.log1p((d.scorefield1 * FACTOR) + 1);
+            assertTrue(log1.containsKey("numeric_feature1"));
+            assertTrue(log2.containsKey("numeric_feature1"));
+
+            assertEquals(score, log1.get("numeric_feature1"), Math.ulp(score));
+            assertEquals(score, log2.get("numeric_feature1"), Math.ulp(score));
+        }
+    }
+
+    public Map<String,Doc> buildIndex() {
+        client().admin().indices().prepareCreate("test_index")
+                .addMapping("test", "{\"properties\":{\"scorefield1\": {\"type\": \"float\"}}}", XContentType.JSON)
+                .get();
+
+        int numDocs = TestUtil.nextInt(random(), 20, 100);
+        Map<String, Doc> docs = new HashMap<>();
+        for (int i = 0; i < numDocs; i++) {
+            boolean field1IsFound = random().nextBoolean();
+            Doc d = new Doc(
+                    field1IsFound ? "found" : "notfound",
+                    field1IsFound ? "notfound" : "found",
+                    Math.abs(random().nextFloat()));
+            indexDoc(d);
+            docs.put(d.id, d);
+        }
+        client().admin().indices().prepareRefresh("test_index").get();
+        return docs;
+    }
+
+    public void indexDoc(Doc d) {
+        IndexResponse resp = client().prepareIndex("test_index", "test")
+                .setSource("field1", d.field1, "field2", d.field2, "scorefield1", d.scorefield1)
+                .get();
+        d.id = resp.getId();
+    }
+
+    static class Doc {
+        String id;
+        String field1;
+        String field2;
+        float scorefield1;
+
+        Doc(String field1, String field2, float scorefield1) {
+            this.field1 = field1;
+            this.field2 = field2;
+            this.scorefield1 = scorefield1;
+        }
+    }
+}

--- a/src/test/java/com/o19s/es/ltr/logging/LoggingSearchExtBuilderTests.java
+++ b/src/test/java/com/o19s/es/ltr/logging/LoggingSearchExtBuilderTests.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.logging;
+
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.o19s.es.ltr.logging.LoggingSearchExtBuilder.parse;
+import static org.hamcrest.CoreMatchers.containsString;
+
+public class LoggingSearchExtBuilderTests extends ESTestCase {
+    public LoggingSearchExtBuilder buildTestExt() {
+        LoggingSearchExtBuilder builder = new LoggingSearchExtBuilder();
+        builder.addQueryLogging("name1", "query1", true);
+        builder.addQueryLogging(null, "query2", false);
+        builder.addRescoreLogging("rescore0", 0, true);
+        builder.addRescoreLogging(null, 1, false);
+        return builder;
+    }
+
+    public String getTestExtAsString() {
+        return "{\"log_specs\":[" +
+                "{\"name\":\"name1\",\"named_query\":\"query1\",\"missing_as_zero\":true}," +
+                "{\"named_query\":\"query2\"}," +
+                "{\"name\":\"rescore0\",\"rescore_index\":0,\"missing_as_zero\":true}," +
+                "{\"rescore_index\":1}]}";
+    }
+
+    public void testEquals() {
+        LoggingSearchExtBuilder ext1 = buildTestExt();
+        LoggingSearchExtBuilder ext2 = buildTestExt();
+        assertTestExt(ext1);
+        assertTestExt(ext2);
+        assertEquals(ext1.hashCode(), ext2.hashCode());
+        assertEquals(ext1, ext2);
+    }
+
+    public void testParse() throws IOException {
+        XContentParser parser = createParser(JsonXContent.jsonXContent, getTestExtAsString());
+        LoggingSearchExtBuilder ext = parse(parser);
+        assertTestExt(ext);
+    }
+
+    public void testToXCtontent() throws IOException {
+        LoggingSearchExtBuilder ext1 = buildTestExt();
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        ext1.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.close();
+        assertEquals(getTestExtAsString(), builder.bytes().utf8ToString());
+    }
+
+    public void testSer() throws IOException {
+        BytesStreamOutput out = new BytesStreamOutput();
+        buildTestExt().writeTo(out);
+        out.close();
+        StreamInput input = StreamInput.wrap(out.bytes().toBytesRef().bytes);
+        LoggingSearchExtBuilder ext = new LoggingSearchExtBuilder(input);
+        assertTestExt(ext);
+    }
+
+    public void testFailOnNoLogSpecs() throws IOException {
+        String data = "{}";
+        ParsingException exc = expectThrows(ParsingException.class,
+                () ->parse(createParser(JsonXContent.jsonXContent, data)));
+        assertThat(exc.getMessage(),
+            containsString("should define at least one [log_specs]"));
+    }
+
+    public void testFailOnEmptyLogSpecs() throws IOException {
+        String data = "{\"log_specs\":[]}";
+        ParsingException exc = expectThrows(ParsingException.class,
+                () ->parse(createParser(JsonXContent.jsonXContent, data)));
+        assertThat(exc.getMessage(),
+                containsString("should define at least one [log_specs]"));
+    }
+
+    public void testFailOnBadLogSpec() throws IOException {
+        String data = "{\"log_specs\":[" +
+                "{\"name\":\"name1\",\"missing_as_zero\":true}," +
+                "]}";
+        ParsingException exc = expectThrows(ParsingException.class,
+                () ->parse(createParser(JsonXContent.jsonXContent, data)));
+        assertThat(exc.getCause().getMessage(),
+                containsString("Either [named_query] or [rescore_index] must be set"));
+    }
+
+    public void testFailOnNegativeRescoreIndex() throws IOException {
+        String data = "{\"log_specs\":[" +
+                "{\"name\":\"name1\",\"rescore_index\":-1, \"missing_as_zero\":true}," +
+                "]}";
+        ParsingException exc = expectThrows(ParsingException.class,
+                () ->parse(createParser(JsonXContent.jsonXContent, data)));
+        assertThat(exc.getCause().getMessage(),
+                containsString("non-negative"));
+    }
+
+    public void assertTestExt(LoggingSearchExtBuilder actual) {
+        List<LoggingSearchExtBuilder.LogSpec> logSpecs = actual.logSpecsStream().collect(Collectors.toList());
+        assertEquals(4, logSpecs.size());
+        LoggingSearchExtBuilder.LogSpec l = logSpecs.get(0);
+        assertEquals("name1", l.getLoggerName());
+        assertEquals("query1", l.getNamedQuery());
+        assertNull(l.getRescoreIndex());
+        assertTrue(l.isMissingAsZero());
+
+        l = logSpecs.get(1);
+        assertEquals("query2", l.getLoggerName());
+        assertEquals("query2", l.getNamedQuery());
+        assertNull(l.getRescoreIndex());
+        assertFalse(l.isMissingAsZero());
+
+        l = logSpecs.get(2);
+        assertEquals("rescore0", l.getLoggerName());
+        assertNull(l.getNamedQuery());
+        assertEquals((Integer) 0, l.getRescoreIndex());
+        assertTrue(l.isMissingAsZero());
+
+        l = logSpecs.get(3);
+        assertEquals("rescore[1]", l.getLoggerName());
+        assertNull(l.getNamedQuery());
+        assertEquals((Integer) 1, l.getRescoreIndex());
+        assertFalse(l.isMissingAsZero());
+    }
+}

--- a/src/test/java/com/o19s/es/ltr/query/StoredLtrQueryBuilderTests.java
+++ b/src/test/java/com/o19s/es/ltr/query/StoredLtrQueryBuilderTests.java
@@ -87,6 +87,7 @@ public class StoredLtrQueryBuilderTests extends AbstractQueryTestCase<StoredLtrQ
                         .modifier(FieldValueFactorFunction.Modifier.LN2P)
                         .missing(0F)).toString());
         StoredFeatureSet set = new StoredFeatureSet("set1", Arrays.asList(feature1, feature2, feature3));
+        store.add(set);
         LtrRanker ranker = new LinearRanker(new float[]{0.1F, 0.2F, 0.3F});
         CompiledLtrModel model = new CompiledLtrModel("model1", set, ranker);
         store.add(model);
@@ -98,7 +99,11 @@ public class StoredLtrQueryBuilderTests extends AbstractQueryTestCase<StoredLtrQ
     @Override
     protected StoredLtrQueryBuilder doCreateTestQueryBuilder() {
         StoredLtrQueryBuilder builder = new StoredLtrQueryBuilder();
-        builder.modelName("model1");
+        if (random().nextBoolean()) {
+            builder.modelName("model1");
+        } else {
+            builder.featureSetName("set1");
+        }
         Map<String, Object> params = new HashMap<>();
         params.put("query_string", "a wonderful query");
         builder.params(params);

--- a/src/test/java/com/o19s/es/ltr/ranker/LogLtrRankerTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/LogLtrRankerTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.ranker;
+
+import com.o19s.es.ltr.LtrTestUtils;
+import com.o19s.es.ltr.ranker.linear.LinearRankerTests;
+import org.apache.lucene.util.LuceneTestCase;
+import org.apache.lucene.util.TestUtil;
+
+public class LogLtrRankerTests extends LuceneTestCase {
+    public void testNewFeatureVector() throws Exception {
+        int modelSize = TestUtil.nextInt(random(), 1, 20);
+
+        final float[] expectedScores = new float[modelSize];
+        LinearRankerTests.fillRandomWeights(expectedScores);
+
+        final float[] actualScores = new float[modelSize];
+        LogLtrRanker ranker = new LogLtrRanker(LtrTestUtils.buildRandomRanker(modelSize), (i, s) -> actualScores[i] = s);
+        LtrRanker.FeatureVector vector = ranker.newFeatureVector(null);
+        for (int i = 0; i < expectedScores.length; i++) {
+            vector.setFeatureScore(i, expectedScores[i]);
+        }
+        assertArrayEquals(expectedScores, actualScores, 0F);
+    }
+
+    public void score() throws Exception {
+        int modelSize = TestUtil.nextInt(random(), 1, 20);
+        LtrRanker ranker = LtrTestUtils.buildRandomRanker(modelSize);
+        LogLtrRanker logRanker = new LogLtrRanker(ranker, (i, s) -> {});
+        int nPass = TestUtil.nextInt(random(), 100, 200);
+        float[] scores = new float[modelSize];
+
+        while (nPass-- > 0) {
+            LinearRankerTests.fillRandomWeights(scores);
+            LtrRanker.FeatureVector vect1 = ranker.newFeatureVector(null);
+            LtrRanker.FeatureVector vect2 = logRanker.newFeatureVector(null);
+        }
+
+    }
+
+}

--- a/src/test/java/com/o19s/es/ltr/ranker/parser/LinearRankerParserTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/parser/LinearRankerParserTests.java
@@ -17,6 +17,7 @@
 package com.o19s.es.ltr.ranker.parser;
 
 import com.o19s.es.ltr.LtrTestUtils;
+import com.o19s.es.ltr.feature.FeatureSet;
 import com.o19s.es.ltr.feature.store.StoredFeatureSet;
 import com.o19s.es.ltr.ranker.DenseFeatureVector;
 import com.o19s.es.ltr.ranker.linear.LinearRanker;
@@ -82,5 +83,15 @@ public class LinearRankerParserTests extends LuceneTestCase {
         StoredFeatureSet set = new StoredFeatureSet("test", singletonList(LtrTestUtils.randomFeature("feature")));
         LinearRankerParser parser = new LinearRankerParser();
         expectThrows(ParsingException.class, () -> parser.parse(set, "{ \"features\": 1.5 }"));
+    }
+
+    public static String generateRandomModelString(FeatureSet set) throws IOException {
+        XContentBuilder builder = JsonXContent.contentBuilder();
+        builder.startObject();
+        for (int i = 0; i < set.size(); i++) {
+            builder.field(set.feature(i).name(), random().nextFloat());
+        }
+        builder.endObject().close();
+        return builder.bytes().utf8ToString();
     }
 }


### PR DESCRIPTION
Use the search_ext to tell the plugin which model/featureset to collect.
Feature values are extracted as part of the search response using a
special field _ltrlog.
Multiple models/sets can be collected at once.
Feature collection happens during the fetch phase by running the feature
queries on the hits returned.

Queries to log are identified by using the _name attribute when used inside
the main search query or by an index in the list of rescore queries

For users that can afford running the feature queries a second time on the
returned hits this should permit to do runtime logging.

fixes #13