### PR TITLE
[doc] Use filter instead of must to avoid confusion

### DIFF
--- a/demo/collectFeatures.py
+++ b/demo/collectFeatures.py
@@ -4,7 +4,7 @@ logQuery = {
     "size": 100,
     "query": {
         "bool": {
-            "must": [
+            "filter": [
                 {
                     "terms": {
                         "_id": ["7555"]
@@ -51,7 +51,7 @@ def logFeatures(es, judgmentsByQid):
     for qid, judgments in judgmentsByQid.items():
         keywords = judgments[0].keywords
         docIds = [judgment.docId for judgment in judgments]
-        logQuery['query']['bool']['must'][0]['terms']['_id'] = docIds
+        logQuery['query']['bool']['filter'][0]['terms']['_id'] = docIds
         logQuery['query']['bool']['should'][0]['sltr']['params']['keywords'] = keywords
         print("POST")
         print(json.dumps(logQuery, indent=2))

--- a/docs/logging-features.rst
+++ b/docs/logging-features.rst
@@ -147,7 +147,6 @@ Finally the full request::
                     {
                         "terms": {
                             "_id": ["7555", "1370", "1369"]
-                        
                         }
                     },
                     {
@@ -158,7 +157,6 @@ Finally the full request::
                                 "keywords": "rambo"
                             }
                     }}
-                    
                 ]
             }
         },
@@ -329,15 +327,13 @@ We can log `other_movie_features` alongside a live production `more_movie_featur
     "query": {
         "bool": {
             "filter": [
-                {"sltr": {
-                        "_name": "logged_featureset",
-                        "featureset": "other_movie_features",
-                        "params": {
-                            "keywords": "rambo"
-                        }
-                    }}
-            ],
-            "must": [
+                { "sltr": {
+                    "_name": "logged_featureset",
+                    "featureset": "other_movie_features",
+                    "params": {
+                        "keywords": "rambo"
+                    }
+		}},
                 {"match": {
                     "_all": "rambo"
                 }}


### PR DESCRIPTION
in some examples we use a must clause while we really
want to filter. This can cause confusions about how
the plugin handles feature values.

closes #148