### PR TITLE
Allow empty featuresets

### DIFF
--- a/src/main/java/com/o19s/es/ltr/feature/store/StoredFeatureSet.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/StoredFeatureSet.java
@@ -71,10 +71,7 @@ public class StoredFeatureSet implements FeatureSet, Accountable, StorableElemen
                 throw new ParsingException(parser.getTokenLocation(), "Field [name] is mandatory");
             }
             if (state.features == null) {
-                throw new ParsingException(parser.getTokenLocation(), "Field [features] is mandatory");
-            }
-            if (state.features.isEmpty()) {
-                throw new ParsingException(parser.getTokenLocation(), "At least one feature must be defined in [features]");
+                state.features = Collections.emptyList();
             }
             return new StoredFeatureSet(state.name, state.features);
         } catch (IllegalArgumentException iae) {

--- a/src/test/java/com/o19s/es/ltr/feature/store/StoredFeatureSetParserTests.java
+++ b/src/test/java/com/o19s/es/ltr/feature/store/StoredFeatureSetParserTests.java
@@ -108,19 +108,17 @@ public class StoredFeatureSetParserTests extends LuceneTestCase {
     }
 
     public void testParseErrorOnMissingSet() throws IOException {
-        String missingName = "{ \"name\": \"my_set\"}";
-        assertThat(expectThrows(ParsingException.class,
-                () -> parse(missingName)).getMessage(),
-                equalTo("Field [features] is mandatory"));
+        String missingList = "{ \"name\": \"my_set\"}";
+        StoredFeatureSet set = parse(missingList);
+        assertEquals(0, set.size());
     }
 
     public void testParseErrorOnEmptySet() throws IOException {
-        String missingName = "{ \"name\": \"my_set\"," +
+        String missingList = "{ \"name\": \"my_set\"," +
                 "\"features\": []}";
 
-        assertThat(expectThrows(ParsingException.class,
-                () -> parse(missingName)).getMessage(),
-                equalTo("At least one feature must be defined in [features]"));
+        StoredFeatureSet set = parse(missingList);
+        assertEquals(0, set.size());
     }
 
     public void testParseErrorOnExtraField() throws IOException {


### PR DESCRIPTION
This was forbidden for no particular reason except than using an empty featureset
makes no sense. But if creating an empty set makes sense in certain usecases
let's allow them.

closes #82