### PR TITLE
Add support for feature validation

### DIFF
--- a/demo/loadFeatures.py
+++ b/demo/loadFeatures.py
@@ -24,8 +24,10 @@ def eachFeature():
 
 def loadFeatures(esHost, featureSetName='movie_features'):
     featureSet = {
-        "name": featureSetName,
-        "features": [feature for feature in eachFeature()]
+        "featureset": {
+            "name": featureSetName,
+            "features": [feature for feature in eachFeature()]
+        }
     }
     path = "_ltr/_featureset/%s" % featureSetName
     fullPath = urljoin(esHost, path)

--- a/demo/rest/1.json
+++ b/demo/rest/1.json
@@ -1,10 +1,12 @@
 {
-  "name": "tmdb_title",
-  "params": ["query_string"],
-  "template_language": "mustache",
-  "template" : {
-    "match": {
-      "title": "{{query_string}}"
+  "feature": {
+    "name": "tmdb_title",
+    "params": ["query_string"],
+    "template_language": "mustache",
+    "template" : {
+      "match": {
+        "title": "{{query_string}}"
+      }
     }
   }
 }

--- a/demo/rest/2.json
+++ b/demo/rest/2.json
@@ -1,13 +1,15 @@
 {
-  "name": "tmdb_multi",
-  "params": ["query_string"],
-  "template_language": "mustache",
-  "template" : {
-    "multi_match": {
-      "query": "{{query_string}}",
-      "type": "cross_fields",
-      "fields": ["overview", "genres.name", "title", "tagline", "belongs_to_collection.name", "cast.name", "directors.name"],
-      "tie_breaker": 1.0
+  "feature": {
+    "name": "tmdb_multi",
+    "params": ["query_string"],
+    "template_language": "mustache",
+    "template" : {
+      "multi_match": {
+        "query": "{{query_string}}",
+        "type": "cross_fields",
+        "fields": ["overview", "genres.name", "title", "tagline", "belongs_to_collection.name", "cast.name", "directors.name"],
+        "tie_breaker": 1.0
+      }
     }
   }
 }

--- a/demo/rest/model.json
+++ b/demo/rest/model.json
@@ -1,19 +1,21 @@
 {
-  "name": "example-model",
   "model": {
-    "type": "model/xgboost+json",
-    "definition": [  { "nodeid": 0, "depth": 0, "split": "tmdb_multi", "split_condition": 11.2009, "yes": 1, "no": 2, "missing": 1, "children": [
-    { "nodeid": 1, "depth": 1, "split": "tmdb_title", "split_condition": 2.20631, "yes": 3, "no": 4, "missing": 3, "children": [
-      { "nodeid": 3, "leaf": -0.03125 },
-      { "nodeid": 4, "leaf": -0.25 }
-    ]},
-    { "nodeid": 2, "leaf": 2.45 }
-  ]},  { "nodeid": 0, "depth": 0, "split": "tmdb_title", "split_condition": 7.56362, "yes": 1, "no": 2, "missing": 1, "children": [
-    { "nodeid": 1, "depth": 1, "split": "tmdb_multi", "split_condition": 11.2009, "yes": 3, "no": 4, "missing": 3, "children": [
-      { "nodeid": 3, "leaf": -0.0165441 },
-      { "nodeid": 4, "leaf": 0.04375 }
-    ]},
-    { "nodeid": 2, "leaf": 0.7 }
-  ]}] 
+    "name": "example-model",
+    "model": {
+      "type": "model/xgboost+json",
+      "definition": [  { "nodeid": 0, "depth": 0, "split": "tmdb_multi", "split_condition": 11.2009, "yes": 1, "no": 2, "missing": 1, "children": [
+      { "nodeid": 1, "depth": 1, "split": "tmdb_title", "split_condition": 2.20631, "yes": 3, "no": 4, "missing": 3, "children": [
+        { "nodeid": 3, "leaf": -0.03125 },
+        { "nodeid": 4, "leaf": -0.25 }
+      ]},
+      { "nodeid": 2, "leaf": 2.45 }
+    ]},  { "nodeid": 0, "depth": 0, "split": "tmdb_title", "split_condition": 7.56362, "yes": 1, "no": 2, "missing": 1, "children": [
+      { "nodeid": 1, "depth": 1, "split": "tmdb_multi", "split_condition": 11.2009, "yes": 3, "no": 4, "missing": 3, "children": [
+        { "nodeid": 3, "leaf": -0.0165441 },
+        { "nodeid": 4, "leaf": 0.04375 }
+      ]},
+      { "nodeid": 2, "leaf": 0.7 }
+    ]}]
+    }
   }
 }

--- a/demo/train.py
+++ b/demo/train.py
@@ -19,19 +19,21 @@ def saveModel(esHost, scriptName, featureSet, modelFname):
     import json
     from urllib.parse import urljoin
     modelPayload = {
-        "name": scriptName,
         "model": {
-            "type": "model/ranklib",
+            "name": scriptName,
+            "model": {
+                "type": "model/ranklib",
                 "definition": {
                 }
             }
+        }
     }
 
     with open(modelFname) as modelFile:
         modelContent = modelFile.read()
         path = "_ltr/_featureset/%s/_createmodel" % featureSet
         fullPath = urljoin(esHost, path)
-        modelPayload['model']['definition'] = modelContent
+        modelPayload['model']['model']['definition'] = modelContent
         print("POST %s" % fullPath)
         resp = requests.post(fullPath, json.dumps(modelPayload))
         print(resp.status_code)

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -73,12 +73,14 @@ and always use the `_ltr` API endpoints to update their contents.
 The format of a feature is :
 ```json
 {
-  "name": "my_feature",
-  "params": ["query_string"],
-  "template_language": "mustache",
-  "template" : {
-    "match": {
-      "field": "{{query_string}}"
+  "feature": {
+    "name": "my_feature",
+    "params": ["query_string"],
+    "template_language": "mustache",
+    "template" : {
+      "match": {
+        "field": "{{query_string}}"
+      }
     }
   }
 }
@@ -107,19 +109,21 @@ The output is exactly the same as the `_search` API.
 The format of a feature set is :
 ```json
 {
-  "name": "my_feature_set",
-  "features" : [
-    {
-      "name": "my_feature",
-      "params": ["query_string"],
-      "template_language": "mustache",
-      "template" : {
-        "match": {
-          "field": "{{query_string}}"
+  "featureset": {
+    "name": "my_feature_set",
+    "features" : [
+      {
+        "name": "my_feature",
+        "params": ["query_string"],
+        "template_language": "mustache",
+        "template" : {
+          "match": {
+            "field": "{{query_string}}"
+          }
         }
       }
-    }
-  ]
+    ]
+  }
 }
 ```
 
@@ -186,26 +190,28 @@ You can force to the api endpoint to update exiting features within the set by a
 The format of a model is:
 ```json
 {
-  "name" : "my_model",
-  "feature_set": { 
-    "name": "my_feature_set",
-    "features" : [
-      {
-        "name": "my_feature",
-        "params": ["query_string"],
-        "template_language": "mustache",
-        "template" : {
-          "match": {
-            "field": "{{query_string}}"
+  "model" : {
+    "name" : "my_model",
+    "feature_set": { 
+      "name": "my_feature_set",
+      "features" : [
+        {
+          "name": "my_feature",
+          "params": ["query_string"],
+          "template_language": "mustache",
+          "template" : {
+            "match": {
+              "field": "{{query_string}}"
+            }
           }
         }
+      ]
+    },
+    "model": {
+      "type": "model/linear",
+      "definition": {
+        "feature" : 0.3
       }
-    ]
-  },
-  "model": {
-    "type": "model/linear",
-    "definition": {
-      "feature" : 0.3
     }
   }
 }
@@ -240,13 +246,15 @@ A model can be created by using an existing feature set:
 `POST /_ltr/_featureset/my_featureset/_createmodel`
 ```json
 {
-  "name": "my_model_name",
   "model": {
-    "type": "model/linear",
-    "definition": {
-      "feature1" : 0.3,
-      "feature2" : 0.4,
-      "feature3" : 0.8
+    "name": "my_model_name",
+    "model": {
+      "type": "model/linear",
+      "definition": {
+        "feature1" : 0.3,
+        "feature2" : 0.4,
+        "feature3" : 0.8
+      }
     }
   }
 }
@@ -254,6 +262,48 @@ A model can be created by using an existing feature set:
 
 A `version` query param can be added to ensure that the set used to create the model is the version expected:
 `POST /_ltr/_featureset/my_featureset/_createmodel?version=23`
+
+## Validation
+
+When creating features, featuresets or models the plugin will only validate the formats it owns. This does not
+guarantee that the elements you create are valid elasticsearch queries.
+In order to avoid last minute surprises you can append a `validation` json field:
+```json
+{
+"validation": {
+  "params" : {
+    "query_string": "test query"
+  },
+  "index": "test_index"
+}
+}
+```
+
+Just before creating/updating the element in the feature it will perform a search request to make sure
+that all your feature queries are valid.
+Example to create a validated feature to the store:
+`PUT /_ltr/_feature/my_feature`
+
+```json
+{
+  "feature": {
+    "name": "my_feature",
+    "params": ["query_string"],
+    "template_language": "mustache",
+    "template" : {
+      "match": {
+        "field": "{{query_string}}"
+      }
+    }
+  },
+  "validation": {
+    "params": {
+      "query_string": "a test query"
+    },
+    "index": "test_index"
+  }
+}
+```
 
 # Caches
 The plugin uses an internal cache not to compile the models on every request.

--- a/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
+++ b/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
@@ -41,6 +41,7 @@ import com.o19s.es.ltr.logging.LoggingFetchSubPhase;
 import com.o19s.es.ltr.logging.LoggingSearchExtBuilder;
 import com.o19s.es.ltr.query.LtrQueryBuilder;
 import com.o19s.es.ltr.query.StoredLtrQueryBuilder;
+import com.o19s.es.ltr.query.ValidatingLtrQueryBuilder;
 import com.o19s.es.ltr.ranker.parser.LinearRankerParser;
 import com.o19s.es.ltr.ranker.parser.LtrRankerParserFactory;
 import com.o19s.es.ltr.ranker.parser.XGBoostJsonParser;
@@ -109,7 +110,10 @@ public class LtrQueryParserPlugin extends Plugin implements SearchPlugin, Script
                 new QuerySpec<>(LtrQueryBuilder.NAME, LtrQueryBuilder::new, LtrQueryBuilder::fromXContent),
                 new QuerySpec<>(StoredLtrQueryBuilder.NAME,
                         (input) -> new StoredLtrQueryBuilder(getFeatureStoreLoader(), input),
-                        (ctx) -> StoredLtrQueryBuilder.fromXContent(getFeatureStoreLoader(), ctx)));
+                        (ctx) -> StoredLtrQueryBuilder.fromXContent(getFeatureStoreLoader(), ctx)),
+                new QuerySpec<>(ValidatingLtrQueryBuilder.NAME,
+                        (input) -> new ValidatingLtrQueryBuilder(input, parserFactory),
+                        (ctx) -> ValidatingLtrQueryBuilder.fromXContent(ctx, parserFactory)));
     }
 
     @Override

--- a/src/main/java/com/o19s/es/ltr/action/AddFeaturesToSetAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/AddFeaturesToSetAction.java
@@ -17,6 +17,7 @@
 package com.o19s.es.ltr.action;
 
 import com.o19s.es.ltr.feature.store.StoredFeature;
+import com.o19s.es.ltr.feature.FeatureValidation;
 import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
@@ -68,6 +69,8 @@ public class AddFeaturesToSetAction extends Action<AddFeaturesToSetAction.AddFea
         private boolean merge;
         private String featureSet;
         private String routing;
+        private FeatureValidation validation;
+
         @Override
         public ActionRequestValidationException validate() {
             ActionRequestValidationException arve = null;
@@ -96,6 +99,7 @@ public class AddFeaturesToSetAction extends Action<AddFeaturesToSetAction.AddFea
             merge = in.readBoolean();
             featureSet = in.readString();
             routing = in.readOptionalString();
+            validation = in.readOptionalWriteable(FeatureValidation::new);
         }
 
         @Override
@@ -109,6 +113,7 @@ public class AddFeaturesToSetAction extends Action<AddFeaturesToSetAction.AddFea
             out.writeBoolean(merge);
             out.writeString(featureSet);
             out.writeOptionalString(routing);
+            out.writeOptionalWriteable(validation);
         }
 
         public String getStore() {
@@ -157,6 +162,14 @@ public class AddFeaturesToSetAction extends Action<AddFeaturesToSetAction.AddFea
 
         public void setMerge(boolean merge) {
             this.merge = merge;
+        }
+
+        public FeatureValidation getValidation() {
+            return validation;
+        }
+
+        public void setValidation(FeatureValidation validation) {
+            this.validation = validation;
         }
     }
 

--- a/src/main/java/com/o19s/es/ltr/action/CreateModelFromSetAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/CreateModelFromSetAction.java
@@ -16,6 +16,7 @@
 
 package com.o19s.es.ltr.action;
 
+import com.o19s.es.ltr.feature.FeatureValidation;
 import com.o19s.es.ltr.feature.store.StoredLtrModel;
 import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ActionRequest;
@@ -96,6 +97,7 @@ public class CreateModelFromSetAction extends Action<CreateModelFromSetAction.Cr
         private String modelName;
         private StoredLtrModel.LtrModelDefinition definition;
         private String routing;
+        private FeatureValidation validation;
 
         public CreateModelFromSetRequest() {
         }
@@ -127,6 +129,7 @@ public class CreateModelFromSetAction extends Action<CreateModelFromSetAction.Cr
             modelName = in.readString();
             definition = new StoredLtrModel.LtrModelDefinition(in);
             routing = in.readOptionalString();
+            validation = in.readOptionalWriteable(FeatureValidation::new);
         }
 
         @Override
@@ -138,6 +141,7 @@ public class CreateModelFromSetAction extends Action<CreateModelFromSetAction.Cr
             out.writeString(modelName);
             definition.writeTo(out);
             out.writeOptionalString(routing);
+            out.writeOptionalWriteable(validation);
         }
 
         public String getStore() {
@@ -166,6 +170,14 @@ public class CreateModelFromSetAction extends Action<CreateModelFromSetAction.Cr
 
         public void setRouting(String routing) {
             this.routing = routing;
+        }
+
+        public FeatureValidation getValidation() {
+            return validation;
+        }
+
+        public void setValidation(FeatureValidation validation) {
+            this.validation = validation;
         }
     }
 

--- a/src/main/java/com/o19s/es/ltr/action/FeatureStoreAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/FeatureStoreAction.java
@@ -16,6 +16,7 @@
 
 package com.o19s.es.ltr.action;
 
+import com.o19s.es.ltr.feature.FeatureValidation;
 import com.o19s.es.ltr.feature.store.StorableElement;
 import com.o19s.es.ltr.feature.store.index.IndexFeatureStore;
 import org.elasticsearch.action.Action;
@@ -68,6 +69,8 @@ public class FeatureStoreAction extends Action<FeatureStoreAction.FeatureStoreRe
         private StorableElement storableElement;
         private Long updatedVersion;
         private String routing;
+
+        private FeatureValidation validation;
 
         public FeatureStoreRequest() {}
 
@@ -145,6 +148,15 @@ public class FeatureStoreAction extends Action<FeatureStoreAction.FeatureStoreRe
             this.updatedVersion = updatedVersion;
         }
 
+        public FeatureValidation getValidation() {
+            return validation;
+        }
+
+        public void setValidation(FeatureValidation validation) {
+            this.validation = validation;
+        }
+
+
         @Override
         public void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);
@@ -152,6 +164,7 @@ public class FeatureStoreAction extends Action<FeatureStoreAction.FeatureStoreRe
             routing = in.readOptionalString();
             action = Action.values()[in.readVInt()];
             storableElement = in.readNamedWriteable(StorableElement.class);
+            validation = in.readOptionalWriteable(FeatureValidation::new);
         }
 
         @Override
@@ -161,6 +174,7 @@ public class FeatureStoreAction extends Action<FeatureStoreAction.FeatureStoreRe
             out.writeOptionalString(routing);
             out.writeVInt(action.ordinal());
             out.writeNamedWriteable(storableElement);
+            out.writeOptionalWriteable(validation);
         }
 
         public enum Action {

--- a/src/main/java/com/o19s/es/ltr/action/TransportAddFeatureToSetAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportAddFeatureToSetAction.java
@@ -19,6 +19,7 @@ package com.o19s.es.ltr.action;
 import com.o19s.es.ltr.action.AddFeaturesToSetAction.AddFeaturesToSetRequest;
 import com.o19s.es.ltr.action.AddFeaturesToSetAction.AddFeaturesToSetResponse;
 import com.o19s.es.ltr.action.FeatureStoreAction.FeatureStoreRequest;
+import com.o19s.es.ltr.feature.FeatureValidation;
 import com.o19s.es.ltr.feature.store.StorableElement;
 import com.o19s.es.ltr.feature.store.StoredFeature;
 import com.o19s.es.ltr.feature.store.StoredFeatureSet;
@@ -114,6 +115,7 @@ public class TransportAddFeatureToSetAction extends HandledTransportAction<AddFe
         private final TransportSearchAction searchAction;
         private final TransportGetAction getAction;
         private final TransportFeatureStoreAction featureStoreAction;
+        private final FeatureValidation validation;
 
         AsyncAction(Task task, AddFeaturesToSetRequest request, ActionListener<AddFeaturesToSetResponse> listener,
                            ClusterService clusterService, TransportSearchAction searchAction, TransportGetAction getAction,
@@ -139,6 +141,7 @@ public class TransportAddFeatureToSetAction extends HandledTransportAction<AddFe
             this.searchAction = searchAction;
             this.getAction = getAction;
             this.featureStoreAction = featureStoreAction;
+            this.validation = request.getValidation();
         }
 
         private void start() {
@@ -283,7 +286,7 @@ public class TransportAddFeatureToSetAction extends HandledTransportAction<AddFe
             }
             frequest.setRouting(routing);
             frequest.setParentTask(clusterService.localNode().getId(), task.getId());
-
+            frequest.setValidation(validation);
             featureStoreAction.execute(frequest, wrap(
                     (r) -> listener.onResponse(new AddFeaturesToSetResponse(r.getResponse())),
                     listener::onFailure));

--- a/src/main/java/com/o19s/es/ltr/action/TransportCreateModelFromSetAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportCreateModelFromSetAction.java
@@ -94,6 +94,7 @@ public class TransportCreateModelFromSetAction extends HandledTransportAction<Cr
         FeatureStoreRequest featureStoreRequest = new FeatureStoreRequest(request.getStore(), model, FeatureStoreRequest.Action.CREATE);
         featureStoreRequest.setRouting(request.getRouting());
         featureStoreRequest.setParentTask(clusterService.localNode().getId(), parentTask.getId());
+        featureStoreRequest.setValidation(request.getValidation());
         featureStoreAction.execute(featureStoreRequest, ActionListener.wrap(
                 (r) -> listener.onResponse(new CreateModelFromSetResponse(r.getResponse())),
                 listener::onFailure));

--- a/src/main/java/com/o19s/es/ltr/feature/FeatureValidation.java
+++ b/src/main/java/com/o19s/es/ltr/feature/FeatureValidation.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.feature;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Simple object to store the parameters needed to validate stored elements:
+ * - The list of template params to replace
+ * - The index to run the query
+ */
+public class FeatureValidation implements Writeable, ToXContentObject {
+    @SuppressWarnings("unchecked")
+    public static final ConstructingObjectParser<FeatureValidation, Void> PARSER = new ConstructingObjectParser<>("feature_validation",
+            (Object[] args) -> new FeatureValidation((String) args[0], (Map<String, Object>) args[1]));
+
+    public static final ParseField INDEX = new ParseField("index");
+
+    public static final ParseField PARAMS = new ParseField("params");
+
+    static {
+        PARSER.declareString(ConstructingObjectParser.constructorArg(), INDEX);
+        PARSER.declareField(ConstructingObjectParser.constructorArg(), XContentParser::map,
+                PARAMS, ObjectParser.ValueType.OBJECT);
+    }
+
+    private final String index;
+    private final Map<String, Object> params;
+
+    public FeatureValidation(String index, Map<String, Object> params) {
+        this.index = Objects.requireNonNull(index);
+        this.params = Objects.requireNonNull(params);
+    }
+
+    public FeatureValidation(StreamInput input) throws IOException {
+        this.index = input.readString();
+        this.params = input.readMap();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(index);
+        out.writeMap(params);
+    }
+
+    public String getIndex() {
+        return index;
+    }
+
+    public Map<String, Object> getParams() {
+        return params;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        FeatureValidation that = (FeatureValidation) o;
+
+        if (!index.equals(that.index)) return false;
+        return params.equals(that.params);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = index.hashCode();
+        result = 31 * result + params.hashCode();
+        return result;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder.startObject()
+                .field(INDEX.getPreferredName(), index)
+                .field(PARAMS.getPreferredName(), this.params)
+                .endObject();
+    }
+}

--- a/src/main/java/com/o19s/es/ltr/feature/store/StoredFeature.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/StoredFeature.java
@@ -69,7 +69,7 @@ public class StoredFeature implements Feature, Accountable, StorableElement {
     private static final ParseField NAME = new ParseField("name");
     private static final ParseField PARAMS = new ParseField("params");
     private static final ParseField TEMPLATE_LANGUAGE = new ParseField("template_language");
-    private static final ParseField TEMPLATE = new ParseField("template");
+    public static final ParseField TEMPLATE = new ParseField("template");
 
     static {
         PARSER = new ObjectParser<>(TYPE, ParsingState::new);

--- a/src/main/java/com/o19s/es/ltr/query/ValidatingLtrQueryBuilder.java
+++ b/src/main/java/com/o19s/es/ltr/query/ValidatingLtrQueryBuilder.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.query;
+
+import com.o19s.es.ltr.feature.Feature;
+import com.o19s.es.ltr.feature.FeatureSet;
+import com.o19s.es.ltr.feature.FeatureValidation;
+import com.o19s.es.ltr.feature.store.CompiledLtrModel;
+import com.o19s.es.ltr.feature.store.PrecompiledExpressionFeature;
+import com.o19s.es.ltr.feature.store.StorableElement;
+import com.o19s.es.ltr.feature.store.StoredFeature;
+import com.o19s.es.ltr.feature.store.StoredFeatureSet;
+import com.o19s.es.ltr.feature.store.StoredLtrModel;
+import com.o19s.es.ltr.ranker.linear.LinearRanker;
+import com.o19s.es.ltr.ranker.parser.LtrRankerParserFactory;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.AbstractQueryBuilder;
+import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.QueryShardException;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableSet;
+import static java.util.stream.Collectors.joining;
+
+public class ValidatingLtrQueryBuilder extends AbstractQueryBuilder<ValidatingLtrQueryBuilder> {
+    public static final Set<String> SUPPORTED_TYPES = unmodifiableSet(new HashSet<>(asList(
+            StoredFeature.TYPE,
+            StoredFeatureSet.TYPE,
+            StoredLtrModel.TYPE)));
+
+    public static final String NAME = "validating_ltr_query";
+    private static ObjectParser<ValidatingLtrQueryBuilder, QueryParseContext> PARSER = new ObjectParser<>(NAME);
+    private static final ParseField VALIDATION = new ParseField("validation");
+
+    static {
+        BiConsumer<ValidatingLtrQueryBuilder, StorableElement> setElem = (b, v) -> {
+            if (b.element != null) {
+                throw new IllegalArgumentException("[" + b.element.type() + "] already set, only one element can be set at a time (" +
+                        SUPPORTED_TYPES.stream().collect(joining(",")) + ").");
+            }
+            b.element = v;
+        };
+
+        PARSER.declareObject(setElem,
+                (parser, ctx) -> StoredFeature.parse(parser),
+                new ParseField(StoredFeature.TYPE));
+        PARSER.declareObject(setElem,
+                (parser, ctx) -> StoredFeatureSet.parse(parser),
+                new ParseField(StoredFeatureSet.TYPE));
+        PARSER.declareObject(setElem,
+                (parser, ctx) -> StoredLtrModel.parse(parser),
+                new ParseField(StoredLtrModel.TYPE));
+        PARSER.declareObject((b, v) -> b.validation = v,
+                (p, c) -> FeatureValidation.PARSER.apply(p, null),
+                new ParseField("validation"));
+        declareStandardFields(PARSER);
+    }
+
+    private StorableElement element;
+    private FeatureValidation validation;
+    private final transient LtrRankerParserFactory factory;
+
+    private ValidatingLtrQueryBuilder(LtrRankerParserFactory factory) {
+        this.factory = factory;
+    }
+
+    public ValidatingLtrQueryBuilder(StorableElement element, FeatureValidation validation, LtrRankerParserFactory factory) {
+        this(factory);
+        this.element = Objects.requireNonNull(element);
+        this.validation = Objects.requireNonNull(validation);
+    }
+
+    public ValidatingLtrQueryBuilder(StreamInput input, LtrRankerParserFactory factory) throws IOException {
+        super(input);
+        // XXX: hack because AbstractQueryTest does not inject
+        // our NamedWriteable to the context.
+        String type = input.readString();
+        final Reader<StorableElement> reader;
+        switch(type) {
+            case StoredFeature.TYPE:
+                reader = StoredFeature::new;
+                break;
+            case StoredFeatureSet.TYPE:
+                reader = StoredFeatureSet::new;
+                break;
+            case StoredLtrModel.TYPE:
+                reader = StoredLtrModel::new;
+                break;
+            default: throw new IOException("Unsupported storable element [" + type + "]");
+        }
+        this.element = reader.read(input);
+        this.validation = new FeatureValidation(input);
+        this.factory = factory;
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(element.getWriteableName());
+        element.writeTo(out);
+        validation.writeTo(out);
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(NAME);
+        builder.field(element.type(), element);
+        builder.field(VALIDATION.getPreferredName(), validation);
+        printBoostAndQueryName(builder);
+        builder.endObject();
+    }
+
+    public static Optional<ValidatingLtrQueryBuilder> fromXContent(QueryParseContext context,
+                                                                   LtrRankerParserFactory factory) throws IOException {
+        XContentParser parser = context.parser();
+        try {
+            ValidatingLtrQueryBuilder builder = new ValidatingLtrQueryBuilder(factory);
+            PARSER.parse(parser, builder, context);
+            if (builder.element == null) {
+                throw new ParsingException(parser.getTokenLocation(), "Element of type [" + SUPPORTED_TYPES.stream().collect(joining(",")) +
+                    "] is mandatory.");
+            }
+            if (builder.validation == null) {
+                throw new ParsingException(parser.getTokenLocation(), "Expected field [" + VALIDATION.getPreferredName() + "]");
+            }
+
+            return Optional.of(builder);
+        } catch (IllegalArgumentException iae) {
+            throw new ParsingException(parser.getTokenLocation(), iae.getMessage(), iae);
+        }
+    }
+
+    @Override
+    protected Query doToQuery(QueryShardContext context) throws IOException {
+        if (StoredFeature.TYPE.equals(element.type())) {
+            Feature feature = ((StoredFeature)element).optimize();
+            if (feature instanceof PrecompiledExpressionFeature) {
+                // Derived features cannot be tested alone
+                return new MatchAllDocsQuery();
+            }
+            return feature.doToQuery(context, null, validation.getParams());
+        } else if (StoredFeatureSet.TYPE.equals(element.type())) {
+            FeatureSet set = ((StoredFeatureSet)element).optimize();
+            LinearRanker ranker = new LinearRanker(new float[set.size()]);
+            CompiledLtrModel model = new CompiledLtrModel("validation", set, ranker);
+            return RankerQuery.build(model, context, validation.getParams());
+        } else if (StoredLtrModel.TYPE.equals(element.type())) {
+            CompiledLtrModel model = ((StoredLtrModel)element).compile(factory);
+            return RankerQuery.build(model, context, validation.getParams());
+        } else {
+            throw new QueryShardException(context, "Unknown element type [" + element.type() + "]" );
+        }
+    }
+
+    @Override
+    protected boolean doEquals(ValidatingLtrQueryBuilder other) {
+        return Objects.equals(element, other.element) &&
+                Objects.equals(validation, other.validation);
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(element, validation);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    public StorableElement getElement() {
+        return element;
+    }
+
+    public FeatureValidation getValidation() {
+        return validation;
+    }
+}

--- a/src/test/java/com/o19s/es/ltr/action/ValidatingFeatureStoreActionIT.java
+++ b/src/test/java/com/o19s/es/ltr/action/ValidatingFeatureStoreActionIT.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.action;
+
+import com.o19s.es.ltr.feature.FeatureValidation;
+import com.o19s.es.ltr.feature.store.StoredFeature;
+import com.o19s.es.ltr.feature.store.StoredFeatureSet;
+import com.o19s.es.ltr.feature.store.StoredLtrModel;
+import com.o19s.es.ltr.feature.store.index.IndexFeatureStore;
+import com.o19s.es.ltr.ranker.parser.LinearRankerParser;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.hamcrest.CoreMatchers;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static java.util.Collections.singletonList;
+import static org.hamcrest.CoreMatchers.instanceOf;
+
+public class ValidatingFeatureStoreActionIT extends BaseIntegrationTest {
+    public void testValidateFeature() throws ExecutionException, InterruptedException {
+        prepareTestIndex();
+        String brokenQuery = "{\"query\": {\"match\":{\"test\": \"{{query_string}}\"}}}";
+        StoredFeature feature = new StoredFeature("test", singletonList("query_string"), "mustache", brokenQuery);
+        Map<String, Object> params = new HashMap<>();
+        params.put("query_string", "a query");
+        Throwable e = expectThrows(ExecutionException.class,
+                () -> addElement(feature, new FeatureValidation("test_index", params))).getCause();
+        assertThat(e, instanceOf(IllegalArgumentException.class));
+        assertThat(e.getMessage(), CoreMatchers.containsString("Cannot store element, validation failed."));
+    }
+
+    public void testValidateFeatureSet() throws ExecutionException, InterruptedException {
+        prepareTestIndex();
+        String matchQuery = QueryBuilders.matchQuery("test", "{{query_string}}").toString();
+
+        StoredFeature feature = new StoredFeature("test", singletonList("query_string"), "mustache", matchQuery);
+        String brokenQuery = "{\"query\": {\"match\":{\"test\": \"{{query_string}}\"}}}";
+        StoredFeature brokenFeature = new StoredFeature("broken", singletonList("query_string"), "mustache", brokenQuery);
+        Map<String, Object> params = new HashMap<>();
+        params.put("query_string", "a query");
+        StoredFeatureSet brokenFeatureSet = new StoredFeatureSet("my_feature_set", Arrays.asList(feature, brokenFeature));
+        Throwable e = expectThrows(ExecutionException.class,
+                () -> addElement(brokenFeatureSet, new FeatureValidation("test_index", params))).getCause();
+        assertThat(e, instanceOf(IllegalArgumentException.class));
+        assertThat(e.getMessage(), CoreMatchers.containsString("Cannot store element, validation failed."));
+    }
+
+    public void testValidateModel() throws ExecutionException, InterruptedException {
+        prepareTestIndex();
+        String matchQuery = QueryBuilders.matchQuery("test", "{{query_string}}").toString();
+
+        StoredFeature feature = new StoredFeature("test", singletonList("query_string"), "mustache", matchQuery);
+        String brokenQuery = "{\"query\": {\"match\":{\"test\": \"{{query_string}}\"}}}";
+        StoredFeature brokenFeature = new StoredFeature("broken", singletonList("query_string"), "mustache", brokenQuery);
+        Map<String, Object> params = new HashMap<>();
+        params.put("query_string", "a query");
+        String model = "{\"test\": 2.1, \"broken\": 4.3}";
+        StoredLtrModel brokenModel = new StoredLtrModel("broken_model",
+                new StoredFeatureSet("my_feature_set", Arrays.asList(feature, brokenFeature)),
+                new StoredLtrModel.LtrModelDefinition(LinearRankerParser.TYPE, model, true));
+        Throwable e = expectThrows(ExecutionException.class, () -> addElement(brokenModel,
+                new FeatureValidation("test_index", params))).getCause();
+        assertThat(e, instanceOf(IllegalArgumentException.class));
+        assertThat(e.getMessage(), CoreMatchers.containsString("Cannot store element, validation failed."));
+    }
+
+    public void testValidationOnAddFeatureToSet() {
+        prepareTestIndex();
+        String matchQuery = QueryBuilders.matchQuery("test", "{{query_string}}").toString();
+
+        StoredFeature feature = new StoredFeature("test", singletonList("query_string"), "mustache", matchQuery);
+        String brokenQuery = "{\"query\": {\"match\":{\"test\": \"{{query_string}}\"}}}";
+        StoredFeature brokenFeature = new StoredFeature("broken", singletonList("query_string"), "mustache", brokenQuery);
+        Map<String, Object> params = new HashMap<>();
+        params.put("query_string", "a query");
+        AddFeaturesToSetAction.AddFeaturesToSetRequestBuilder request = AddFeaturesToSetAction.INSTANCE.newRequestBuilder(client());
+        request.request().setStore(IndexFeatureStore.DEFAULT_STORE);
+        request.request().setValidation(new FeatureValidation("test_index", params));
+        request.request().setFeatures(Arrays.asList(feature, brokenFeature));
+        request.request().setFeatureSet("my_feature_set");
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, request::get);
+        assertThat(e.getMessage(), CoreMatchers.containsString("Cannot store element, validation failed."));
+
+    }
+
+    public void testValidationOnCreateModelFromSet() throws ExecutionException, InterruptedException {
+        prepareTestIndex();
+        String matchQuery = QueryBuilders.matchQuery("test", "{{query_string}}").toString();
+
+        StoredFeature feature = new StoredFeature("test", singletonList("query_string"), "mustache", matchQuery);
+        String brokenQuery = "{\"query\": {\"match\":{\"test\": \"{{query_string}}\"}}}";
+        StoredFeature brokenFeature = new StoredFeature("broken", singletonList("query_string"), "mustache", brokenQuery);
+        Map<String, Object> params = new HashMap<>();
+        params.put("query_string", "a query");
+        StoredFeatureSet brokenFeatureSet = new StoredFeatureSet("my_feature_set", Arrays.asList(feature, brokenFeature));
+        // Store a broken feature set
+        addElement(brokenFeatureSet);
+        CreateModelFromSetAction.CreateModelFromSetRequestBuilder request = CreateModelFromSetAction.INSTANCE.newRequestBuilder(client());
+        request.request().setValidation(new FeatureValidation("test_index", params));
+        StoredLtrModel.LtrModelDefinition definition = new StoredLtrModel.LtrModelDefinition("model/linear",
+                "{\"test\": 2.1, \"broken\": 4.3}", true);
+        request.withoutVersion(IndexFeatureStore.DEFAULT_STORE, "my_feature_set", "broken_model", definition);
+        request.request().setValidation(new FeatureValidation("test_index", params));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, request::get);
+        assertThat(e.getMessage(), CoreMatchers.containsString("Cannot store element, validation failed."));
+
+    }
+
+    private void prepareTestIndex() {
+        client().admin().indices().prepareCreate("test_index").get();
+    }
+}

--- a/src/test/java/com/o19s/es/ltr/query/ValidatingLtrQueryBuilderTests.java
+++ b/src/test/java/com/o19s/es/ltr/query/ValidatingLtrQueryBuilderTests.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.query;
+
+import com.o19s.es.ltr.LtrQueryParserPlugin;
+import com.o19s.es.ltr.feature.FeatureValidation;
+import com.o19s.es.ltr.feature.store.StorableElement;
+import com.o19s.es.ltr.feature.store.StoredFeature;
+import com.o19s.es.ltr.feature.store.StoredFeatureSet;
+import com.o19s.es.ltr.feature.store.StoredLtrModel;
+import com.o19s.es.ltr.ranker.parser.LinearRankerParser;
+import com.o19s.es.ltr.ranker.parser.LtrRankerParserFactory;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.test.AbstractQueryTestCase;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.joining;
+import static org.hamcrest.CoreMatchers.instanceOf;
+
+public class ValidatingLtrQueryBuilderTests extends AbstractQueryTestCase<ValidatingLtrQueryBuilder> {
+    private final LtrRankerParserFactory factory = new LtrRankerParserFactory.Builder()
+            .register(LinearRankerParser.TYPE, LinearRankerParser::new)
+            .build();
+
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return singletonList(LtrQueryParserPlugin.class);
+    }
+
+    @Override
+    protected Set<String> getObjectsHoldingArbitraryContent() {
+        return new HashSet<>(asList(FeatureValidation.PARAMS.getPreferredName(),
+                StoredFeature.TEMPLATE.getPreferredName()));
+    }
+
+    /**
+     * Create the query that is being tested
+     */
+    @Override
+    protected ValidatingLtrQueryBuilder doCreateTestQueryBuilder() {
+        StorableElement element;
+        Function<String, StoredFeature> buildFeature = (n) ->  new StoredFeature(n,
+                asList("query_string"), "mustache",
+                QueryBuilders.matchQuery("test", "{{query_string}}").toString());
+        BiFunction<Integer, String, StoredFeatureSet> buildFeatureSet = (i, name) -> new StoredFeatureSet(name, IntStream.range(0, i)
+                .mapToObj((idx) -> buildFeature.apply("feature"+idx))
+                .collect(Collectors.toList()));
+        Function<String, StoredLtrModel> buildModel = (name) -> new StoredLtrModel(name,
+                buildFeatureSet.apply(5, "the_feature_set"),
+                "model/linear",
+                IntStream.range(0, 5)
+                        .mapToObj((i) -> "\"feature"+i+"\": " + random().nextFloat())
+                        .collect(joining(",", "{", "}")),
+                true);
+
+        int type = randomInt(2);
+        switch(type) {
+            case 0:
+                element = buildFeature.apply("feature");
+                break;
+            case 1:
+                element = buildFeatureSet.apply(randomInt(19) + 1, "featureset");
+                break;
+            case 2:
+                element = buildModel.apply("model");
+                break;
+            default:
+                throw new UnsupportedOperationException("Invalid type " + type);
+        }
+        Map<String, Object> params = new HashMap<>();
+        params.put("query_string", "hello world");
+        FeatureValidation val = new FeatureValidation("test_index", params);
+        return new ValidatingLtrQueryBuilder(element, val, factory);
+    }
+
+    @Override
+    protected boolean builderGeneratesCacheableQueries() {
+        return false;
+    }
+
+    @Override
+    protected boolean supportsBoostAndQueryName() {
+        return false;
+    }
+
+    @Override
+    protected void doAssertLuceneQuery(ValidatingLtrQueryBuilder queryBuilder, Query query, SearchContext context) throws IOException {
+        if (StoredFeature.TYPE.equals(queryBuilder.getElement().type())) {
+            assertThat(query, instanceOf(BooleanQuery.class));
+        } else if (StoredFeatureSet.TYPE.equals(queryBuilder.getElement().type())) {
+            assertThat(query, instanceOf(RankerQuery.class));
+            RankerQuery q = (RankerQuery) query;
+            assertEquals(queryBuilder.getElement().name(), q.featureSet().name());
+        } else if (StoredLtrModel.TYPE.equals(queryBuilder.getElement().type())) {
+            assertThat(query, instanceOf(RankerQuery.class));
+            RankerQuery q = (RankerQuery) query;
+            assertEquals(((StoredLtrModel)queryBuilder.getElement()).featureSet().name(), q.featureSet().name());
+        } else {
+            throw new AssertionError("Invalid storable element type : " + queryBuilder.getElement().type());
+        }
+    }
+}

--- a/src/test/resources/rest-api-spec/test/fstore/20_features.yaml
+++ b/src/test/resources/rest-api-spec/test/fstore/20_features.yaml
@@ -7,6 +7,7 @@
         ltr.create_feature:
            name: my_feature
            body:
+            feature:
               name: my_feature
               params:
                  - query_string
@@ -29,6 +30,7 @@
         ltr.create_feature:
            name: my_feature
            body:
+            feature:
               name: my_feature
               params:
                  - query_string2
@@ -40,6 +42,7 @@
         ltr.update_feature:
            name: my_feature
            body:
+            feature:
               name: my_feature
               params:
                  - query_string2
@@ -96,6 +99,7 @@
            store: mystore
            name: my_feature
            body:
+            feature:
               name: my_feature
               params:
                  - query_string
@@ -120,6 +124,7 @@
            store: mystore
            name: my_feature
            body:
+            feature:
               name: my_feature
               params:
                  - query_string
@@ -132,6 +137,7 @@
            store: mystore
            name: my_feature
            body:
+            feature:
               name: my_feature
               params:
                  - query_string

--- a/src/test/resources/rest-api-spec/test/fstore/30_featuresets.yaml
+++ b/src/test/resources/rest-api-spec/test/fstore/30_featuresets.yaml
@@ -7,6 +7,7 @@
         ltr.create_featureset:
            name: my_featureset
            body:
+            featureset:
               name: my_featureset
               features:
                   - name: feature1
@@ -30,6 +31,7 @@
         ltr.create_featureset:
            name: my_featureset
            body:
+            featureset:
               name: my_featureset
               features:
                   - name: feature1
@@ -47,6 +49,7 @@
         ltr.update_featureset:
            name: my_featureset
            body:
+            featureset:
               name: my_featureset
               features:
                   - name: feature1
@@ -109,6 +112,7 @@
            store: mystore
            name: my_featureset
            body:
+            featureset:
               name: my_featureset
               features:
                   - name: feature1
@@ -134,6 +138,7 @@
            store: mystore
            name: my_featureset
            body:
+            featureset:
               name: my_featureset
               features:
                   - name: feature1
@@ -152,6 +157,7 @@
            store: mystore
            name: my_featureset
            body:
+            featureset:
               name: my_featureset
               features:
                   - name: feature1

--- a/src/test/resources/rest-api-spec/test/fstore/40_models.yaml
+++ b/src/test/resources/rest-api-spec/test/fstore/40_models.yaml
@@ -7,6 +7,7 @@
         ltr.create_model:
            name: my_model
            body:
+            model:
               name: my_model
               feature_set:
                 name: my_set
@@ -43,6 +44,7 @@
         ltr.update_model:
            name: my_model
            body:
+            model:
               name: my_model
               feature_set:
                 name: my_set
@@ -102,6 +104,7 @@
            store: mystore
            name: my_model
            body:
+            model:
               name: my_model
               feature_set:
                 name: my_set
@@ -140,6 +143,7 @@
            store: mystore
            name: my_model
            body:
+            model:
               name: my_model
               feature_set:
                 name: my_set

--- a/src/test/resources/rest-api-spec/test/fstore/50_add_features_to_set.yaml
+++ b/src/test/resources/rest-api-spec/test/fstore/50_add_features_to_set.yaml
@@ -7,6 +7,7 @@
         ltr.create_feature:
            name: my_feature1
            body:
+            feature:
               name: my_feature1
               params:
                  - query_string
@@ -18,6 +19,7 @@
         ltr.create_feature:
            name: my_feature2
            body:
+            feature:
               name: my_feature2
               params:
                  - query_string
@@ -29,6 +31,7 @@
         ltr.create_feature:
            name: another_feature
            body:
+            feature:
               name: another_feature
               params:
                  - query_string
@@ -97,6 +100,7 @@
            store: mystore
            name: another_feature
            body:
+            feature:
               name: another_feature
               params:
                  - query_string
@@ -127,17 +131,6 @@
 "Append/merge features to set on the default store with a list":
   - do:
         ltr.create_store: {}
-
-  - do:
-        ltr.create_feature:
-          name: another_feature
-          body:
-              name: another_feature
-              params:
-                - query_string
-              template:
-                match:
-                  field_test_other: "{{query_string}}"
 
   - do:
         ltr.add_features_to_set:

--- a/src/test/resources/rest-api-spec/test/fstore/60_create_model_from_set.yaml
+++ b/src/test/resources/rest-api-spec/test/fstore/60_create_model_from_set.yaml
@@ -7,23 +7,25 @@
         ltr.create_featureset:
            name: my_featureset
            body:
+            featureset:
               name: my_featureset
               features:
                   - name: feature1
                     params: query_string
                     template:
                       match:
-                      field_test1: "{{query_string}}"
+                        field_test1: "{{query_string}}"
                   - name: feature2
                     params: query_string
                     template:
                       match:
-                      field_test2: "{{query_string}}"
+                        field_test2: "{{query_string}}"
 
   - do:
         ltr.create_model_from_set:
             name: my_featureset
             body:
+              model:
                 name: my_model
                 model:
                   type: model/linear
@@ -40,6 +42,7 @@
         ltr.create_model_from_set:
             name: my_featureset
             body:
+              model:
                 name: my_model
                 model:
                   type: model/linear
@@ -58,24 +61,26 @@
            store: mystore
            name: my_featureset
            body:
+            featureset:
               name: my_featureset
               features:
                   - name: feature1
                     params: query_string
                     template:
                       match:
-                      field_test1: "{{query_string}}"
+                        field_test1: "{{query_string}}"
                   - name: feature2
                     params: query_string
                     template:
                       match:
-                      field_test2: "{{query_string}}"
+                        field_test2: "{{query_string}}"
 
   - do:
         ltr.create_model_from_set:
             store: mystore
             name: my_featureset
             body:
+              model:
                 name: my_model
                 model:
                   type: model/linear
@@ -93,6 +98,7 @@
             store: mystore
             name: my_featureset
             body:
+              model:
                 name: my_model
                 model:
                   type: model/linear

--- a/src/test/resources/rest-api-spec/test/fstore/70_validation.yaml
+++ b/src/test/resources/rest-api-spec/test/fstore/70_validation.yaml
@@ -1,0 +1,174 @@
+---
+"Validate feature":
+  - do:
+        ltr.create_store: {}
+  - do:
+        indices.create:
+          index: test_index
+
+  - do:
+        catch: /Cannot store element, validation failed/
+        ltr.create_feature:
+           name: my_feature
+           body:
+            feature:
+              name: my_feature
+              params:
+                 - query_string
+              template:
+                broken_query:
+                  field_test: "{{query_string}}"
+            validation:
+              index: test_index
+              params:
+                query_string: test query
+
+---
+"Validate featureset":
+  - do:
+        ltr.create_store: {}
+  - do:
+        indices.create:
+          index: test_index
+
+  - do:
+        catch: /Cannot store element, validation failed/
+        ltr.create_featureset:
+           name: my_featureset
+           body:
+            featureset:
+              name: my_featureset
+              features:
+                  - name: feature1
+                    params: query_string
+                    template:
+                      broken_query:
+                      field_test: "{{query_string}}"
+            validation:
+              index: test_index
+              params:
+                query_string: test query
+
+---
+"Validate model":
+  - do:
+        ltr.create_store: {}
+  - do:
+        indices.create:
+          index: test_index
+
+  - do:
+        catch: /Cannot store element, validation failed/
+        ltr.create_model:
+           name: my_model
+           body:
+            model:
+              name: my_model
+              feature_set:
+                name: my_set
+                features:
+                  - name: feature1
+                    params: query_string
+                    template:
+                      match:
+                        field_test: "{{query_string}}"
+                  - name: feature2
+                    params: query_string
+                    template:
+                      broken_query:
+                        field_test2: "{{query_string}}"
+              model:
+                type: model/linear
+                definition:
+                    feature1: 1.2
+                    feature2: 0.2
+            validation:
+              index: test_index
+              params:
+                query_string: test query
+
+---
+"Validate on add features to set":
+  - do:
+        ltr.create_store: {}
+  - do:
+        indices.create:
+          index: test_index
+
+  - do:
+        ltr.create_feature:
+           name: my_feature1
+           body:
+            feature:
+              name: my_feature1
+              params:
+                 - query_string
+              template:
+                match:
+                  field_test1: "{{query_string}}"
+
+  - do:
+        ltr.create_feature:
+           name: my_feature2
+           body:
+            feature:
+              name: my_feature2
+              params:
+                 - query_string
+              template:
+                broken_query:
+                  field_test2: "{{query_string}}"
+
+  - do:
+        catch: /Cannot store element, validation failed/
+        ltr.add_features_to_set:
+            name: my_generated_set
+            query: my_feature*
+            body:
+              validation:
+                index: test_index
+                params:
+                  query_string: test query
+
+---
+"Validate on create model from set":
+  - do:
+        ltr.create_store: {}
+  - do:
+        indices.create:
+          index: test_index
+
+  - do:
+        ltr.create_featureset:
+           name: my_featureset
+           body:
+            featureset:
+              name: my_featureset
+              features:
+                  - name: feature1
+                    params: query_string
+                    template:
+                      match:
+                        field_test1: "{{query_string}}"
+                  - name: feature2
+                    params: query_string
+                    template:
+                      broken_query:
+                        field_test2: "{{query_string}}"
+
+  - do:
+        catch: /Cannot store element, validation failed/
+        ltr.create_model_from_set:
+            name: my_featureset
+            body:
+              model:
+                name: my_model
+                model:
+                  type: model/linear
+                  definition:
+                    feature1: 1.3
+                    feature2: 0.3
+              validation:
+                index: test_index
+                params:
+                  query_string: test query


### PR DESCRIPTION
Introduce a new json block to ask the plugin to fully validate features
prior to storing elements.
This still requires the user to explicitly set the "validation" which
contains the information needed to validate features:
- the index to run the query on (for mapping validation in some cases)
- the template param values

NOTE: that I had to change the body format to include the new "validation".
See changes in the docs folder for more details.

It might be interesting (1.1?) to add a new specific rest endpoint to validate
stored features/set/models.

closes #84