### PR TITLE
Add support for query time `variables` in `derived_expression`.

### DIFF
--- a/docs/building-features.rst
+++ b/docs/building-features.rst
@@ -67,6 +67,12 @@ You'll notice the :code:`{{keywords}}`, :code:`{{users_lat}}`, and :code:`{{user
 
 For now, we'll simply focus on typical keyword searches.
 
+=================
+Derived Features
+=================
+
+Features that build on top of other features are called derived features.  These can be expressed as `lucene expressions <http://lucene.apache.org/core/7_1_0/expressions/index.html?org/apache/lucene/expressions/js/package-summary.html>`_. They are recognized by :code:`"template_language": "derived_expression"`. Besides these can also take in query time variables of type `Number <https://docs.oracle.com/javase/8/docs/api/java/lang/Number.html>`_ as explained in :ref:`create-feature-set`.
+
 =============================
 Uploading and Naming Features
 =============================
@@ -102,6 +108,7 @@ Feature sets are where the action really happens in Elasticsearch LTR.
 
 A *feature set* is a set of features that has been grouped together for logging & model evaluation. You'll refer to feature sets when you want to log multiple feature values for offline training. You'll also create a model from a feature set, copying the feature set into model.
 
+.. _create-feature-set:
 
 ====================
 Create a feature set 
@@ -125,6 +132,14 @@ You can create a feature set simply by using a POST. To create it, you give a fe
                             "title": "{{keywords}}"
                         }
                     }
+                },
+                {
+                    "name": "title_query_boost",
+                    "params": [
+                        "some_multiplier"
+                    ],
+                    "template_language": "derived_expressions",
+                    "template": "title_query * some_multiplier"
                 }
             ]
        }

--- a/docs/searching-with-your-model.rst
+++ b/docs/searching-with-your-model.rst
@@ -44,8 +44,8 @@ More often, you'll execute your model on the top N of a baseline relevance query
                     }
                 }
             }
+        }
     }
-}
 
 Here we execute a query that limits the result set to documents that match "rambo". All the documents are scored based on Elasticsearch's default similarity (BM25). On top of those already reasonably relevant results we apply our model over the top 1000. 
 
@@ -56,7 +56,7 @@ Scoring on a subset of features with `sltr` (added in 1.0.1-es6.2.4)
 ====================================================================
 
 Sometimes you might want to execute your query on a subset of the features rather than use all the ones specified in the model. In this case the features not specified in :code:`active_features` list will not be scored upon. They will be marked as missing.
