### PR TITLE
[tests] Cleanup the cache before checking it

### DIFF
--- a/src/test/resources/rest-api-spec/test/fstore/10_manage.yaml
+++ b/src/test/resources/rest-api-spec/test/fstore/10_manage.yaml
@@ -59,11 +59,6 @@
         ltr.create_store: {}
 
   - do:
-        ltr.cache_stats: {}
-
-  - match: { all.total.ram: 0 }
-
-  - do:
         ltr.clear_cache: {}
 
   - is_true: ''


### PR DESCRIPTION
quick fix to avoid isolation problems between tests.
Would be better to integrate this cleanup more appropriately.