### PR TITLE
Update featureset with features provided in request body

### DIFF
--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -142,6 +142,43 @@ A set can also be created/updated from existing features:
 
 Will create or update the `my_featureset` by collecting all features named with the prefix `my_feature`.
 
+Features can also be embedded in the body of the request:
+
+`POST /_ltr/_featureset/my_featureset/_addfeatures`
+
+```json
+{
+  "features" : [
+    {
+      "name": "my_feature",
+      "params": ["query_string"],
+      "template_language": "mustache",
+      "template" : {
+        "match": {
+          "field": "{{query_string}}"
+        }
+      }
+    },
+    {
+      "name": "my_feature2",
+      "params": ["query_string"],
+      "template_language": "mustache",
+      "template" : {
+        "match": {
+          "field2": "{{query_string}}"
+        }
+      }
+    }
+  ]
+}
+```
+
+By default features are appended and a failure is thrown if a feature is duplicated.
+You can force to the api endpoint to update exiting features within the set by adding the query param `merge=true` :
+
+`POST /_ltr/_featureset/my_featureset/_addfeatures?merge=true`
+
+
 ### Models
 
 `/_ltr/_model/model_name` supports `PUT`, `GET` and `DELETE` operations.

--- a/src/main/java/com/o19s/es/ltr/feature/store/StoredFeatureSet.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/StoredFeatureSet.java
@@ -175,6 +175,36 @@ public class StoredFeatureSet implements FeatureSet, Accountable, StorableElemen
         return new StoredFeatureSet(name, newFeatures);
     }
 
