### PR TITLE
Fixes #118 properly handle cache state on store and model deletion

### DIFF
--- a/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
+++ b/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
@@ -42,6 +42,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.ScriptPlugin;
@@ -165,6 +166,13 @@ public class LtrQueryParserPlugin extends Plugin implements SearchPlugin, Script
     public Collection<Object> createComponents(Client client, ClusterService clusterService, ThreadPool threadPool,
                                                ResourceWatcherService resourceWatcherService, ScriptService scriptService,
                                                NamedXContentRegistry xContentRegistry) {
+        clusterService.addListener(event -> {
+            for (Index i : event.indicesDeleted()) {
+                if (IndexFeatureStore.isIndexStore(i.getName())) {
+                    caches.evict(i.getName());
+                }
+            }
+        });
         return asList(caches, parserFactory);
     }
 

--- a/src/main/java/com/o19s/es/ltr/rest/RestSimpleFeatureStore.java
+++ b/src/main/java/com/o19s/es/ltr/rest/RestSimpleFeatureStore.java
@@ -29,8 +29,10 @@ import static org.elasticsearch.rest.RestStatus.OK;
 import java.io.IOException;
 import java.util.List;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsResponse;
+import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.ParseField;
@@ -52,6 +54,7 @@ import org.elasticsearch.rest.action.RestBuilderListener;
 import org.elasticsearch.rest.action.RestStatusToXContentListener;
 import org.elasticsearch.rest.action.RestToXContentListener;
 
+import com.o19s.es.ltr.action.ClearCachesAction;
 import com.o19s.es.ltr.action.FeatureStoreAction;
 import com.o19s.es.ltr.action.ListStoresAction;
 import com.o19s.es.ltr.feature.FeatureValidation;
@@ -252,8 +255,35 @@ public abstract class RestSimpleFeatureStore extends FeatureStoreBaseRestHandler
         String name = request.param("name");
         String id = generateId(type, name);
         String routing = request.param("routing");
-        return (channel) ->  client.prepareDelete(indexName, ES_TYPE, id).setRouting(routing)
-                .execute(new RestStatusToXContentListener<>(channel, (r) -> r.getLocation(routing)));
+        return (channel) ->  {
+            RestStatusToXContentListener<DeleteResponse> restR = new RestStatusToXContentListener<>(channel, (r) -> r.getLocation(routing));
+            client.prepareDelete(indexName, ES_TYPE, id)
+                    .setRouting(routing)
+                    .execute(ActionListener.wrap((deleteResponse) -> {
+                            // wrap the response so we can send another request to clear the cache
+                            // usually we send only one transport request from the rest layer
+                            // it's still unclear which direction we should take (thick or thin REST layer?)
+                            ClearCachesAction.RequestBuilder clearCache = ClearCachesAction.INSTANCE.newRequestBuilder(client);
+                            switch (type) {
+                            case StoredFeature.TYPE:
+                                clearCache.request().clearFeature(indexName, name);
+                                break;
+                            case StoredFeatureSet.TYPE:
+                                clearCache.request().clearFeatureSet(indexName, name);
+                                break;
+                            case StoredLtrModel.TYPE:
+                                clearCache.request().clearModel(indexName, name);
+                                break;
+                            }
+                            clearCache.execute(ActionListener.wrap(
+                                    (r) -> restR.onResponse(deleteResponse),
+                                    // Is it good to fail the whole request if cache invalidation failed?
+                                    restR::onFailure
+                            ));
+                        },
+                        restR::onFailure
+                    ));
+        };
     }
 
     RestChannelConsumer get(NodeClient client, String type, String indexName, RestRequest request) {

--- a/src/test/resources/rest-api-spec/test/fstore/10_manage.yaml
+++ b/src/test/resources/rest-api-spec/test/fstore/10_manage.yaml
@@ -101,3 +101,58 @@
         catch: /Invalid feature store name/
         ltr.create_store:
             store: mystore#15
+
+---
+"Cache invalidation":
+  - do:
+        ltr.create_store:
+          store: custom
+
+  - do:
+        ltr.create_model:
+           store: custom
+           name: my_model
+           body:
+            model:
+              feature_set:
+                name: my_set
+                features:
+                  - name: feature1
+                    params: query_string
+                    template:
+                      match:
+                        field_test: "{{query_string}}"
+                  - name: feature2
+                    params: query_string
+                    template:
+                      match:
+                        field_test2: "{{query_string}}"
+              model:
+                type: model/linear
+                definition:
+                    feature1: 1.2
+                    feature2: 0.2
+
+  - do:
+      indices.create:
+          index:  test
+
+  - do:
+      search:
+        index: test
+        body: { query: { "sltr": { "params": {"query_string": "rambo"}, "model": "my_model", "store": "custom" } } }
+
+  - do:
+      ltr.cache_stats: {}
+
+  - gt: { all.total.ram: 0 }
+
+  - do:
+      indices.delete:
+          index: .ltrstore_custom
+
+  - do:
+        ltr.cache_stats: {}
+
+  - match : { all.total.ram: 0 }
+

--- a/src/test/resources/rest-api-spec/test/fstore/10_manage.yaml
+++ b/src/test/resources/rest-api-spec/test/fstore/10_manage.yaml
@@ -58,9 +58,6 @@
   - do:
         ltr.create_store: {}
 
-  - do:
-        ltr.clear_cache: {}
-
   - is_true: ''
 
   - do:
@@ -103,7 +100,7 @@
             store: mystore#15
 
 ---
-"Cache invalidation":
+"Deleting the store should invalidate the cache":
   - do:
         ltr.create_store:
           store: custom
@@ -156,3 +153,57 @@
 
   - match : { all.total.ram: 0 }
 
+---
+"Deleting the model should invalidate the cache":
+  - do:
+        ltr.create_store:
+          store: custom
+
+  - do:
+        ltr.create_model:
+           store: custom
+           name: my_model
+           body:
+            model:
+              feature_set:
+                name: my_set
+                features:
+                  - name: feature1
+                    params: query_string
+                    template:
+                      match:
+                        field_test: "{{query_string}}"
+                  - name: feature2
+                    params: query_string
+                    template:
+                      match:
+                        field_test2: "{{query_string}}"
+              model:
+                type: model/linear
+                definition:
+                    feature1: 1.2
+                    feature2: 0.2
+
+  - do:
+      indices.create:
+          index:  test
+
+  - do:
+      search:
+        index: test
+        body: { query: { "sltr": { "params": {"query_string": "rambo"}, "model": "my_model", "store": "custom" } } }
+
+  - do:
+      ltr.cache_stats: {}
+
+  - gt: { all.total.ram: 0 }
+
+  - do:
+      ltr.delete_model:
+         store: custom
+         name: my_model
+
+  - do:
+        ltr.cache_stats: {}
+
+  - match : { all.total.ram: 0 }


### PR DESCRIPTION
The cache was only properly maintained on UPDATE actions.
Add proper cache invalidation on:
- store deletion
- model/set/feature deletion

We still do not maintain the cache properly if the user attempts to change
the store content directly bypassing our rest endpoints (creating model
using the elasticsearch index API).

Fixes #118
  