### PR TITLE
Fixes #85 -- logs features as a list

### DIFF
--- a/demo/collectFeatures.py
+++ b/demo/collectFeatures.py
@@ -36,12 +36,13 @@ logQuery = {
 
 def featureDictToList(ranklibLabeledFeatures):
     rVal = [0.0] * len(ranklibLabeledFeatures)
-    for ranklibIdx, value in ranklibLabeledFeatures.items():
+    for idx, logEntry in enumerate(ranklibLabeledFeatures):
+        value = logEntry['value']
         try:
-            rVal[int(ranklibIdx) - 1] = value
+            rVal[idx - 1] = value
         except IndexError:
             import pdb; pdb.set_trace()
-            print("Out of range %s" % ranklibIdx)
+            print("Out of range %s" % idx)
     return rVal
 
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -62,7 +62,7 @@ Example to output the feature scores for the feature set `my_feature_set` and fo
 }
 ```
 
-The log entries are appendend to a search hit field named `_ltrlog` with a sub field per log entry.
+The log entries are appended to a search hit field named `_ltrlog` with a sub field per log entry. Entries are listed in the same value they were added.
 
 ```json
 {
@@ -84,17 +84,41 @@ The log entries are appendend to a search hit field named `_ltrlog` with a sub f
         "_score": 1.3862944,
         "fields" : {
           "_ltrlog": [{
-            "log_entry1": {
-              "feature1": 1.232,
-              "feature2": 0,
-              "feature3": 2.324,
-              "feature4": 0.3234
-            },
-            "log_entry2": {
-              "feature1": 1.232,
-              "feature3": 2.324,
-              "feature4": 0.3234
-            }
+            "log_entry1": [
+              {
+                "name": "feature1",
+                "value": 1.232
+              },
+              {
+                "name": "feature2",
+                "value": 0
+              },
+              {
+                "name": "feature3",
+                "value": 2.324
+              },
+              {
+                "name": "feature4",
+                "value": 0.3234
+              }
+            ],
+            "log_entry2": [
+              {
+                "name": "feature1",
+                "value": 1.232
+              },
+              {
+                "name": "feature2",
+              },
+              {
+                "name": "feature3",
+                "value": 2.324
+              },
+              {
+                "name": "feature4",
+                "value": 0.3234
+              }
+            ]
           }]
         }
       },
@@ -103,18 +127,44 @@ The log entries are appendend to a search hit field named `_ltrlog` with a sub f
         "_type" : "my_type",
         "_id" : "4",
         "_score": 1.2324,
-        "fields" : {
+        "fields" : 
+        {
           "_ltrlog": [{
-            "log_entry1": {
-              "feature1": 1.112,
-              "feature2": 3.234,
-              "feature3": 0,
-              "feature4": 0
-            },
-            "log_entry2": {
-              "feature1": 1.112,
-              "feature2": 3.234
-            }
+
+            "log_entry1": [
+              {
+                "name": "feature1",
+                "value": 1.112
+              },
+              {
+                "name": "feature2",
+                "value": 3.234
+              },
+              {
+                "name": "feature3",
+                "value": 0
+              },
+              {
+                "name": "feature4",
+                "value": 0
+              }
+            ],
+            "log_entry2": [
+              {
+                "name": "feature1",
+                "value": 1.112
+              },
+              {
+                "name": "feature2",
+                "value": 3.234
+              },
+              {
+                "name": "feature3",
+              },
+              {
+                "name": "feature4",
+              }
+            ]
           }]
         }
       }

