### PR TITLE
Don't validate the whole index

### DIFF
--- a/src/main/java/com/o19s/es/ltr/action/TransportFeatureStoreAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportFeatureStoreAction.java
@@ -162,6 +162,8 @@ public class TransportFeatureStoreAction extends HandledTransportAction<FeatureS
         builder.setQuery(ltrBuilder);
         builder.setFrom(0);
         builder.setSize(20);
+        // Bail out early and don't score the whole index.
+        builder.setTerminateAfter(1000);
         builder.request().setParentTask(clusterService.localNode().getId(), task.getId());
         builder.execute(wrap((r) -> {
                 if (r.getFailedShards() > 0) {


### PR DESCRIPTION
The sltr query being unfiltered using a validation block with a large index can
be very slow. Use terminate_after to make sure we don't score all the docs in
the index.