+    /**
+     * Generate a new set by merging features with this set, feature with same names are updated new features are appended.
+     * Ordinals of existing features are kept.
+     *
+     * @param mergedFeatures the list of features to merge
+     * @return the new set
+     * @throws IllegalArgumentException if the resulting size of the set exceed MAX_FEATURES
+     */
+    public StoredFeatureSet merge(List<StoredFeature> mergedFeatures) {
+        int merged = (int) mergedFeatures.stream()
+                .map(StoredFeature::name)
+                .filter(this::hasFeature)
+                .count();
+
+        if (size() + (mergedFeatures.size() - merged) > MAX_FEATURES) {
+            throw new IllegalArgumentException("The resulting feature set would be too large");
+        }
+        List<StoredFeature> newFeatures = new ArrayList<>(this.features.size() + mergedFeatures.size() - merged);
+        newFeatures.addAll(this.features);
+        for (StoredFeature f : mergedFeatures) {
+            if (hasFeature(f.name())) {
+                newFeatures.set(featureOrdinal(f.name()), f);
+            } else {
+                newFeatures.add(f);
+            }
+        }
+        assert newFeatures.size() <= MAX_FEATURES;
+        return new StoredFeatureSet(name, newFeatures);
+    }
+
     @Override
     public List<Query> toQueries(QueryShardContext context, Map<String, Object> params) {
         List<Query> queries = new ArrayList<>(features.size());

--- a/src/main/java/com/o19s/es/ltr/rest/RestAddFeatureToSet.java
+++ b/src/main/java/com/o19s/es/ltr/rest/RestAddFeatureToSet.java
@@ -18,13 +18,18 @@ package com.o19s.es.ltr.rest;
 
 import com.o19s.es.ltr.action.AddFeaturesToSetAction;
 import com.o19s.es.ltr.action.AddFeaturesToSetAction.AddFeaturesToSetRequestBuilder;
+import com.o19s.es.ltr.feature.store.StoredFeature;
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestStatusToXContentListener;
 
 import java.io.IOException;
+import java.util.List;
 
 public class RestAddFeatureToSet extends FeatureStoreBaseRestHandler {
 
@@ -32,6 +37,8 @@ public class RestAddFeatureToSet extends FeatureStoreBaseRestHandler {
         super(settings);
         controller.registerHandler(RestRequest.Method.POST, "/_ltr/_featureset/{name}/_addfeatures/{query}", this);
         controller.registerHandler(RestRequest.Method.POST, "/_ltr/{store}/_featureset/{name}/_addfeatures/{query}", this);
+        controller.registerHandler(RestRequest.Method.POST, "/_ltr/_featureset/{name}/_addfeatures", this);
+        controller.registerHandler(RestRequest.Method.POST, "/_ltr/{store}/_featureset/{name}/_addfeatures", this);
     }
 
     @Override
@@ -39,12 +46,55 @@ public class RestAddFeatureToSet extends FeatureStoreBaseRestHandler {
         String store = indexName(request);
         String setName = request.param("name");
         String routing = request.param("routing");
-        String featureQuery = request.param("query");
+        String featureQuery = null;
+        List<StoredFeature> features = null;
+        boolean merge = request.paramAsBoolean("merge", false);
+        if (request.hasParam("query")) {
+            featureQuery = request.param("query");
+        }
+        if (request.hasContentOrSourceParam()) {
+            if (featureQuery != null) {
+                throw new IllegalArgumentException("features must be provided as a query for the feature store " +
+                        "or directly in the body not both");
+            }
+            FeaturesParserState featuresParser = new FeaturesParserState();
+            request.applyContentParser(featuresParser::parse);
+            features = featuresParser.features;
+        } else if (featureQuery == null) {
+            throw new IllegalArgumentException("features must be provided as a query for the feature store " +
+                    "or in the body, none provided");
+        }
+
         AddFeaturesToSetRequestBuilder builder = AddFeaturesToSetAction.INSTANCE.newRequestBuilder(client);
         builder.request().setStore(store);
         builder.request().setFeatureSet(setName);
         builder.request().setFeatureNameQuery(featureQuery);
         builder.request().setRouting(routing);
+        builder.request().setFeatures(features);
+        builder.request().setMerge(merge);
         return (channel) -> builder.execute(new RestStatusToXContentListener<>(channel, (r) -> r.getResponse().getLocation(routing)));
+    }
+
+    static class FeaturesParserState {
+        public static final ObjectParser<FeaturesParserState, Void> PARSER = new ObjectParser<>("features");
+        private List<StoredFeature> features;
+        static {
+            PARSER.declareObjectArray(
+                    FeaturesParserState::setFeatures,
+                    (parser, context) -> StoredFeature.parse(parser),
+                    new ParseField("features"));
+        }
+
+        public void parse(XContentParser parser) throws IOException {
+            PARSER.parse(parser, this, null);
+        }
+
+        List<StoredFeature> getFeatures() {
+            return features;
+        }
+
+        public void setFeatures(List<StoredFeature> features) {
+            this.features = features;
+        }
     }
 }

--- a/src/test/java/com/o19s/es/ltr/LtrTestUtils.java
+++ b/src/test/java/com/o19s/es/ltr/LtrTestUtils.java
@@ -29,11 +29,14 @@ import com.o19s.es.ltr.ranker.linear.LinearRankerTests;
 import com.o19s.es.ltr.ranker.parser.LinearRankerParser;
 import com.o19s.es.ltr.utils.FeatureStoreLoader;
 import org.apache.lucene.util.TestUtil;
+import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.query.WrapperQueryBuilder;
 
 import java.io.IOException;
+import java.util.function.Function;
+import java.util.function.IntFunction;
 
 import static org.apache.lucene.util.LuceneTestCase.random;
 
@@ -95,6 +98,26 @@ public class LtrTestUtils {
                 "wrapping it inside a " + WrapperQueryBuilder.class.getSimpleName() + ":\n" +
                 "\tnew WrapperQueryBuilder(sltrBuilder.toString())\n" +
                 "This will force elastic to initialize the feature loader properly");};
