### PR TITLE
Add ES 6.2.1 support based on ES 6.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,12 +7,12 @@ buildscript {
   }
 
   dependencies {
-    classpath "org.elasticsearch.gradle:build-tools:6.2.2"
+    classpath "org.elasticsearch.gradle:build-tools:6.2.1"
   }
 }
 
 group = 'com.o19s'
-version = '1.0.1-es6.2.2'
+version = '1.0.1-es6.2.1'
 
 apply plugin: 'java'
 apply plugin: 'elasticsearch.esplugin'
@@ -52,10 +52,10 @@ dependencies {
   compile 'org.ow2.asm:asm:5.0.4'
   compile 'org.ow2.asm:asm-commons:5.0.4'
   compile 'org.ow2.asm:asm-tree:5.0.4'
-  compile 'org.elasticsearch:elasticsearch:6.2.2'
+  compile 'org.elasticsearch:elasticsearch:6.2.1'
   compile 'com.o19s:RankyMcRankFace:0.1.1'
   compile "com.github.spullara.mustache.java:compiler:0.9.3"
-  testCompile 'org.elasticsearch.test:framework:6.2.2'
+  testCompile 'org.elasticsearch.test:framework:6.2.1'
 }
 
 dependencyLicenses {

--- a/build.gradle
+++ b/build.gradle
@@ -7,12 +7,12 @@ buildscript {
   }
 
   dependencies {
-    classpath "org.elasticsearch.gradle:build-tools:6.1.2"
+    classpath "org.elasticsearch.gradle:build-tools:6.2.2"
   }
 }
 
 group = 'com.o19s'
-version = '1.0.1-es6.1.2'
+version = '1.0.1-es6.2.2'
 
 apply plugin: 'java'
 apply plugin: 'elasticsearch.esplugin'
@@ -52,10 +52,10 @@ dependencies {
   compile 'org.ow2.asm:asm:5.0.4'
   compile 'org.ow2.asm:asm-commons:5.0.4'
   compile 'org.ow2.asm:asm-tree:5.0.4'
-  compile 'org.elasticsearch:elasticsearch:6.1.2'
+  compile 'org.elasticsearch:elasticsearch:6.2.2'
   compile 'com.o19s:RankyMcRankFace:0.1.1'
   compile "com.github.spullara.mustache.java:compiler:0.9.3"
-  testCompile 'org.elasticsearch.test:framework:6.1.2'
+  testCompile 'org.elasticsearch.test:framework:6.2.2'
 }
 
 dependencyLicenses {

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   java:
-    version: oraclejdk8
+    version: oraclejdk9
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   java:
-    version: oraclejdk9
+    version: openjdk9
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -5,4 +5,4 @@ jobs:
           - image: circleci/openjdk:9-jdk-browsers
         steps:
             - checkout
-            - run: ./gradlew clean check
+            - run: ./gradlew clean check -Dtest.jvms=1

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,11 @@
-machine:
-  java:
-    version: openjdk9
+version: 2
 
-test:
-  override:
-    - ./gradlew clean check
+jobs:
+    build:
+        docker:
+          - image: circleci/openjdk:9-jdk-browsers
+
+    
+    steps:
+      - checkout
+      - ./gradlew clean check

--- a/circle.yml
+++ b/circle.yml
@@ -5,4 +5,4 @@ jobs:
           - image: circleci/openjdk:9-jdk-browsers
         steps:
             - checkout
-            - run: ./gradlew clean check -Dtest.jvms=1
+            - run: ./gradlew clean check -Dtests.jvms=1

--- a/circle.yml
+++ b/circle.yml
@@ -1,11 +1,8 @@
 version: 2
-
 jobs:
     build:
         docker:
           - image: circleci/openjdk:9-jdk-browsers
-
-    
     steps:
       - checkout
-      - ./gradlew clean check
+      - run: ./gradlew clean check

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,6 @@ jobs:
     build:
         docker:
           - image: circleci/openjdk:9-jdk-browsers
-    steps:
-      - checkout
-      - run: ./gradlew clean check
+        steps:
+            - checkout
+            - run: ./gradlew clean check

--- a/docs/x-pack.rst
+++ b/docs/x-pack.rst
@@ -18,8 +18,7 @@ and one to run the queries.
 For this configuration, we supose you already have identified, and created two users, one for running queries and one for doing administrative tasks. If you
 need help to create the users, we recommend you to check the `x-pack api documentation for user management <https://www.elastic.co/guide/en/elasticsearch/reference/6.1/security-api-users.html>`_.
 
-
-To create the two roles, you can do it with this commands,
+To create two roles, you can do it with these commands::
 
     POST /_xpack/security/role/ltr_admin
     {
@@ -43,11 +42,9 @@ To create the two roles, you can do it with this commands,
         ]
     }
 