-You only need to specify the :code:`params` applicable to the :code:`active_features`. If you request a feature name that is not a part of the feature set assigned to that model the query will throw an error.
+You only need to specify the :code:`params` applicable to the :code:`active_features`. If you request a feature name that is not a part of the feature set assigned to that model the query will throw an error. ::
 
     POST tmdb/_search
     {
@@ -78,8 +78,8 @@ You only need to specify the :code:`params` applicable to the :code:`active_feat
                     }
                 }
             }
+        }
     }
-}
 
 Here we apply our model over the top 1000 results but only for the selected features which in this case is title_query
 

--- a/src/main/java/com/o19s/es/ltr/feature/store/PrecompiledExpressionFeature.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/PrecompiledExpressionFeature.java
@@ -26,36 +26,47 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
 
 public class PrecompiledExpressionFeature implements Feature, Accountable {
+
     public static final String TEMPLATE_LANGUAGE = "derived_expression";
 
     private static final long BASE_RAM_USED = RamUsageEstimator.shallowSizeOfInstance(PrecompiledExpressionFeature.class);
 
     private final String name;
     private final Expression expression;
+    private final Set<String> expressionVariables;
+    private final Collection<String> queryParams;
 
-    private PrecompiledExpressionFeature(String name, Expression expression) {
+    private PrecompiledExpressionFeature(String name, Expression expression, Collection<String> queryParams) {
         this.name = name;
         this.expression = expression;
+        this.queryParams = queryParams;
+        this.expressionVariables = new HashSet<>(Arrays.asList(this.expression.variables));
     }
 
     public static PrecompiledExpressionFeature compile(StoredFeature feature) {
         assert TEMPLATE_LANGUAGE.equals(feature.templateLanguage());
         Expression expr = (Expression) Scripting.compile(feature.template());
-        return new PrecompiledExpressionFeature(feature.name(), expr);
+        return new PrecompiledExpressionFeature(feature.name(), expr, feature.queryParams());
     }
 
     @Override
     public long ramBytesUsed() {
         return BASE_RAM_USED +
                 (Character.BYTES * name.length()) + NUM_BYTES_ARRAY_HEADER +
-                (((Character.BYTES * expression.sourceText.length()) + NUM_BYTES_ARRAY_HEADER)*2);
+                (((Character.BYTES * expression.sourceText.length()) + NUM_BYTES_ARRAY_HEADER) * 2);
     }
 
     @Override
@@ -65,31 +76,71 @@ public class PrecompiledExpressionFeature implements Feature, Accountable {
 
     @Override
     public Query doToQuery(LtrQueryContext context, FeatureSet set, Map<String, Object> params) {
-        return new DerivedExpressionQuery(set, expression);
+        List<String> missingParams = queryParams.stream()
+                .filter((x) -> params == null || !params.containsKey(x))
+                .collect(Collectors.toList());
+        if (!missingParams.isEmpty()) {
+            String names = missingParams.stream().collect(Collectors.joining(","));
+            throw new IllegalArgumentException("Missing required param(s): [" + names + "]");
+        }
+
+        Map<String, Double> queryParamValues = getQueryParamValues(params);
+        return new DerivedExpressionQuery(set, expression, queryParamValues);
+    }
+
+    /**
+     * If a param is an expression variable then we need to use it as {@link Expression#variables} in lucene expression exposed via Bindings
+     *
+     * @param params {@link Map<String, Double>} all query params across features.
+     * @return {@link Map<String, Double>} of {@link Expression#variables} names to params values.
+     */
+    private Map<String, Double> getQueryParamValues(Map<String, Object> params) {
+        Map<String, Double> queryParamValues = new HashMap<>();
+        for (String param : queryParams) {
+            if (expressionVariables.contains(param)) {
+                try {
+                    Number number = (Number) params.get(param);
+                    queryParamValues.put(param, number.doubleValue());
+                } catch (ClassCastException classCastException) {
+                    throw new IllegalArgumentException("parameter: " + param + " expected to be of type Double");
+                }
+            }
+        }
+        return queryParamValues;
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         PrecompiledExpressionFeature that = (PrecompiledExpressionFeature) o;
 
         return Objects.equals(name, that.name)
-                && Objects.equals(expression, that.expression);
+                && Objects.equals(expression, that.expression)
+                && Objects.equals(queryParams, that.queryParams)
+                && Objects.equals(expressionVariables, that.expressionVariables);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, expression);
+        return Objects.hash(name, expression, queryParams, expressionVariables);
     }
 
     @Override
     public void validate(FeatureSet set) {
-        for(String var : expression.variables) {
-            if(!set.hasFeature(var)) {
+        for (String var : expression.variables) {
+            if (!set.hasFeature(var) && !queryParams.contains(var)) {
                 throw new IllegalArgumentException("Derived feature [" + this.name + "] refers " +
-                        "to unknown feature: [" + var + "]");
+                        "to unknown feature or parameter: [" + var + "]");
+            }
+            if(set.hasFeature(var) && queryParams.contains(var)){
+                throw new IllegalArgumentException("Duplicate name " + var + " . " +
+                        "Cannot be used as both feature name and query parameter name");
             }
         }
     }


### PR DESCRIPTION
`derived_expression` did not allow for passing in query time variables. This change allows `derived_expression` to pass in query time parameters (only type:double) as `variables` in lucene expression. 

I simply reuse the existing `DerviedExpressionQuery` and modify the `getDoubleValuesSource` to emit a `DoubleValuesSource` if it happens to be a `queryParam`.

Example use case: We have one _mustached_feature_: `distance` and one _derived_feature_: `distance_with_some_multiplier` as follows

```
"features": [
      {
        "name": "distance",
        "params": [
          "distance_latitude",
          "distance_longitude"
        ],
        "template_language": "mustache",
        "template": {
          "function_score": {
            "script_score": {
              "script": {
                "lang": "native",
                "source": "feature_extractor",
                "params": {
                  "name": "distance",
                  "type": "distance",
                  "latitude": "{{distance_latitude}}",
                  "longitude": "{{distance_longitude}}"
                }
              }
            }
          }
        }
      },
     {
      "name": "distance_with_some_multiplier",
      "params": [
        "foo_one"
      ],
      "template_language": "derived_expression",
      "template": "distance * foo_one"
    }
  ]

```
Then we query it as follows:
```
{
	"query": {
			"bool": {
       "filter": {
				 "terms": {
					 "_id": ["1", "2"]
				 }}}
    },
    "rescore": {
        "query": {
           "rescore_query": {
            "sltr": {
							"model": "ltr_linear_derived_features",
							"params": {
								"distance_longitude": -79.715773,
								"distance_latitude": 43.638228,
								"foo_one": 10.20
							},
							"active_features": [ "distance", "distance_with_some_multiplier"]
            }
           }
        }
    }
}
```
