### PR TITLE
Fail when logging NaN values

### DIFF
--- a/src/main/java/com/o19s/es/ltr/logging/LtrLoggingException.java
+++ b/src/main/java/com/o19s/es/ltr/logging/LtrLoggingException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.logging;
+
+/**
+ * Error happening while logging feature values.
+ */
+public class LtrLoggingException extends RuntimeException {
+    public LtrLoggingException(String s) {
+        super(s);
+    }
+}


### PR DESCRIPTION
It can be extremely misleading to allow logging NaN as it creates
a log entry missing:false, value:NaN.
We should detect this behavior as soon as possible to warn the user
that their query is broken.

fixes #136