### PR TITLE
Returns a 404 when issuing a GET on a missing store

### DIFF
--- a/src/test/resources/rest-api-spec/api/ltr.get_store.json
+++ b/src/test/resources/rest-api-spec/api/ltr.get_store.json
@@ -1,0 +1,16 @@
+{
+  "ltr.get_store": {
+    "methods" : ["GET"],
+    "url": {
+      "paths": ["/_ltr/{store}"],
+      "parts": {
+        "store": {
+          "type": "string",
+          "required": true,
+          "description": "The store name"
+        }
+      }
+    },
+    "body": null
+  }
+}

--- a/src/test/resources/rest-api-spec/test/fstore/10_manage.yaml
+++ b/src/test/resources/rest-api-spec/test/fstore/10_manage.yaml
@@ -31,6 +31,12 @@
   - is_true: ''
 
   - do:
+        ltr.get_store:
+            store: mystore
+
+  - match: { exists: true }
+
+  - do:
         ltr.delete_store:
             store: mystore
 
@@ -39,6 +45,13 @@
             index: .ltrstore_mystore
 
   - is_false: ''
+
+  - do:
+        catch: missing
+        ltr.get_store:
+            store: mystore
+
+  - match: { exists: false }
 
 ---
 "Get cache stats":


### PR DESCRIPTION
Add a new GET endpoint to test if the store exists.
Only works for custom stores as GET /_ltr is already bound
to the list store action.

closes #67