### PR TITLE
Prevent creating feature stores with ambiguous names

### DIFF
--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -15,6 +15,8 @@ Initialize a custom store:
 PUT /_ltr/custom
 ```
 
+NOTE: the name of the store must be a valid index name and must not use the words `feature`, `featureset` or `model` to avoid confusion with the rest of the API.
+
 List feature stores:
 ```
 GET /_ltr

--- a/src/main/java/com/o19s/es/ltr/action/TransportFeatureStoreAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportFeatureStoreAction.java
@@ -68,6 +68,7 @@ public class TransportFeatureStoreAction extends HandledTransportAction<FeatureS
         throw new UnsupportedOperationException("attempt to execute a TransportFeatureStoreAction without a task");
     }
 
+    @Override
     protected void doExecute(Task task, FeatureStoreRequest request, ActionListener<FeatureStoreResponse> listener) {
         if (!clusterService.state().routingTable().hasIndex(request.getStore())) {
             // To prevent index auto creation

--- a/src/main/java/com/o19s/es/ltr/rest/RestSimpleFeatureStore.java
+++ b/src/main/java/com/o19s/es/ltr/rest/RestSimpleFeatureStore.java
@@ -153,6 +153,9 @@ public abstract class RestSimpleFeatureStore extends FeatureStoreBaseRestHandler
         protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
             String indexName = indexName(request);
             if (request.method() == RestRequest.Method.PUT) {
+                if (request.hasParam("store")) {
+                    IndexFeatureStore.validateFeatureStoreName(request.param("store"));
+                }
                 return createIndex(client, indexName);
             } else if (request.method() == RestRequest.Method.DELETE) {
                 return deleteIndex(client, indexName);

--- a/src/test/resources/rest-api-spec/api/ltr.clear_cache.json
+++ b/src/test/resources/rest-api-spec/api/ltr.clear_cache.json
@@ -1,6 +1,6 @@
 {
   "ltr.clear_cache": {
-    "methods" : ["PUT"],
+    "methods" : ["POST"],
     "url": {
       "paths": ["/_ltr/_clearcache", "/_ltr/{store}/_clearcache"],
       "parts": {

--- a/src/test/resources/rest-api-spec/test/fstore/10_manage.yaml
+++ b/src/test/resources/rest-api-spec/test/fstore/10_manage.yaml
@@ -81,3 +81,15 @@
   - match: { stores._default_.index: .ltrstore }
   - match: { stores.mystore.version: 1 }
   - match: { stores.mystore.index: .ltrstore_mystore }
+
+---
+"Create invalid custom stores":
+  - do:
+        catch: /A featurestore name cannot be based on the words \[feature\], \[featureset\] and \[model\]/
+        ltr.create_store:
+            store: feature
+
+  - do:
+        catch: /Invalid feature store name/
+        ltr.create_store:
+            store: mystore#15


### PR DESCRIPTION
Names based on feature, featureset and model are forbidden.
Make sure that the store name is a valid index name as well.

closes #80