-the first one will allow the users to perform all the operations while the last one will only allow for read operations.
+the first one will allow the users to perform all the operations while the last one will only allow read operations.
 
-Once the roles are defined, the last step will be to attach this roles to existing users, for this documentation we will suppose
-two users, ltr_admin and ltr_user. The commands to set the roles are:
-
+Once the roles are defined, the last step will be to attach this roles to existing users, for this documentation we will suppose two users, ltr_admin and ltr_user. The commands to set the roles are::
 
     POST /_xpack/security/role_mapping/ltr_admins
     {

--- a/src/main/java/com/o19s/es/explore/ExplorerQuery.java
+++ b/src/main/java/com/o19s/es/explore/ExplorerQuery.java
@@ -240,7 +240,7 @@ public class ExplorerQuery extends Query {
 
         @Override
         public boolean isCacheable(LeafReaderContext ctx) {
-            return true;
+            return this.weight.isCacheable(ctx);
         }
 
         @Override

--- a/src/main/java/com/o19s/es/explore/ExplorerQuery.java
+++ b/src/main/java/com/o19s/es/explore/ExplorerQuery.java
@@ -183,6 +183,12 @@ public class ExplorerQuery extends Query {
                 public Scorer scorer(LeafReaderContext context) throws IOException {
                     return new ConstantScoreScorer(this, constantScore, DocIdSetIterator.all(context.reader().maxDoc()));
                 }
+
+                @Override
+                public boolean isCacheable(LeafReaderContext ctx) {
+                    return true;
+                }
+
             };
         } else {
             return new ExplorerQuery.ExplorerWeight(searcher, needsScores);
@@ -217,6 +223,11 @@ public class ExplorerQuery extends Query {
                 }
             }
             return Explanation.noMatch("no matching term");
+        }
+
+        @Override
+        public boolean isCacheable(LeafReaderContext ctx) {
+            return true;
         }
 
         @Override

