### PR TITLE
X-Pack support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Build directory for read-the-docs
 /docs/_build/
 
+*.patch
+demo/*.jar
+demo/utils.pyc
+
 .envrc
 venv
 sample_judgements_wfeatures.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build directory for read-the-docs
 /docs/_build/
 
+*.patch
 .envrc
 venv
 sample_judgements_wfeatures.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Build directory for read-the-docs
 /docs/_build/
 
-*.patch
 .envrc
 venv
 sample_judgements_wfeatures.txt

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 }
 
 group = 'com.o19s'
-version = '1.0.0-RC2-es6.1.2'
+version = '1.0.1-es6.1.2'
 
 apply plugin: 'java'
 apply plugin: 'elasticsearch.esplugin'

--- a/demo/README.md
+++ b/demo/README.md
@@ -8,6 +8,18 @@ This demo requires
 
 - Python 3+
 - Python `elasticsearch` and `requests` libraries
+- Python `elasticsearch_xpack` libraries if xpack support is necessary
+
+## An aside: X Pack
+
+Using the LTR plugin with xpack requires configuring appropriate roles. These
+can be setup automatically by `prepare_xpack.py` which takes a username and
+will prompt for a password.  After this is run `settings.cfg` must be edited to
+uncomment the ESUser and ESPassword properties.
+
+```
+python prepare_xpack.py <xpack admin username>
+```
 
 ## Download the TMDB Data & Ranklib Jar
 

--- a/demo/collectFeatures.py
+++ b/demo/collectFeatures.py
@@ -81,7 +81,7 @@ def buildFeaturesJudgmentsFile(judgmentsWithFeatures, filename):
 
 if __name__ == "__main__":
     from judgments import judgmentsFromFile, judgmentsByQid
-    from elasticsearch import Elasticsearch
+    from utils import Elasticsearch
     es = Elasticsearch()
     judgmentsByQid = judgmentsByQid(judgmentsFromFile('sample_judgments.txt'))
     logFeatures(es, judgmentsByQid)

--- a/demo/indexMlTmdb.py
+++ b/demo/indexMlTmdb.py
@@ -5,7 +5,7 @@ def enrich(movie):
     if 'title' in movie:
         movie['title_sent'] = 'SENTINEL_BEGIN ' + movie['title']
 
-def reindex(es, analysisSettings={}, mappingSettings={}, movieDict={}, index='tmdb', esUrl='http://localhost:9200'):
+def reindex(es, analysisSettings={}, mappingSettings={}, movieDict={}, index='tmdb'):
     import elasticsearch.helpers
     settings = {
         "settings": {
@@ -36,15 +36,9 @@ def reindex(es, analysisSettings={}, mappingSettings={}, movieDict={}, index='tm
     elasticsearch.helpers.bulk(es, bulkDocs(movieDict))
 
 if __name__ == "__main__":
-    import configparser
-    from elasticsearch import Elasticsearch
+    from utils import Elasticsearch
     from sys import argv
 
-    config = configparser.ConfigParser()
-    config.read('settings.cfg')
-    esUrl=config['DEFAULT']['ESHost']
-    if len(argv) > 1:
-        esUrl = argv[1]
-    es = Elasticsearch(esUrl, timeout=30)
+    es = Elasticsearch(timeout=30)
     movieDict = json.loads(open('tmdb.json').read())
-    reindex(es, movieDict=movieDict, esUrl=esUrl)
+    reindex(es, movieDict=movieDict)

--- a/demo/loadFeatures.py
+++ b/demo/loadFeatures.py
@@ -1,6 +1,8 @@
 import json
 import requests
+from utils import ES_AUTH, ES_HOST
 from urllib.parse import urljoin
+
 
 def getFeature(ftrId):
     return json.loads(open('%s.json' % ftrId).read())
@@ -22,7 +24,7 @@ def eachFeature():
         pass
 
 
-def loadFeatures(esHost, featureSetName='movie_features'):
+def loadFeatures(featureSetName='movie_features'):
     featureSet = {
         "featureset": {
             "name": featureSetName,
@@ -30,30 +32,30 @@ def loadFeatures(esHost, featureSetName='movie_features'):
         }
     }
     path = "_ltr/_featureset/%s" % featureSetName
-    fullPath = urljoin(esHost, path)
+    fullPath = urljoin(ES_HOST, path)
     print("POST %s" % fullPath)
     print(json.dumps(featureSet, indent=2))
     head = {'Content-Type': 'application/json'}
-    resp = requests.post(fullPath, data=json.dumps(featureSet), headers=head)
+    resp = requests.post(fullPath, data=json.dumps(featureSet), headers=head, auth=ES_AUTH)
     print("%s" % resp.status_code)
     print("%s" % resp.text)
 
 
 
-def initDefaultStore(esHost):
-    path = urljoin(esHost, '_ltr')
+def initDefaultStore():
+    path = urljoin(ES_HOST, '_ltr')
     print("DELETE %s" % path)
-    resp = requests.delete(path)
+    resp = requests.delete(path, auth=ES_AUTH)
     print("%s" % resp.status_code)
     print("PUT %s" % path)
-    resp = requests.put(path)
+    resp = requests.put(path, auth=ES_AUTH)
     print("%s" % resp.status_code)
 
 
 
 if __name__ == "__main__":
     from time import sleep
-    esHost='http://localhost:9200'
-    initDefaultStore(esHost)
+    from utils import ES_HOST
+    initDefaultStore(ES_HOST)
     sleep(1)
-    loadFeatures(esHost)
+    loadFeatures(ES_HOST)

--- a/demo/loadFeatures.py
+++ b/demo/loadFeatures.py
@@ -55,7 +55,6 @@ def initDefaultStore():
 
 if __name__ == "__main__":
     from time import sleep
-    from utils import ES_HOST
-    initDefaultStore(ES_HOST)
+    initDefaultStore()
     sleep(1)
-    loadFeatures(ES_HOST)
+    loadFeatures()

--- a/demo/prepare_xpack.py
+++ b/demo/prepare_xpack.py
@@ -1,0 +1,46 @@
+from elasticsearch_xpack import XPackClient
+import getpass
+import sys
+from utils import Elasticsearch
+
+if __name__ == "__main__":
+    if len(sys.argv) == 2:
+        password = getpass.getpass()
+    elif len(sys.argv) == 3:
+        password = sys.argv[2]
+    else:
+        sys.exit(-1)
+
+    username = sys.argv[1]
+
+    es = Elasticsearch(http_auth=(username, password))
+    xpack = XPackClient(es)
+
+    print("Configure ltr_admin role:")
+    res = xpack.security.put_role('ltr_admin', {
+        "cluster": ["all"],
+        "indices": [ {
+            "names": [".ltrstore*"],
+            "privileges": ["all"]
+        } ]
+    })
+    print(res)
+
+    print("Configure tmdb role:")
+    res = xpack.security.put_role('tmdb', {
+        'indices': [ {
+            "names": ["tmdb"],
+            "privileges": ["all"]
+        } ]
+    })
+    print(res)
+
+    print("Configure ltr_demo user:")
+    res = xpack.security.put_user('ltr_demo', {
+        'password': 'changeme',
+        'roles': ['ltr_admin', "tmdb"]
+    })
+    print(res)
+
+    print("\nRoles and user created. Be sure to update settings.cfg")
+

--- a/demo/prepare_xpack.py
+++ b/demo/prepare_xpack.py
@@ -4,11 +4,13 @@ import sys
 from utils import Elasticsearch
 
 if __name__ == "__main__":
+    """This script set the default roles and users to run the LTR demo"""
     if len(sys.argv) == 2:
         password = getpass.getpass()
     elif len(sys.argv) == 3:
         password = sys.argv[2]
     else:
+        print("""prepare_xpack.py [elasticsearch.user] [elasticsearch.password]""")
         sys.exit(-1)
 
     username = sys.argv[1]
@@ -37,7 +39,7 @@ if __name__ == "__main__":
 
     print("Configure ltr_demo user:")
     res = xpack.security.put_user('ltr_demo', {
-        'password': 'changeme',
+        'password': 'elastic',
         'roles': ['ltr_admin', "tmdb"]
     })
     print(res)

--- a/demo/search.py
+++ b/demo/search.py
@@ -31,17 +31,13 @@ def ltrQuery(keywords, modelName):
 if __name__ == "__main__":
     import configparser
     from sys import argv
-    from elasticsearch import Elasticsearch
+    from utils import Elasticsearch
 
-    config = configparser.ConfigParser()
-    config.read('settings.cfg')
-    esUrl=config['DEFAULT']['ESHost']
-
-    es = Elasticsearch(esUrl, timeout=1000)
+    es = Elasticsearch(timeout=1000)
     model = "test_6"
     if len(argv) > 2:
         model = argv[2]
     results = es.search(index='tmdb', doc_type='movie', body=ltrQuery(argv[1], model))
     for result in results['hits']['hits']:
-             print(result['_source']['title'])
+        print(result['_source']['title'])
 

--- a/demo/settings.cfg
+++ b/demo/settings.cfg
@@ -1,2 +1,4 @@
 [DEFAULT]
 ESHost = http://localhost:9200
+ESUser = ltr_demo
+ESPassword = changeme

--- a/demo/settings.cfg
+++ b/demo/settings.cfg
@@ -1,4 +1,4 @@
 [DEFAULT]
 ESHost = http://localhost:9200
-ESUser = ltr_demo
-ESPassword = changeme
+//ESUser = ltr_demo
+//ESPassword = changeme

--- a/demo/train.py
+++ b/demo/train.py
@@ -13,11 +13,13 @@ def trainModel(judgmentsWithFeaturesFile, modelOutput, whichModel=6):
     pass
 
 
-def saveModel(esHost, scriptName, featureSet, modelFname):
+def saveModel(scriptName, featureSet, modelFname):
     """ Save the ranklib model in Elasticsearch """
     import requests
     import json
     from urllib.parse import urljoin
+    from utils import ES_AUTH, ES_HOST
+
     modelPayload = {
         "model": {
             "name": scriptName,
@@ -32,11 +34,11 @@ def saveModel(esHost, scriptName, featureSet, modelFname):
     with open(modelFname) as modelFile:
         modelContent = modelFile.read()
         path = "_ltr/_featureset/%s/_createmodel" % featureSet
-        fullPath = urljoin(esHost, path)
+        fullPath = urljoin(ES_HOST, path)
         modelPayload['model']['model']['definition'] = modelContent
         print("POST %s" % fullPath)
         head = {'Content-Type': 'application/json'}
-        resp = requests.post(fullPath, data=json.dumps(modelPayload), headers=head)
+        resp = requests.post(fullPath, data=json.dumps(modelPayload), headers=head, auth=ES_AUTH)
         print(resp.status_code)
         if (resp.status_code >= 300):
             print(resp.text)
@@ -47,17 +49,13 @@ def saveModel(esHost, scriptName, featureSet, modelFname):
 
 if __name__ == "__main__":
     import configparser
-    from elasticsearch import Elasticsearch
+    from utils import Elasticsearch, ES_HOST
     from judgments import judgmentsFromFile, judgmentsByQid
 
-    config = configparser.ConfigParser()
-    config.read('settings.cfg')
-    esUrl = config['DEFAULT']['ESHost']
-
-    es = Elasticsearch(esUrl, timeout=1000)
+    es = Elasticsearch(timeout=1000)
     # Load features into Elasticsearch
-    initDefaultStore(esUrl)
-    loadFeatures(esUrl)
+    initDefaultStore()
+    loadFeatures()
     # Parse a judgments
     movieJudgments = judgmentsByQid(judgmentsFromFile(filename='sample_judgments.txt'))
     # Use proposed Elasticsearch queries (1.json.jinja ... N.json.jinja) to generate a training set
@@ -77,4 +75,4 @@ if __name__ == "__main__":
         # 9, Linear Regression
         print("*** Training %s " % modelType)
         trainModel(judgmentsWithFeaturesFile='sample_judgments_wfeatures.txt', modelOutput='model.txt', whichModel=modelType)
-        saveModel(esHost=esUrl, scriptName="test_%s" % modelType, featureSet='movie_features', modelFname='model.txt')
+        saveModel(scriptName="test_%s" % modelType, featureSet='movie_features', modelFname='model.txt')

--- a/demo/train.py
+++ b/demo/train.py
@@ -1,7 +1,7 @@
 import os
 from collectFeatures import logFeatures, buildFeaturesJudgmentsFile
 from loadFeatures import initDefaultStore, loadFeatures
-
+from utils import Elasticsearch, ES_HOST, ES_AUTH
 
 def trainModel(judgmentsWithFeaturesFile, modelOutput, whichModel=6):
     # java -jar RankLib-2.6.jar -ranker 6 -train sample_judgments_wfeatures.txt -save model.txt
@@ -18,7 +18,6 @@ def saveModel(scriptName, featureSet, modelFname):
     import requests
     import json
     from urllib.parse import urljoin
-    from utils import ES_AUTH, ES_HOST
 
     modelPayload = {
         "model": {
@@ -49,7 +48,6 @@ def saveModel(scriptName, featureSet, modelFname):
 
 if __name__ == "__main__":
     import configparser
-    from utils import Elasticsearch, ES_HOST
     from judgments import judgmentsFromFile, judgmentsByQid
 
     es = Elasticsearch(timeout=1000)

--- a/demo/utils.py
+++ b/demo/utils.py
@@ -1,0 +1,22 @@
+import configparser
+import elasticsearch
+from requests.auth import HTTPBasicAuth
+
+__all__ = [ "ES_AUTH", "ES_HOST", "Elasticsearch" ]
+
+config = configparser.ConfigParser()
+config.read('settings.cfg')
+ES_HOST = config['DEFAULT']['ESHost']
+if 'ESUser' in config['DEFAULT']:
+    auth = (config['DEFAULT']['ESUser'], config['DEFAULT']['ESPassword'])
+    ES_AUTH = HTTPBasicAuth(*auth)
+else:
+    auth = None
+    ES_AUTH = None
+
+
+def Elasticsearch(url=None, timeout=1000, http_auth=auth):
+    if url is None:
+        url = ES_HOST
+    return elasticsearch.Elasticsearch(url, timeout=timeout, http_auth=http_auth)
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,7 @@ Contents
    logging-features
    training-models
    searching-with-your-model
+   x-pack
    advanced-functionality
    :caption: Contents:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ Pre-built versions can be found `here <http://es-learn-to-rank.labs.o19s.com/>`_
 
 (It's expected you'll confirm some security exceptions, you can pass -b to elasticsearch-plugin to automatically install)
 
+Are you using `x-pack security <https://www.elastic.co/products/x-pack/security>`_ in your cluster? we got you covered, check :doc:`x-pack` for specific configuration details.
 
 HEEELP!
 ------------------------------

--- a/docs/x-pack.rst
+++ b/docs/x-pack.rst
@@ -1,0 +1,76 @@
+Configuring X-Pack (Security)
+***********************
+
+X-Pack is the collection of extensions provided by elastic to enhance the capabilities of the Elastic Stack with things
+such as reporting, monitoring and also security. If you installed x-pack your cluster will now be protected with the
+security module, this will also be like this if you are using Elasticsearch through the Elastic Cloud solution.
+
+=====================================================
+Setup roles and users.
+=====================================================
+
+After installing the plugin, the first thing you will have to do is configure the necessary users and roles to access let
+the LTR plugin operate.
+
+We recommend you to create two separate roles, one for administrative task such as creating the models, updating the feature sets, etc ..
+and one to run the queries.
+
+For this configuration, we supose you already have identified, and created two users, one for running queries and one for doing administrative tasks. If you
+need help to create the users, we recommend you to check the `x-pack api documentation for user management <https://www.elastic.co/guide/en/elasticsearch/reference/6.1/security-api-users.html>`_.
+
+
+To create the two roles, you can do it with this commands,
+
+    POST /_xpack/security/role/ltr_admin
+    {
+        "cluster": [ "ltr" ],
+        "indices": [
+            {
+                "names": [ ".ltrstore*" ],
+                "privileges": [ "all" ],
+            }
+        ]
+    }
+
+    POST /_xpack/security/role/ltr_query
+    {
+        "cluster": [ "ltr" ],
+        "indices": [
+            {
+                "names": [ ".ltrstore*" ],
+                "privileges": [ "read" ],
+            }
+        ]
+    }
+
+the first one will allow the users to perform all the operations while the last one will only allow for read operations.
+
+Once the roles are defined, the last step will be to attach this roles to existing users, for this documentation we will suppose
+two users, ltr_admin and ltr_user. The commands to set the roles are:
+
+
+    POST /_xpack/security/role_mapping/ltr_admins
+    {
+        "roles": [ "ltr_admin" ],
+        "rules": {
+            "field" : { "username" : [ "ltr_admin01", "ltr_admin02" ] }
+        },
+        "metadata" : {
+            "version" : 1
+        }
+    }
+
+    POST /_xpack/security/role_mapping/ltr_users
+    {
+        "roles": [ "ltr_query" ],
+        "rules": {
+            "field" : { "username" : [ "ltr_user01", "ltr_user02" ] }
+        },
+        "metadata" : {
+            "version" : 1
+        }
+    }
+
+After this two steps, your plugin will be fully functional in your x-pack protected cluster.
+
+For more in deep information on how to define roles, we recommend you to check the elastic `x-pack api documentation <https://www.elastic.co/guide/en/x-pack/6.1/defining-roles.html>`_.

--- a/docs/x-pack.rst
+++ b/docs/x-pack.rst
@@ -1,5 +1,5 @@
-Configuring X-Pack (Security)
-***********************
+On XPack Support (Security)
+*****************************
 
 X-Pack is the collection of extensions provided by elastic to enhance the capabilities of the Elastic Stack with things
 such as reporting, monitoring and also security. If you installed x-pack your cluster will now be protected with the
@@ -23,13 +23,13 @@ To create the two roles, you can do it with this commands,
 
     POST /_xpack/security/role/ltr_admin
     {
-        "cluster": [ "ltr" ],
-        "indices": [
-            {
-                "names": [ ".ltrstore*" ],
-                "privileges": [ "all" ],
-            }
-        ]
+      "cluster": [ "ltr" ],
+      "indices": [
+        {
+            "names": [ ".ltrstore*" ],
+            "privileges": [ "all" ],
+        }
+      ]
     }
 
     POST /_xpack/security/role/ltr_query

--- a/docs/x-pack.rst
+++ b/docs/x-pack.rst
@@ -74,3 +74,12 @@ two users, ltr_admin and ltr_user. The commands to set the roles are:
 After this two steps, your plugin will be fully functional in your x-pack protected cluster.
 
 For more in deep information on how to define roles, we recommend you to check the elastic `x-pack api documentation <https://www.elastic.co/guide/en/x-pack/6.1/defining-roles.html>`_.
+
+
+=====================================================
+Considerations
+=====================================================
+
+The read access to models via the sltr query is not strictly gated by x-pack. The access will only be checked if the model needs
+to be loaded, however If the model is already in the cache for that node no checks will be performed. This will generally not have
+a major security impact, however is important to take into account in case is important for your use case.

--- a/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
+++ b/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
@@ -171,11 +171,17 @@ public class LtrQueryParserPlugin extends Plugin implements SearchPlugin, Script
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
         return unmodifiableList(asList(
                 new ActionHandler<>(FeatureStoreAction.INSTANCE, TransportFeatureStoreAction.class),
+                new ActionHandler<>(FeatureStoreAction.BC_INSTANCE, TransportFeatureStoreAction.BC.class),
                 new ActionHandler<>(CachesStatsAction.INSTANCE, TransportCacheStatsAction.class),
+                new ActionHandler<>(CachesStatsAction.BC_INSTANCE, TransportCacheStatsAction.BC.class),
                 new ActionHandler<>(ClearCachesAction.INSTANCE, TransportClearCachesAction.class),
+                new ActionHandler<>(ClearCachesAction.BC_INSTANCE, TransportClearCachesAction.BC.class),
                 new ActionHandler<>(AddFeaturesToSetAction.INSTANCE, TransportAddFeatureToSetAction.class),
+                new ActionHandler<>(AddFeaturesToSetAction.BC_INSTANCE, TransportAddFeatureToSetAction.BC.class),
                 new ActionHandler<>(CreateModelFromSetAction.INSTANCE, TransportCreateModelFromSetAction.class),
-                new ActionHandler<>(ListStoresAction.INSTANCE, TransportListStoresAction.class)));
+                new ActionHandler<>(CreateModelFromSetAction.BC_INSTANCE, TransportCreateModelFromSetAction.BC.class),
+                new ActionHandler<>(ListStoresAction.INSTANCE, TransportListStoresAction.class),
+                new ActionHandler<>(ListStoresAction.BC_INSTANCE, TransportListStoresAction.BC.class)));
     }
 
     @Override

--- a/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
+++ b/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
@@ -171,17 +171,11 @@ public class LtrQueryParserPlugin extends Plugin implements SearchPlugin, Script
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
         return unmodifiableList(asList(
                 new ActionHandler<>(FeatureStoreAction.INSTANCE, TransportFeatureStoreAction.class),
-                new ActionHandler<>(FeatureStoreAction.BC_INSTANCE, TransportFeatureStoreAction.BC.class),
                 new ActionHandler<>(CachesStatsAction.INSTANCE, TransportCacheStatsAction.class),
-                new ActionHandler<>(CachesStatsAction.BC_INSTANCE, TransportCacheStatsAction.BC.class),
                 new ActionHandler<>(ClearCachesAction.INSTANCE, TransportClearCachesAction.class),
-                new ActionHandler<>(ClearCachesAction.BC_INSTANCE, TransportClearCachesAction.BC.class),
                 new ActionHandler<>(AddFeaturesToSetAction.INSTANCE, TransportAddFeatureToSetAction.class),
-                new ActionHandler<>(AddFeaturesToSetAction.BC_INSTANCE, TransportAddFeatureToSetAction.BC.class),
                 new ActionHandler<>(CreateModelFromSetAction.INSTANCE, TransportCreateModelFromSetAction.class),
-                new ActionHandler<>(CreateModelFromSetAction.BC_INSTANCE, TransportCreateModelFromSetAction.BC.class),
-                new ActionHandler<>(ListStoresAction.INSTANCE, TransportListStoresAction.class),
-                new ActionHandler<>(ListStoresAction.BC_INSTANCE, TransportListStoresAction.BC.class)));
+                new ActionHandler<>(ListStoresAction.INSTANCE, TransportListStoresAction.class)));
     }
 
     @Override

--- a/src/main/java/com/o19s/es/ltr/action/AddFeaturesToSetAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/AddFeaturesToSetAction.java
@@ -39,7 +39,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 public class AddFeaturesToSetAction extends Action<AddFeaturesToSetAction.AddFeaturesToSetRequest,
         AddFeaturesToSetAction.AddFeaturesToSetResponse, AddFeaturesToSetAction.AddFeaturesToSetRequestBuilder> {
     public static final AddFeaturesToSetAction INSTANCE = new AddFeaturesToSetAction();
-    public static final String NAME = "indices:data/write/ltr/store/add-features-to-set";
+    public static final String NAME = "cluster:admin/ltr/store/add-features-to-set";
 
     protected AddFeaturesToSetAction() {
         super(NAME);

--- a/src/main/java/com/o19s/es/ltr/action/AddFeaturesToSetAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/AddFeaturesToSetAction.java
@@ -39,7 +39,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 public class AddFeaturesToSetAction extends Action<AddFeaturesToSetAction.AddFeaturesToSetRequest,
         AddFeaturesToSetAction.AddFeaturesToSetResponse, AddFeaturesToSetAction.AddFeaturesToSetRequestBuilder> {
     public static final AddFeaturesToSetAction INSTANCE = new AddFeaturesToSetAction();
-    public static final String NAME = "ltr:store/add-features-to-set";
+    public static final String NAME = "cluster:admin/ltr/store/add-features-to-set";
 
     protected AddFeaturesToSetAction() {
         super(NAME);

--- a/src/main/java/com/o19s/es/ltr/action/AddFeaturesToSetAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/AddFeaturesToSetAction.java
@@ -39,7 +39,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 public class AddFeaturesToSetAction extends Action<AddFeaturesToSetAction.AddFeaturesToSetRequest,
         AddFeaturesToSetAction.AddFeaturesToSetResponse, AddFeaturesToSetAction.AddFeaturesToSetRequestBuilder> {
     public static final AddFeaturesToSetAction INSTANCE = new AddFeaturesToSetAction();
-    public static final String NAME = "cluster:admin/ltr/store/add-features-to-set";
+    public static final String NAME = "indices:data/write/ltr/store/add-features-to-set";
 
     protected AddFeaturesToSetAction() {
         super(NAME);

--- a/src/main/java/com/o19s/es/ltr/action/CachesStatsAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/CachesStatsAction.java
@@ -39,7 +39,7 @@ import java.util.Map;
 
 public class CachesStatsAction extends Action<CachesStatsAction.CachesStatsNodesRequest,
         CachesStatsAction.CachesStatsNodesResponse, CachesStatsAction.CacheStatsRequestBuilder> {
-    public static final String NAME = "ltr:caches/stats";
+    public static final String NAME = "cluster:admin/ltr/caches/stats";
     public static final CachesStatsAction INSTANCE = new CachesStatsAction();
 
     protected CachesStatsAction() {

--- a/src/main/java/com/o19s/es/ltr/action/CachesStatsAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/CachesStatsAction.java
@@ -39,7 +39,7 @@ import java.util.Map;
 
 public class CachesStatsAction extends Action<CachesStatsAction.CachesStatsNodesRequest,
         CachesStatsAction.CachesStatsNodesResponse, CachesStatsAction.CacheStatsRequestBuilder> {
-    public static final String NAME = "cluster:admin/ltr/caches/stats";
+    public static final String NAME = "indices:data/ltr/caches/stats";
     public static final CachesStatsAction INSTANCE = new CachesStatsAction();
 
     protected CachesStatsAction() {

--- a/src/main/java/com/o19s/es/ltr/action/CachesStatsAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/CachesStatsAction.java
@@ -39,7 +39,7 @@ import java.util.Map;
 
 public class CachesStatsAction extends Action<CachesStatsAction.CachesStatsNodesRequest,
         CachesStatsAction.CachesStatsNodesResponse, CachesStatsAction.CacheStatsRequestBuilder> {
-    public static final String NAME = "indices:data/ltr/caches/stats";
+    public static final String NAME = "cluster:admin/ltr/caches/stats";
     public static final CachesStatsAction INSTANCE = new CachesStatsAction();
 
     protected CachesStatsAction() {

--- a/src/main/java/com/o19s/es/ltr/action/ClearCachesAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/ClearCachesAction.java
@@ -37,7 +37,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 public class ClearCachesAction extends Action<ClearCachesAction.ClearCachesNodesRequest,
         ClearCachesAction.ClearCachesNodesResponse, ClearCachesAction.RequestBuilder> {
-    public static final String NAME = "ltr:caches";
+    public static final String NAME = "cluster:admin/ltr/caches";
     public static final ClearCachesAction INSTANCE = new ClearCachesAction();
 
     private ClearCachesAction() {

--- a/src/main/java/com/o19s/es/ltr/action/ClearCachesAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/ClearCachesAction.java
@@ -37,7 +37,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 public class ClearCachesAction extends Action<ClearCachesAction.ClearCachesNodesRequest,
         ClearCachesAction.ClearCachesNodesResponse, ClearCachesAction.RequestBuilder> {
-    public static final String NAME = "cluster:admin/ltr/caches";
+    public static final String NAME = "indices:admin/ltr/caches";
     public static final ClearCachesAction INSTANCE = new ClearCachesAction();
 
     private ClearCachesAction() {

--- a/src/main/java/com/o19s/es/ltr/action/ClearCachesAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/ClearCachesAction.java
@@ -37,7 +37,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 public class ClearCachesAction extends Action<ClearCachesAction.ClearCachesNodesRequest,
         ClearCachesAction.ClearCachesNodesResponse, ClearCachesAction.RequestBuilder> {
-    public static final String NAME = "indices:admin/ltr/caches";
+    public static final String NAME = "cluster:admin/ltr/caches";
     public static final ClearCachesAction INSTANCE = new ClearCachesAction();
 
     private ClearCachesAction() {

--- a/src/main/java/com/o19s/es/ltr/action/CreateModelFromSetAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/CreateModelFromSetAction.java
@@ -37,7 +37,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 public class CreateModelFromSetAction extends Action<CreateModelFromSetAction.CreateModelFromSetRequest,
         CreateModelFromSetAction.CreateModelFromSetResponse, CreateModelFromSetAction.CreateModelFromSetRequestBuilder> {
-    public static final String NAME = "ltr:store/create-model-from-set";
+    public static final String NAME = "cluster:admin/ltr/store/create-model-from-set";
     public static final CreateModelFromSetAction INSTANCE = new CreateModelFromSetAction();
 
     protected CreateModelFromSetAction() {

--- a/src/main/java/com/o19s/es/ltr/action/CreateModelFromSetAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/CreateModelFromSetAction.java
@@ -37,7 +37,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 public class CreateModelFromSetAction extends Action<CreateModelFromSetAction.CreateModelFromSetRequest,
         CreateModelFromSetAction.CreateModelFromSetResponse, CreateModelFromSetAction.CreateModelFromSetRequestBuilder> {
-    public static final String NAME = "indices:data/write/ltr/store/create-model-from-set";
+    public static final String NAME = "cluster:admin/ltr/store/create-model-from-set";
     public static final CreateModelFromSetAction INSTANCE = new CreateModelFromSetAction();
 
     protected CreateModelFromSetAction() {

--- a/src/main/java/com/o19s/es/ltr/action/CreateModelFromSetAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/CreateModelFromSetAction.java
@@ -37,7 +37,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 public class CreateModelFromSetAction extends Action<CreateModelFromSetAction.CreateModelFromSetRequest,
         CreateModelFromSetAction.CreateModelFromSetResponse, CreateModelFromSetAction.CreateModelFromSetRequestBuilder> {
-    public static final String NAME = "cluster:admin/ltr/store/create-model-from-set";
+    public static final String NAME = "indices:data/write/ltr/store/create-model-from-set";
     public static final CreateModelFromSetAction INSTANCE = new CreateModelFromSetAction();
 
     protected CreateModelFromSetAction() {

--- a/src/main/java/com/o19s/es/ltr/action/FeatureStoreAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/FeatureStoreAction.java
@@ -39,7 +39,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 public class FeatureStoreAction extends Action<FeatureStoreAction.FeatureStoreRequest,
         FeatureStoreAction.FeatureStoreResponse, FeatureStoreAction.FeatureStoreRequestBuilder> {
-    public static final String NAME = "indices:data/write/ltr/featurestore/data";
+    public static final String NAME = "cluster:admin/ltr/featurestore/data";
     public static final FeatureStoreAction INSTANCE = new FeatureStoreAction();
 
     protected FeatureStoreAction() {

--- a/src/main/java/com/o19s/es/ltr/action/FeatureStoreAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/FeatureStoreAction.java
@@ -39,7 +39,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 public class FeatureStoreAction extends Action<FeatureStoreAction.FeatureStoreRequest,
         FeatureStoreAction.FeatureStoreResponse, FeatureStoreAction.FeatureStoreRequestBuilder> {
-    public static final String NAME = "ltr:featurestore/data";
+    public static final String NAME = "cluster:admin/ltr/featurestore/data";
     public static final FeatureStoreAction INSTANCE = new FeatureStoreAction();
 
     protected FeatureStoreAction() {

--- a/src/main/java/com/o19s/es/ltr/action/FeatureStoreAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/FeatureStoreAction.java
@@ -39,7 +39,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 public class FeatureStoreAction extends Action<FeatureStoreAction.FeatureStoreRequest,
         FeatureStoreAction.FeatureStoreResponse, FeatureStoreAction.FeatureStoreRequestBuilder> {
-    public static final String NAME = "cluster:admin/ltr/featurestore/data";
+    public static final String NAME = "indices:data/write/ltr/featurestore/data";
     public static final FeatureStoreAction INSTANCE = new FeatureStoreAction();
 
     protected FeatureStoreAction() {

--- a/src/main/java/com/o19s/es/ltr/action/ListStoresAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/ListStoresAction.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 
 public class ListStoresAction extends Action<ListStoresAction.ListStoresActionRequest,
         ListStoresAction.ListStoresActionResponse,ListStoresAction.ListStoresActionRequestBuilder> {
-    public static final String NAME = "ltr:featurestore/list";
+    public static final String NAME = "cluster:admin/ltr/featurestore/list";
     public static final ListStoresAction INSTANCE = new ListStoresAction();
 
     private ListStoresAction() {

--- a/src/main/java/com/o19s/es/ltr/action/ListStoresAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/ListStoresAction.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 
 public class ListStoresAction extends Action<ListStoresAction.ListStoresActionRequest,
         ListStoresAction.ListStoresActionResponse,ListStoresAction.ListStoresActionRequestBuilder> {
-    public static final String NAME = "cluster:admin/ltr/featurestore/list";
+    public static final String NAME = "indices:data/read/ltr/featurestore/list";
     public static final ListStoresAction INSTANCE = new ListStoresAction();
 
     private ListStoresAction() {

--- a/src/main/java/com/o19s/es/ltr/action/ListStoresAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/ListStoresAction.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 
 public class ListStoresAction extends Action<ListStoresAction.ListStoresActionRequest,
         ListStoresAction.ListStoresActionResponse,ListStoresAction.ListStoresActionRequestBuilder> {
-    public static final String NAME = "indices:data/read/ltr/featurestore/list";
+    public static final String NAME = "cluster:admin/ltr/featurestore/list";
     public static final ListStoresAction INSTANCE = new ListStoresAction();
 
     private ListStoresAction() {


### PR DESCRIPTION
This is a follow-up PR growing on the basis of the great work created in #125.

* X Pack only allows our custom transport actions if we name them such
that they live inside the cluster management namespace. Rename them
all.
* Adjusted demo to support xpack. A support script creates
appropriate admin and user roles then creates an ltr admin user. The
rest of the scripts are adjusted to consistently use the host and
username from settings.cfg.
* Adjust documentation to include the need to setup the x-pack roles if under that use case.

Fixes #116