+    }
+
+    public static <T,R,E extends Exception> Function<T, R> wrapFuncion(CheckedFunction<T, R, E> f) {
+        return (p) -> {
+            try {
+                return f.apply(p);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
+    public static <R,E extends Exception> IntFunction<R> wrapIntFuncion(CheckedFunction<Integer, R, E> f) {
+        return (p) -> {
+            try {
+                return f.apply(p);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
     }
 
     public static FeatureStoreLoader wrapMemStore(MemStore store) {

--- a/src/test/java/com/o19s/es/ltr/action/AddFeaturesToSetActionIT.java
+++ b/src/test/java/com/o19s/es/ltr/action/AddFeaturesToSetActionIT.java
@@ -16,7 +16,6 @@
 
 package com.o19s.es.ltr.action;
 
-import com.o19s.es.ltr.LtrTestUtils;
 import com.o19s.es.ltr.action.AddFeaturesToSetAction.AddFeaturesToSetRequestBuilder;
 import com.o19s.es.ltr.action.AddFeaturesToSetAction.AddFeaturesToSetResponse;
 import com.o19s.es.ltr.feature.store.StoredFeature;
@@ -25,23 +24,26 @@ import com.o19s.es.ltr.feature.store.index.IndexFeatureStore;
 import org.elasticsearch.action.DocWriteResponse;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+import static com.o19s.es.ltr.LtrTestUtils.randomFeature;
+import static java.util.Arrays.asList;
 import static org.elasticsearch.ExceptionsHelper.unwrap;
 import static org.hamcrest.CoreMatchers.containsString;
 
 public class AddFeaturesToSetActionIT extends BaseIntegrationTest {
-    public void testAddToSet() throws Exception {
+    public void testAddToSetWithQuery() throws Exception {
         int nFeature = random().nextInt(99) + 1;
         List<StoredFeature> features = new ArrayList<>(nFeature);
         for (int i = 0; i < nFeature; i++) {
-            StoredFeature feat = LtrTestUtils.randomFeature("feature" + i);
+            StoredFeature feat = randomFeature("feature" + i);
             features.add(feat);
             addElement(feat);
         }
 
-        addElement(LtrTestUtils.randomFeature("another"));
+        addElement(randomFeature("another"));
 
         AddFeaturesToSetRequestBuilder builder = AddFeaturesToSetAction.INSTANCE.newRequestBuilder(client());
         builder.request().setFeatureSet("new_feature_set");
@@ -63,8 +65,43 @@ public class AddFeaturesToSetActionIT extends BaseIntegrationTest {
         builder.request().setStore(IndexFeatureStore.DEFAULT_STORE);
         resp = builder.execute().get();
         assertEquals(2, resp.getResponse().getVersion());
+        assertEquals(DocWriteResponse.Result.UPDATED, resp.getResponse().getResult());
         set = getElement(StoredFeatureSet.class, StoredFeatureSet.TYPE, "new_feature_set");
         assertTrue(set.hasFeature("another"));
+    }
+
+    public void testAddToSetWithList() throws Exception {
+        int nFeature = random().nextInt(99) + 1;
+        List<StoredFeature> features = new ArrayList<>(nFeature);
+        for (int i = 0; i < nFeature; i++) {
+            StoredFeature feat = randomFeature("feature" + i);
+            features.add(feat);
+        }
+
+        AddFeaturesToSetRequestBuilder builder = AddFeaturesToSetAction.INSTANCE.newRequestBuilder(client());
+        builder.request().setFeatureSet("new_feature_set");
+        builder.request().setFeatures(features);
+        builder.request().setStore(IndexFeatureStore.DEFAULT_STORE);
+        AddFeaturesToSetResponse resp = builder.execute().get();
+
+        assertEquals(DocWriteResponse.Result.CREATED, resp.getResponse().getResult());
+        assertEquals(1, resp.getResponse().getVersion());
+        StoredFeatureSet set = getElement(StoredFeatureSet.class, StoredFeatureSet.TYPE, "new_feature_set");
+        assertNotNull(set);
+        assertEquals("new_feature_set", set.name());
+        assertEquals(features.size(), set.size());
+        assertTrue(features.stream().map(StoredFeature::name).allMatch(set::hasFeature));
+
+        builder = AddFeaturesToSetAction.INSTANCE.newRequestBuilder(client());
+        builder.request().setFeatureSet("new_feature_set");
+        builder.request().setFeatures(Collections.singletonList(randomFeature("another_feature")));
+        builder.request().setStore(IndexFeatureStore.DEFAULT_STORE);
+        resp = builder.execute().get();
+        assertEquals(2, resp.getResponse().getVersion());
+        assertEquals(DocWriteResponse.Result.UPDATED, resp.getResponse().getResult());
+        set = getElement(StoredFeatureSet.class, StoredFeatureSet.TYPE, "new_feature_set");
+        assertEquals(features.size()+1, set.size());
+        assertTrue(set.hasFeature("another_feature"));
     }
 
     public void testFailuresWhenEmpty() throws Exception {
@@ -79,7 +116,7 @@ public class AddFeaturesToSetActionIT extends BaseIntegrationTest {
     }
 
     public void testFailuresOnDuplicates() throws Exception {
-        addElement(LtrTestUtils.randomFeature("duplicated"));
+        addElement(randomFeature("duplicated"));
 
         AddFeaturesToSetRequestBuilder builder = AddFeaturesToSetAction.INSTANCE.newRequestBuilder(client());
         builder.request().setFeatureSet("duplicated_set");
@@ -100,5 +137,71 @@ public class AddFeaturesToSetActionIT extends BaseIntegrationTest {
                 IllegalArgumentException.class);
         assertNotNull(iae);
         assertThat(iae.getMessage(), containsString("defined twice in this set"));
+    }
+
+    public void testMergeWithQuery() throws Exception {
+        addElement(randomFeature("duplicated"));
+        addElement(randomFeature("new_feature"));
+
+        AddFeaturesToSetRequestBuilder builder = AddFeaturesToSetAction.INSTANCE.newRequestBuilder(client());
+        builder.request().setFeatureSet("merged_set");
+        builder.request().setFeatureNameQuery("duplicated*");
+        builder.request().setStore(IndexFeatureStore.DEFAULT_STORE);
+        builder.request().setMerge(true);
+        AddFeaturesToSetResponse resp = builder.execute().get();
+
+        assertEquals(DocWriteResponse.Result.CREATED, resp.getResponse().getResult());
+        assertEquals(1, resp.getResponse().getVersion());
+
+        builder = AddFeaturesToSetAction.INSTANCE.newRequestBuilder(client());
+        builder.request().setFeatureSet("merged_set");
+        builder.request().setFeatureNameQuery("*");
+        builder.request().setStore(IndexFeatureStore.DEFAULT_STORE);
+        builder.request().setMerge(true);
+        resp = builder.execute().get();
+
+        assertEquals(DocWriteResponse.Result.UPDATED, resp.getResponse().getResult());
+        assertEquals(2, resp.getResponse().getVersion());
+        StoredFeatureSet set = getElement(StoredFeatureSet.class, StoredFeatureSet.TYPE, "merged_set");
+        assertEquals(2, set.size());
+        assertEquals(0, set.featureOrdinal("duplicated"));
+        assertEquals(1, set.featureOrdinal("new_feature"));
+    }
+
+    public void testMergeWithList() throws Exception {
+        int nFeature = random().nextInt(99) + 1;
+        List<StoredFeature> features = new ArrayList<>(nFeature);
+        for (int i = 0; i < nFeature; i++) {
+            StoredFeature feat = randomFeature("feature" + i);
+            features.add(feat);
+        }
+
+        AddFeaturesToSetRequestBuilder builder = AddFeaturesToSetAction.INSTANCE.newRequestBuilder(client());
+        builder.request().setFeatureSet("new_feature_set");
+        builder.request().setFeatures(features);
+        builder.request().setMerge(true);
+        builder.request().setStore(IndexFeatureStore.DEFAULT_STORE);
+        AddFeaturesToSetResponse resp = builder.execute().get();
+
+        assertEquals(DocWriteResponse.Result.CREATED, resp.getResponse().getResult());
+        assertEquals(1, resp.getResponse().getVersion());
+        StoredFeatureSet set = getElement(StoredFeatureSet.class, StoredFeatureSet.TYPE, "new_feature_set");
+        assertNotNull(set);
+        assertEquals("new_feature_set", set.name());
+        assertEquals(features.size(), set.size());
+        assertTrue(features.stream().map(StoredFeature::name).allMatch(set::hasFeature));
+
+        builder = AddFeaturesToSetAction.INSTANCE.newRequestBuilder(client());
+        builder.request().setFeatureSet("new_feature_set");
+        builder.request().setFeatures(asList(randomFeature("another_feature"), randomFeature("feature0")));
+        builder.request().setMerge(true);
+        builder.request().setStore(IndexFeatureStore.DEFAULT_STORE);
+        resp = builder.execute().get();
+        assertEquals(2, resp.getResponse().getVersion());
+        assertEquals(DocWriteResponse.Result.UPDATED, resp.getResponse().getResult());
+        set = getElement(StoredFeatureSet.class, StoredFeatureSet.TYPE, "new_feature_set");
+        assertEquals(features.size()+1, set.size());
+        assertTrue(set.hasFeature("another_feature"));
+        assertEquals(0, set.featureOrdinal("feature0"));
     }
 }

--- a/src/test/java/com/o19s/es/ltr/feature/store/StoredFeatureParserTests.java
+++ b/src/test/java/com/o19s/es/ltr/feature/store/StoredFeatureParserTests.java
@@ -53,14 +53,18 @@ public class StoredFeatureParserTests extends LuceneTestCase {
         assertTestFeature(feature);
     }
 
-    public static String generateTestFeature() {
+    public static String generateTestFeature(String name) {
         return "{\n" +
-                    "\"name\": \"testFeature\",\n" +
-                    "\"params\": [\"param1\", \"param2\"],\n" +
-                    "\"template_language\": \"mustache\",\n" +
-                    "\"template\": \n" +
-                    new MatchQueryBuilder("match_field", "match_word").toString() +
-                    "\n}\n";
+                "\"name\": \""+name+"\",\n" +
+                "\"params\": [\"param1\", \"param2\"],\n" +
+                "\"template_language\": \"mustache\",\n" +
+                "\"template\": \n" +
+                new MatchQueryBuilder("match_field", "match_word").toString() +
+                "\n}\n";
+    }
+
+    public static String generateTestFeature() {
+        return generateTestFeature("testFeature");
     }
 
     public void assertTestFeature(StoredFeature feature) {

--- a/src/test/java/com/o19s/es/ltr/feature/store/StoredFeatureSetTests.java
+++ b/src/test/java/com/o19s/es/ltr/feature/store/StoredFeatureSetTests.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.feature.store;
+
+import org.apache.lucene.util.LuceneTestCase;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.o19s.es.ltr.LtrTestUtils.randomFeature;
+import static com.o19s.es.ltr.LtrTestUtils.wrapIntFuncion;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class StoredFeatureSetTests extends LuceneTestCase {
+    public void testCreate() throws IOException {
+        StoredFeature f1 = randomFeature("feat1");
+        StoredFeatureSet set = new StoredFeatureSet("name", singletonList(f1));
+        assertEquals(1, set.size());
+        assertTrue(set.hasFeature("feat1"));
+        assertEquals(0, set.featureOrdinal("feat1"));
+        assertEquals("feat1", set.feature(0).name());
+        assertSame(set, set.optimize());
+        StoredFeature f2 = randomFeature("feat2");
+        set = new StoredFeatureSet("name", asList(f1, f2));
+
+        assertTrue(set.hasFeature("feat1"));
+        assertTrue(set.hasFeature("feat2"));
+        assertEquals(1, set.featureOrdinal("feat2"));
+        assertEquals("feat2", set.feature(1).name());
+        assertSame(set, set.optimize());
+        set.validate();
+    }
+
+    public void testAppend() throws IOException {
+        StoredFeatureSet set = new StoredFeatureSet("name", emptyList());
+        assertEquals(0, set.size());
+        StoredFeature v1 = randomFeature("feat1");
+        StoredFeatureSet set2 = set.append(singletonList(v1));
+        assertSame(v1, set2.feature(0));
+        assertEquals(0, set.size());
+        assertEquals(1, set2.size());
+        StoredFeature v2 = randomFeature("feat1");
+        expectThrows(IllegalArgumentException.class, () -> set2.append(singletonList(randomFeature("feat1"))));
+        assertSame(v1, set2.feature(0));
+        set.validate();
+        set2.validate();
+    }
+
+    public void testAppendMaxSize() throws IOException {
+        StoredFeatureSet set_v1 = new StoredFeatureSet("name", emptyList());
+        assertEquals(0, set_v1.size());
+        List<StoredFeature> features = IntStream.range(0, StoredFeatureSet.MAX_FEATURES)
+                .mapToObj(wrapIntFuncion((i) -> randomFeature("feat" + i)))
+                .collect(Collectors.toList());
+        StoredFeatureSet set_v2 = set_v1.append(features);
+
+        IllegalArgumentException iae = expectThrows(IllegalArgumentException.class,
+                () -> set_v2.append(singletonList(randomFeature("new_feat"))));
+        assertThat(iae.getMessage(), equalTo("The resulting feature set would be too large"));
+    }
+
+    public void testMergeMaxSize() throws IOException {
+        StoredFeatureSet set_v1 = new StoredFeatureSet("name", emptyList());
+        assertEquals(0, set_v1.size());
+        assert StoredFeatureSet.MAX_FEATURES > 10;
+        List<StoredFeature> features = IntStream.range(0, StoredFeatureSet.MAX_FEATURES - 2)
+                .mapToObj(wrapIntFuncion((i) -> randomFeature("feat" + i)))
+                .collect(Collectors.toList());
+        StoredFeatureSet set_v2 = set_v1.append(features)
+                .merge(asList(randomFeature("feat0"),
+                        randomFeature("feat9"),
+                        randomFeature("new1"),
+                        randomFeature("new2")));
+        assertEquals(StoredFeatureSet.MAX_FEATURES, set_v2.size());
+
+        IllegalArgumentException iae = expectThrows(IllegalArgumentException.class,
+                () -> set_v2.merge(asList(randomFeature("new4"), randomFeature("feat9"))));
+        assertThat(iae.getMessage(), equalTo("The resulting feature set would be too large"));
+    }
+
+    public void testMerge() throws IOException {
+        StoredFeatureSet set_v1 = new StoredFeatureSet("name", emptyList());
+        assertEquals(0, set_v1.size());
+        StoredFeature feat1_v1 = randomFeature("feat1");
+        StoredFeature feat2_v1 = randomFeature("feat2");
+        StoredFeatureSet set_v2 = set_v1.merge(asList(feat1_v1, feat2_v1));
+        assertSame(feat1_v1, set_v2.feature(0));
+        assertSame(feat2_v1, set_v2.feature(1));
+        assertEquals(0, set_v1.size());
+        assertEquals(2, set_v2.size());
+        StoredFeature feat1_v2 = randomFeature("feat1");
+        StoredFeature feat3_v1 = randomFeature("feat3");
+        StoredFeatureSet set_v3 = set_v2.merge(asList(feat3_v1, feat1_v2));
+        assertSame(feat1_v2, set_v3.feature(0));
+        assertSame(feat2_v1, set_v3.feature(1));
+        assertSame(feat3_v1, set_v3.feature(2));
+    }
+}

--- a/src/test/java/com/o19s/es/ltr/rest/FeaturesParserTests.java
+++ b/src/test/java/com/o19s/es/ltr/rest/FeaturesParserTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.rest;
+
+import org.apache.lucene.util.LuceneTestCase;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.o19s.es.ltr.feature.store.StoredFeatureParserTests.generateTestFeature;
+import static org.elasticsearch.common.xcontent.json.JsonXContent.jsonXContent;
+
+public class FeaturesParserTests extends LuceneTestCase {
+    public void testParseArray() throws IOException {
+        RestAddFeatureToSet.FeaturesParserState fparser = new RestAddFeatureToSet.FeaturesParserState();
+        int nFeat = random().nextInt(18)+1;
+        String featuresArray = IntStream.range(0, nFeat)
+                .mapToObj((i) -> generateTestFeature("feat" + i))
+                .collect(Collectors.joining(","));
+        XContentParser parser = jsonXContent.createParser(NamedXContentRegistry.EMPTY, "{\"features\":[" + featuresArray + "]}");
+        fparser.parse(parser);
+        assertEquals(nFeat, fparser.getFeatures().size());
+        assertEquals("feat0", fparser.getFeatures().get(0).name());
+    }
+}

--- a/src/test/resources/rest-api-spec/api/ltr.add_features_to_set.json
+++ b/src/test/resources/rest-api-spec/api/ltr.add_features_to_set.json
@@ -3,7 +3,12 @@
     "methods" : ["POST"],
     "url": {
       "path": "/_ltr/{store}/_featureset/{name}/_addfeatures/{query}",
-      "paths": ["/_ltr/{store}/_featureset/{name}/_addfeatures/{query}","/_ltr/_featureset/{name}/_addfeatures/{query}"],
+      "paths": [
+        "/_ltr/{store}/_featureset/{name}/_addfeatures/{query}",
+        "/_ltr/{store}/_featureset/{name}/_addfeatures",
+        "/_ltr/_featureset/{name}/_addfeatures/{query}",
+        "/_ltr/_featureset/{name}/_addfeatures"
+      ],
       "parts": {
         "store": {
           "type": "string",
@@ -17,7 +22,7 @@
         },
         "query": {
           "type": "string",
-          "required": true,
+          "required": false,
           "description": "The feature names query"
         }
       },
@@ -29,9 +34,16 @@
         "version": {
           "type" : "long",
           "description" : "Extra check to ensure that the model is created with this version of the set"
+        },
+        "merge": {
+          "type" : "boolean",
+          "description" : "Merge the list for features otherwise append only"
         }
       }
     },
-    "body": null
+    "body": {
+      "description" : "The feature",
+      "required": "false"
+    }
   }
 }

--- a/src/test/resources/rest-api-spec/test/fstore/50_add_features_to_set.yaml
+++ b/src/test/resources/rest-api-spec/test/fstore/50_add_features_to_set.yaml
@@ -1,5 +1,5 @@
 ---
-"Append features to set on the default store":
+"Append/merge features to set on the default store with a query":
   - do:
         ltr.create_store: {}
 
@@ -69,11 +69,25 @@
   - do:
         catch: /Feature \[another_feature\] defined twice in this set/
         ltr.add_features_to_set:
-            name: my_generated_set
+            name:  my_generated_set
             query: another_feature
 
+  - do:
+        ltr.add_features_to_set:
+            name: my_generated_set
+            merge: true
+            query: another_feature
+  - do:
+         ltr.get_featureset:
+             name: my_generated_set
+
+  - match: { _index: .ltrstore }
+  - match: { _id:  featureset-my_generated_set }
+  - match: { _version: 3 }
+  - length: { _source.featureset.features: 3 }
+
 ---
-"Append features to set on custom store":
+"Append features to set on custom store with a query":
   - do:
         ltr.create_store:
            store: mystore
@@ -98,6 +112,141 @@
            store: mystore
            name: my_generated_set
            query: another_feature
+
+  - match: { _index:   .ltrstore_mystore }
+  - match: { _id:      featureset-my_generated_set }
+  - match: { _version: 1 }
+
+  - do:
+         ltr.get_featureset:
+             store: mystore
+             name: my_generated_set
+
+  - length: { _source.featureset.features: 1 }
+---
+"Append/merge features to set on the default store with a list":
+  - do:
+        ltr.create_store: {}
+
+  - do:
+        ltr.create_feature:
+          name: another_feature
+          body:
+              name: another_feature
+              params:
+                - query_string
+              template:
+                match:
+                  field_test_other: "{{query_string}}"
+
+  - do:
+        ltr.add_features_to_set:
+            name: my_generated_set
+            body:
+              features:
+                - name: my_feature1
+                  params:
+                    - query_string
+                  template:
+                    match:
+                      field_test1: "{{query_string}}"
+                - name: my_feature2
+                  params:
+                    - query_string
+                  template:
+                    match:
+                      field_test2: "{{query_string}}"
+
+  - match: { _index:   .ltrstore }
+  - match: { _id:      featureset-my_generated_set }
+  - match: { _version: 1 }
+
+  - do:
+         ltr.get_featureset:
+             name: my_generated_set
+
+  - length: { _source.featureset.features: 2 }
+
+  - do:
+        ltr.add_features_to_set:
+            name: my_generated_set
+            body:
+              features:
+                - name: another_feature
+                  params:
+                    - query_string
+                  template:
+                    match:
+                      field_test_other: "{{query_string}}"
+
+  - do:
+         ltr.get_featureset:
+             name: my_generated_set
+
+  - match: { _index: .ltrstore }
+  - match: { _id:  featureset-my_generated_set }
+  - match: { _version: 2 }
+  - length: { _source.featureset.features: 3 }
+
+  - do:
+        catch: /Feature \[another_feature\] defined twice in this set/
+        ltr.add_features_to_set:
+            name: my_generated_set
+            body:
+              features:
+                - name: another_feature
+                  params:
+                    - query_string
+                  template:
+                    match:
+                      field_test_other: "{{query_string}}"
+
+  - do:
+        ltr.add_features_to_set:
+            name: my_generated_set
+            merge: true
+            body:
+              features:
+                - name: another_feature
+                  params:
+                    - query_string
+                  template:
+                    match:
+                      field_test_other: "{{query_string}}"
+                - name: feature3
+                  params:
+                    - query_string
+                  template:
+                    match:
+                      field_test_other: "{{query_string}}"
+
+  - do:
+         ltr.get_featureset:
+             name: my_generated_set
+
+  - match: { _index: .ltrstore }
+  - match: { _id:  featureset-my_generated_set }
+  - match: { _version: 3 }
+  - length: { _source.featureset.features: 4 }
+
+---
+"Append features to set on custom store":
+  - do:
+        ltr.create_store:
+           store: mystore
+
+  - do:
+        ltr.add_features_to_set:
+           store: mystore
+           name: my_generated_set
+           body:
+              features:
+                - name: another_feature
+                  params:
+                    - query_string
+                  template:
+                    match:
+                      field_test_other: "{{query_string}}"
 
   - match: { _index:   .ltrstore_mystore }
   - match: { _id:      featureset-my_generated_set }


### PR DESCRIPTION
Allows to update featureset by adding features in the request body
rather than providing a prefix query.
Initially it was only possible to update the featureset by adding
features from the store.
It's now possible to provide the feature definitions directly in
the request body bypassing the feature store.
Added an option to merge the features, it permits to replace a
feature instead of throwing an error.

relates #83