--- a/src/main/java/com/o19s/es/explore/ExplorerScorer.java
+++ b/src/main/java/com/o19s/es/explore/ExplorerScorer.java
@@ -15,21 +15,18 @@
  */
 package com.o19s.es.explore;
 
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Scorer;
-import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.Weight;
+
 import java.io.IOException;
 
 public class ExplorerScorer extends Scorer {
     private Scorer subScorer;
     private String type;
-    private LeafReaderContext context;
 
-    protected ExplorerScorer(Weight weight, LeafReaderContext context, String type, Scorer subScorer) {
+    protected ExplorerScorer(Weight weight, String type, Scorer subScorer) {
         super(weight);
-        this.context = context;
         this.type = type;
         this.subScorer = subScorer;
     }
@@ -41,13 +38,15 @@ public class ExplorerScorer extends Scorer {
         // Grab freq from subscorer, or the children if available
         if(subScorer.getChildren().size() > 0) {
             for(ChildScorer child : subScorer.getChildren()) {
+                assert child.child instanceof PostingsExplorerQuery.PostingsExplorerScorer;
                 if(child.child.docID() == docID()) {
-                    tf_stats.add(child.child.freq());
+                    tf_stats.add(child.child.score());
                 }
             }
         } else {
+            assert subScorer instanceof PostingsExplorerQuery.PostingsExplorerScorer;
             assert subScorer.docID() == docID();
-            tf_stats.add(subScorer.freq());
+            tf_stats.add(subScorer.score());
         }
 
         float retval = 0.0f;

--- a/src/main/java/com/o19s/es/explore/ExplorerScorer.java
+++ b/src/main/java/com/o19s/es/explore/ExplorerScorer.java
@@ -18,6 +18,7 @@ package com.o19s.es.explore;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.Weight;
 import java.io.IOException;
 
@@ -78,10 +79,6 @@ public class ExplorerScorer extends Scorer {
         return subScorer.docID();
     }
 
-    @Override
-    public int freq() throws IOException {
-        return subScorer.freq();
-    }
 
     @Override
     public DocIdSetIterator iterator() {

--- a/src/main/java/com/o19s/es/explore/PostingsExplorerQuery.java
+++ b/src/main/java/com/o19s/es/explore/PostingsExplorerQuery.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.explore;
+
+import com.o19s.es.ltr.utils.CheckedBiFunction;
+import org.apache.lucene.index.IndexReaderContext;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.ReaderUtil;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.index.TermContext;
+import org.apache.lucene.index.TermState;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Set;
+
+public class PostingsExplorerQuery extends Query {
+    private final Term term;
+    private final Type type;
+
+    PostingsExplorerQuery(Term term, Type type) {
+        this.term = Objects.requireNonNull(term);
+        this.type = Objects.requireNonNull(type);
+    }
+
+    @Override
+    public String toString(String field) {
+        StringBuilder buffer = new StringBuilder("postings_explorer(");
+        buffer.append(type.name()).append(", ");
+        if (!this.term.field().equals(field)) {
+            buffer.append(this.term.field());
+            buffer.append(":");
+        }
+
+        buffer.append(this.term.text());
+        buffer.append(")");
+        return buffer.toString();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return this.sameClassAs(obj)
+                && this.term.equals(((PostingsExplorerQuery)obj).term)
+                && this.type.equals(((PostingsExplorerQuery)obj).type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(classHash(), this.term, this.type);
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, boolean needsScores, float boost) throws IOException {
+        IndexReaderContext context = searcher.getTopReaderContext();
+        assert needsScores : "Should not be used in filtering mode";
+        return new PostingsExplorerWeight(this, this.term, TermContext.build(context, this.term), this.type);
+    }
+
+    /**
+     * Will eventually allow implementing more explorer techniques (e.g. some stats on positions)
+     */
+    enum Type implements CheckedBiFunction<Weight, TermsEnum, Scorer, IOException> {
+        // Extract TF from the postings
+        TF((weight, terms) -> new TFScorer(weight, terms.postings(null, PostingsEnum.FREQS)));
+
+        private final CheckedBiFunction<Weight, TermsEnum, Scorer, IOException> func;
+
+        Type(CheckedBiFunction<Weight, TermsEnum, Scorer, IOException> func) {
+            this.func = func;
+        }
+
+        @Override
+        public Scorer apply(Weight weight, TermsEnum termsEnum) throws IOException {
+            return func.apply(weight, termsEnum);
+        }
+    }
+
+    static class PostingsExplorerWeight extends Weight {
+        private final Term term;
+        private final TermContext termStates;
+        private final Type type;
+
+        PostingsExplorerWeight(Query query, Term term, TermContext termStates, Type type) {
+            super(query);
+            this.term = term;
+            this.termStates = termStates;
+            this.type = type;
+        }
+
+        @Override
+        public void extractTerms(Set<Term> terms) {
+            terms.add(term);
+        }
+
+        @Override
+        public Explanation explain(LeafReaderContext context, int doc) throws IOException {
+            Scorer scorer = this.scorer(context);
+            int newDoc = scorer.iterator().advance(doc);
+            if (newDoc == doc) {
+                return Explanation.match(scorer.score(), "weight(" + this.getQuery()  + " in doc " + newDoc + ")");
+            }
+            return Explanation.noMatch("no matching term" );
+        }
+
+        @Override
+        public Scorer scorer(LeafReaderContext context) throws IOException {
+            assert this.termStates != null && this.termStates.wasBuiltFor(ReaderUtil.getTopLevelContext(context));
+            TermState state = this.termStates.get(context.ord);
+            if (state == null) {
+                return null;
+            } else {
+                TermsEnum terms = context.reader().terms(this.term.field()).iterator();
+                terms.seekExact(this.term.bytes(), state);
+                return this.type.apply(this, terms);
+            }
+        }
+
+        @Override
+        public boolean isCacheable(LeafReaderContext ctx) {
+            return true;
+        }
+    }
+
+    public abstract static class PostingsExplorerScorer extends Scorer {
+        final PostingsEnum postingsEnum;
+
+        PostingsExplorerScorer(Weight weight, PostingsEnum postingsEnum) {
+            super(weight);
+            this.postingsEnum = postingsEnum;
+        }
+
+        @Override
+        public int docID() {
+            return this.postingsEnum.docID();
+        }
+
+        @Override
+        public DocIdSetIterator iterator() {
+            return this.postingsEnum;
+        }
+    }
+
+    static class TFScorer extends PostingsExplorerScorer {
+        TFScorer(Weight weight, PostingsEnum postingsEnum) {
+            super(weight, postingsEnum);
+        }
+
+        @Override
+        public float score() throws IOException {
+            return this.postingsEnum.freq();
+        }
+    }
+}

--- a/src/main/java/com/o19s/es/explore/StatisticsHelper.java
+++ b/src/main/java/com/o19s/es/explore/StatisticsHelper.java
@@ -76,7 +76,7 @@ public class StatisticsHelper {
         float temp = 0.0f;
         for(float a : data)
             temp += (a-mean)*(a-mean);
-        return temp/(data.size()-1);
+        return temp/data.size();
     }
 
     public float getStdDev() {

--- a/src/main/java/com/o19s/es/ltr/query/DerivedExpressionQuery.java
+++ b/src/main/java/com/o19s/es/ltr/query/DerivedExpressionQuery.java
@@ -53,9 +53,16 @@ public class DerivedExpressionQuery extends Query {
             // If scores are not needed simply return a constant score on all docs
             return new ConstantScoreWeight(this, boost) {
                 @Override
+                public boolean isCacheable(LeafReaderContext ctx) {
+                    return true;
+                }
+
+                @Override
                 public Scorer scorer(LeafReaderContext context) throws IOException {
                     return new ConstantScoreScorer(this, score(), DocIdSetIterator.all(context.reader().maxDoc()));
                 }
+
+
             };
         }
 
@@ -126,6 +133,10 @@ public class DerivedExpressionQuery extends Query {
             return Explanation.match((float) values.doubleValue(), "Evaluation of derived expression: " + expression.sourceText);
         }
 
+        @Override
+        public boolean isCacheable(LeafReaderContext ctx) {
+            return false;
+        }
     }
 
     static class DValScorer extends Scorer {
@@ -152,10 +163,10 @@ public class DerivedExpressionQuery extends Query {
         /**
          * Returns the freq of this Scorer on the current document
          */
-        @Override
-        public int freq() throws IOException {
-            return 1;
-        }
+//        @Override
+//        public int freq() throws IOException {
+//            return 1;
+//        }
 
         @Override
         public DocIdSetIterator iterator() {
@@ -197,6 +208,11 @@ public class DerivedExpressionQuery extends Query {
         }
 
         @Override
+        public DoubleValuesSource rewrite(IndexSearcher reader) throws IOException {
+            return this;
+        }
+
+        @Override
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
@@ -217,6 +233,11 @@ public class DerivedExpressionQuery extends Query {
                     "ordinal=" + ordinal +
                     ", vectorSupplier=" + vectorSupplier +
                     '}';
+        }
+
+        @Override
+        public boolean isCacheable(LeafReaderContext ctx) {
+            return false;
         }
     }
 }

--- a/src/main/java/com/o19s/es/ltr/query/NoopScorer.java
+++ b/src/main/java/com/o19s/es/ltr/query/NoopScorer.java
@@ -53,11 +53,6 @@ public class NoopScorer extends Scorer {
     }
 
     @Override
-    public int freq() throws IOException {
-        return 0;
-    }
-
-    @Override
     public DocIdSetIterator iterator() {
         return _noopIter;
     }

--- a/src/main/java/com/o19s/es/ltr/query/RankerQuery.java
+++ b/src/main/java/com/o19s/es/ltr/query/RankerQuery.java
@@ -174,6 +174,11 @@ public class RankerQuery extends Query {
                 public Scorer scorer(LeafReaderContext context) throws IOException {
                     return new ConstantScoreScorer(this, score(), DocIdSetIterator.all(context.reader().maxDoc()));
                 }
+
+                @Override
+                public boolean isCacheable(LeafReaderContext ctx) {
+                    return true;
+                }
             };
         }
         List<Weight> weights = new ArrayList<>(queries.size());
@@ -185,6 +190,13 @@ public class RankerQuery extends Query {
 
     public class RankerWeight extends Weight {
         private final List<Weight> weights;
+
+        @Override
+        public boolean isCacheable(LeafReaderContext ctx) {
+            // Only cachable if model doesn't change?
+            // I *think* it should be the case it should be true
+            return true;
+        }
 
         RankerWeight(List<Weight> weights) {
             super(RankerQuery.this);
@@ -294,10 +306,10 @@ public class RankerQuery extends Query {
                 return ranker.score(fv);
             }
 
-            @Override
-            public int freq() throws IOException {
-                return scorers.size();
-            }
+//            @Override
+//            public int freq() throws IOException {
+//                return scorers.size();
+//            }
 
             @Override
             public DocIdSetIterator iterator() {

--- a/src/main/java/com/o19s/es/ltr/query/RankerQuery.java
+++ b/src/main/java/com/o19s/es/ltr/query/RankerQuery.java
@@ -193,8 +193,10 @@ public class RankerQuery extends Query {
 
         @Override
         public boolean isCacheable(LeafReaderContext ctx) {
-            // Only cachable if model doesn't change?
-            // I *think* it should be the case it should be true
+            for (Weight w : weights) {
+                if (w.isCacheable(ctx) == false)
+                    return false;
+            }
             return true;
         }
 

--- a/src/main/java/com/o19s/es/ltr/utils/CheckedBiFunction.java
+++ b/src/main/java/com/o19s/es/ltr/utils/CheckedBiFunction.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.utils;
+
+@FunctionalInterface
+public interface CheckedBiFunction<T, U, R, E extends Exception> {
+    R apply(T var1, U var2) throws E;
+}

--- a/src/test/java/com/o19s/es/explore/StatisticsHelperTests.java
+++ b/src/test/java/com/o19s/es/explore/StatisticsHelperTests.java
@@ -32,7 +32,19 @@ public class StatisticsHelperTests extends LuceneTestCase {
         assertEquals(10.0f, stats.getMax(), 0.0f);
         assertEquals(-5.0f, stats.getMin(), 0.0f);
         assertEquals(2.5f, stats.getMean(), 0.0f);
-        assertEquals(6.45, stats.getStdDev(), 0.009f);
-        assertEquals(41.66f, stats.getVariance(), 0.009f);
+        assertEquals(5.59f, stats.getStdDev(), 0.009f);
+        assertEquals(31.25f, stats.getVariance(), 0.009f);
+    }
+
+    public void testSingleElement() throws Exception {
+        StatisticsHelper stats = new StatisticsHelper();
+
+        stats.add(42.0f);
+
+        assertEquals(42.0f, stats.getMax(), 0.0f);
+        assertEquals(42.0f, stats.getMin(), 0.0f);
+        assertEquals(42.0f, stats.getMean(), 0.0f);
+        assertEquals(0.0f, stats.getStdDev(), 0.0f);
+        assertEquals(0.0f, stats.getVariance(), 0.0f);
     }
 }


### PR DESCRIPTION
Merged in changes from master, then just did a `sed -i 's/6.2.2/6.2.1/g' build.gradle`. Strangely I had to unzip and re-zip the file before elasticsearch would install it. it was failing with:
> ERROR: `elasticsearch` directory is missing in the plugin zip

I'm assuming that was an issue with my build environment. Once I re-ziped it though, everything seemed to work fine.
It would help us out if this made it to http://es-learn-to-rank.labs.o19s.com/ quickly
#132 
