### PR TITLE
Update building-features.rst

### DIFF
--- a/docs/building-features.rst
+++ b/docs/building-features.rst
@@ -230,7 +230,7 @@ Because some model training libraries refer to features by name, Elasticsearch L
 Feature Sets are Lists
 ==========================
 
-You'll notice we *appended* to the feature set. Feature sets perhaps ought to be really called "lists." Each feature has an ordinal (it's place in the list) in addition to a name. Some LTR training applications, such as Ranklib, refer to a feature by ordinal (the "1st" feature, the "2nd" feature). Others more conveniently refer to the name. So you may need both/either. You'll see that when features are logged, they give you a list of features back to preserve the ordinal.
+You'll notice we *appended* to the feature set. Feature sets perhaps ought to be really called "lists." Each feature has an ordinal (its place in the list) in addition to a name. Some LTR training applications, such as Ranklib, refer to a feature by ordinal (the "1st" feature, the "2nd" feature). Others more conveniently refer to the name. So you may need both/either. You'll see that when features are logged, they give you a list of features back to preserve the ordinal.
 
 
 Next-up, we'll talk about some unique features the Elasticsearch LTR plugin allows with a few extra custom queries in :doc:`feature-engineering`.


### PR DESCRIPTION
typo in the bottom section, updating 'it's' to 'its' for a feature's ordinal