--- a/src/main/java/com/o19s/es/ltr/logging/LoggingFetchSubPhase.java
+++ b/src/main/java/com/o19s/es/ltr/logging/LoggingFetchSubPhase.java
@@ -215,9 +215,6 @@ public class LoggingFetchSubPhase implements FetchSubPhase {
 
         @Override
         public void accept(int featureOrdinal, float score) {
-            if (currentLog.isEmpty()) {
-                rebuild();
-            }
             currentLog.get(featureOrdinal).put("value", score);
         }
 

--- a/src/main/java/com/o19s/es/ltr/logging/LoggingFetchSubPhase.java
+++ b/src/main/java/com/o19s/es/ltr/logging/LoggingFetchSubPhase.java
@@ -179,24 +179,46 @@ public class LoggingFetchSubPhase implements FetchSubPhase {
         private static final String FIELD_NAME = "_ltrlog";
         private final String name;
         private final FeatureSet set;
-        private final Map<String, Float> initialLog;
-        private Map<String, Float> currentLog;
+        private final boolean missingAsZero;
+
+        // [
+        //      {
+        //          "name": "featureName",
+        //          "value": 1.33
+        //      },
+        //      {
+        //          "name": "otherFeatureName",
+        //      }
+        // ]
+        private List<Map<String, Object>> currentLog;
+
 
         HitLogConsumer(String name, FeatureSet set, boolean missingAsZero) {
             this.name = name;
             this.set = set;
-            Map<String, Float> ini = new HashMap<>();
-            if (missingAsZero) {
-                for (int i = 0; i < set.size(); i++) {
-                    ini.put(set.feature(i).name(), 0F);
+            this.missingAsZero = missingAsZero;
+        }
+
+        private void rebuild() {
+            List<Map<String, Object>> ini = new ArrayList<Map<String, Object>>(set.size()) ;
+
+            for (int i = 0; i < set.size(); i++) {
+                Map<String, Object> defaultKeyVal = new HashMap<String, Object>();
+                defaultKeyVal.put("name", set.feature(i).name());
+                if (missingAsZero) {
+                    defaultKeyVal.put("value", 0.0F);
                 }
+                ini.add(i, defaultKeyVal);
             }
-            initialLog = Collections.unmodifiableMap(ini);
+            currentLog = ini;
         }
 
         @Override
         public void accept(int featureOrdinal, float score) {
-            currentLog.put(set.feature(featureOrdinal).name(), score);
+            if (currentLog.isEmpty()) {
+                rebuild();
+            }
+            currentLog.get(featureOrdinal).put("value", score);
         }
 
         void nextDoc(SearchHit hit) {
@@ -205,13 +227,13 @@ public class LoggingFetchSubPhase implements FetchSubPhase {
             }
             SearchHitField logs = hit.getFields()
                     .computeIfAbsent(FIELD_NAME,(k) -> newLogField());
-            Map<String, Map<String, Float>> entries = logs.getValue();
-            currentLog = new HashMap<>(initialLog);
+            Map<String, List<Map<String, Object>>> entries = logs.getValue();
+            rebuild();
             entries.put(name, currentLog);
         }
 
         SearchHitField newLogField() {
-            List<Object> logList = Collections.singletonList(new HashMap<String, Map<String, Float>>());
+            List<Object> logList = Collections.singletonList(new HashMap<String, List<Map<String, Object>>>());
             return new SearchHitField(FIELD_NAME, logList);
         }
     }

--- a/src/test/java/com/o19s/es/ltr/logging/LoggingFetchSubPhaseTests.java
+++ b/src/test/java/com/o19s/es/ltr/logging/LoggingFetchSubPhaseTests.java
@@ -41,7 +41,6 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.TestUtil;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.lucene.search.function.CombineFunction;
 import org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction;
 import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
@@ -51,7 +50,6 @@ import org.elasticsearch.index.fielddata.plain.SortedNumericDVIndexFieldData;
 import org.elasticsearch.search.SearchHit;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/com/o19s/es/ltr/logging/LoggingIT.java
+++ b/src/test/java/com/o19s/es/ltr/logging/LoggingIT.java
@@ -195,41 +195,51 @@ public class LoggingIT extends BaseIntegrationTest {
     protected void assertSearchHits(Map<String, Doc> docs, SearchResponse resp) {
         for (SearchHit hit: resp.getHits()) {
             assertTrue(hit.getFields().containsKey("_ltrlog"));
-            Map<String, Map<String, Float>> logs = hit.getFields().get("_ltrlog").getValue();
+            Map<String, List<Map<String, Object>>> logs = hit.getFields().get("_ltrlog").getValue();
             assertTrue(logs.containsKey("first_log"));
             assertTrue(logs.containsKey("second_log"));
 
-            Map<String, Float> log1 = logs.get("first_log");
-            Map<String, Float> log2 = logs.get("second_log");
+            List<Map<String, Object>> log1 = logs.get("first_log");
+            List<Map<String, Object>> log2 = logs.get("second_log");
             Doc d = docs.get(hit.getId());
             if (d.field1.equals("found")) {
-                assertTrue(log1.containsKey("text_feature1"));
-                assertTrue(log2.containsKey("text_feature1"));
-                assertTrue(log1.get("text_feature1") > 0F);
-                assertTrue(log2.get("text_feature1") > 0F);
-                assertFalse(log1.containsKey("text_feature2"));
-                assertTrue(log2.containsKey("text_feature2"));
-                assertEquals(0F, log2.get("text_feature2"), 0F);
+                assertEquals(log1.get(0).get("name"), "text_feature1");
+                assertEquals(log2.get(0).get("name"), "text_feature1");
+
+                assertTrue((Float)log1.get(0).get("value") > 0F);
+                assertTrue((Float)log2.get(0).get("value") > 0F);
+
+                assertEquals(log1.get(1).get("name"), "text_feature2");
+                assertFalse(log1.get(1).containsKey("value"));
+
+                assertEquals(log2.get(1).get("name"), "text_feature2");
+                assertEquals(log2.get(1).get("value"), 0F);
+
             } else {
-                assertTrue(log1.containsKey("text_feature2"));
-                assertTrue(log2.containsKey("text_feature2"));
-                assertTrue(log1.get("text_feature2") > 0F);
-                assertTrue(log2.get("text_feature2") > 0F);
-                assertFalse(log1.containsKey("text_feature1"));
-                assertTrue(log2.containsKey("text_feature1"));
-                assertEquals(0F, log2.get("text_feature1"), 0F);
+                assertEquals(log1.get(0).get("name"), "text_feature1");
+                assertEquals(log2.get(0).get("name"), "text_feature1");
+
+                assertTrue((Float)log1.get(1).get("value") > 0F);
+                assertTrue((Float)log2.get(1).get("value") > 0F);
+
+                assertEquals(log1.get(0).get("name"), "text_feature1");
+                assertEquals(log2.get(0).get("name"), "text_feature1");
+
+                assertEquals(0F, (Float)log2.get(0).get("value"), 0F);
             }
             float score = (float) Math.log1p((d.scorefield1 * FACTOR) + 1);
-            assertTrue(log1.containsKey("numeric_feature1"));
-            assertTrue(log2.containsKey("numeric_feature1"));
+            assertEquals(log1.get(2).get("name"), "numeric_feature1");
+            assertEquals(log2.get(2).get("name"), "numeric_feature1");
 
-            assertEquals(score, log1.get("numeric_feature1"), Math.ulp(score));
-            assertEquals(score, log2.get("numeric_feature1"), Math.ulp(score));
+            assertEquals(score, (Float)log1.get(2).get("value"), Math.ulp(score));
+            assertEquals(score, (Float)log2.get(2).get("value"), Math.ulp(score));
 
-            assertTrue(log1.containsKey("derived_feature"));
-            assertTrue(log2.containsKey("derived_feature"));
-            assertEquals(100.0, log1.get("derived_feature"), Math.ulp(100.0));
-            assertEquals(100.0, log2.get("derived_feature"), Math.ulp(100.0));
+            assertEquals(log1.get(3).get("name"), "derived_feature");
+            assertEquals(log2.get(3).get("name"), "derived_feature");
+
+            assertEquals(100.0, (Float)log1.get(3).get("value"), Math.ulp(100.0));
+            assertEquals(100.0, (Float) log2.get(3).get("value"), Math.ulp(100.0));
+
         }
     }
 


### PR DESCRIPTION
Change the dictionary logging structure to a list. This ensures you can use the ordinal when logging for tools like ranklib that want that info. 

Example:

```
      "fields": {
               "_ltrlog": [
                  {
                     "log_entry1": [
                        {
                           "name": "body_query",
                           "value": 9.8376875
                        },
                        {
                           "name": "title_query",
                           "value": 12.318446
                        }
                     ]
                  }
               ]
```

When no value present (and `missing_as_zero` is `false`) then feature is logged with "value" key missing, ie:

```
      "fields": {
               "_ltrlog": [
                  {
                     "log_entry1": [
                        {
                           "name": "body_query"
                        },
                        {
                           "name": "title_query",
                           "value": 12.318446
                        }
                     ]
                  }
               ]
```