### PR TITLE
Mark 2 CachedFeatureStoreTests tests as @BadApple

### DIFF
--- a/src/test/java/com/o19s/es/ltr/feature/store/index/CachedFeatureStoreTests.java
+++ b/src/test/java/com/o19s/es/ltr/feature/store/index/CachedFeatureStoreTests.java
@@ -112,6 +112,7 @@ public class CachedFeatureStoreTests extends LuceneTestCase {
         }
     }
 
+    @BadApple(bugUrl = "https://github.com/o19s/elasticsearch-learning-to-rank/issues/75")
     public void testExpirationOnWrite() throws IOException, InterruptedException {
         Caches caches = new Caches(TimeValue.timeValueMillis(100), TimeValue.timeValueHours(1), new ByteSizeValue(1000000));
         CachedFeatureStore store = new CachedFeatureStore(memStore, caches);
@@ -129,6 +130,7 @@ public class CachedFeatureStoreTests extends LuceneTestCase {
         assertEquals(0, caches.getPerStoreStats(memStore.getStoreName()).totalCount());
     }
 
+    @BadApple(bugUrl = "https://github.com/o19s/elasticsearch-learning-to-rank/issues/75")
     public void testExpirationOnGet() throws IOException, InterruptedException {
         Caches caches = new Caches(TimeValue.timeValueHours(1), TimeValue.timeValueMillis(100), new ByteSizeValue(1000000));
         CachedFeatureStore store = new CachedFeatureStore(memStore, caches);


### PR DESCRIPTION
They randomly fail, the code itself is being covered by elastic itself.
It should not be big deal to disable them while we find a proper fix
to make them stable.

relates #75