### PR TITLE
poc add derived feature support in native plugins. reuses poc from sha: d629523

### DIFF
--- a/docs/building-features.rst
+++ b/docs/building-features.rst
@@ -67,11 +67,19 @@ You'll notice the :code:`{{keywords}}`, :code:`{{users_lat}}`, and :code:`{{user
 
 For now, we'll simply focus on typical keyword searches.
 
+.. _derived-features:
+
 =================
 Derived Features
 =================
 
 Features that build on top of other features are called derived features.  These can be expressed as `lucene expressions <http://lucene.apache.org/core/7_1_0/expressions/index.html?org/apache/lucene/expressions/js/package-summary.html>`_. They are recognized by :code:`"template_language": "derived_expression"`. Besides these can also take in query time variables of type `Number <https://docs.oracle.com/javase/8/docs/api/java/lang/Number.html>`_ as explained in :ref:`create-feature-set`.
+
+=================
+Script Features
+=================
+These are essentially :ref:`derived-features`, having access to the :code:`feature_vector` but could be native or painless elasticsearch scripts rather than `lucene expressions <http://lucene.apache.org/core/7_1_0/expressions/index.html?org/apache/lucene/expressions/js/package-summary.html>`_. :code:`"template_language": "script_feature""` allows LTR to identify the templated script as a regular elasticsearch script e.g. native, painless, etc. The custom script has access to the feature_vector via the java `Map <https://docs.oracle.com/javase/8/docs/api/java/util/Map.html>`_ interface as explained in :ref:`create-feature-set`.
+
 
 =============================
 Uploading and Naming Features
@@ -140,6 +148,20 @@ You can create a feature set simply by using a POST. To create it, you give a fe
                     ],
                     "template_language": "derived_expressions",
                     "template": "title_query * some_multiplier"
+                },
+                {
+                    "name": "custom_title_query_boost",
+                    "params": [
+                        "some_multiplier"
+                    ],
+                    "template_language": "script_feature",
+                    "template": {
+                        "lang": "painless",
+                        "source": "params.feature_vector.get('title_query') * (long)params.some_multiplier",
+                        "params": {
+                            "some_multiplier": "some_multiplier"
+                        }
+                    }
                 }
             ]
        }

--- a/src/main/java/com/o19s/es/ltr/feature/store/FeatureSupplier.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/FeatureSupplier.java
@@ -1,0 +1,121 @@
+package com.o19s.es.ltr.feature.store;
+
+import com.o19s.es.ltr.feature.FeatureSet;
+import com.o19s.es.ltr.ranker.LtrRanker;
+
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.function.Supplier;
+
+
+public class FeatureSupplier extends AbstractMap<String, Float> implements Supplier<LtrRanker.FeatureVector> {
+    private Supplier<LtrRanker.FeatureVector> vectorSupplier;
+    private final FeatureSet featureSet;
+
+    FeatureSupplier(FeatureSet featureSet) {
+        this.featureSet = featureSet;
+    }
+
+    @Override
+    public LtrRanker.FeatureVector get() {
+        return vectorSupplier.get();
+    }
+
+    public void set(Supplier<LtrRanker.FeatureVector> supplier) {
+        this.vectorSupplier = supplier;
+    }
+
+    /**
+     * Returns {@code true} if this map contains a mapping for the specified
+     * featureName.
+     *
+     * @param featureName featureName whose presence in this map is to be tested
+     * @return {@code true} if this map contains a mapping for the specified
+     * featureName
+     * @throws ClassCastException if the key is of an inappropriate type for
+     *                            this map
+     */
+    @Override
+    public boolean containsKey(Object featureName) {
+        return featureSet.hasFeature((String) featureName);
+    }
+
+    /**
+     * Returns the score to which the specified featureName is mapped,
+     * or {@code null} if this map contains no mapping for the featureName.
+     *
+     * @param featureName the featureName whose associated score is to be returned
+     * @return the score to which the specified featureName is mapped, or
+     * {@code null} if this map contains no mapping for the key
+     */
+    @Override
+    public Float get(Object featureName) {
+        int featureOrdinal;
+        try {
+            featureOrdinal = featureSet.featureOrdinal((String) featureName);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+        return vectorSupplier.get().getFeatureScore(featureOrdinal);
+    }
+
+    /**
+     * Strictly speaking the only methods of this {@code Map} needed are
+     * containsKey and get. The remaining methods help fix issues like
+     * - deserialization of FEATURE_VECTOR parameter as a Map object
+     * - keeps editors like intellij happy when debugging e.g. providing introspection into Map object.
+     */
+
+    @Override
+    public Set<Entry<String, Float>> entrySet() {
+        return new AbstractSet<Entry<String, Float>>() {
+            @Override
+            public Iterator<Entry<String, Float>> iterator() {
+                return new Iterator<Entry<String, Float>>() {
+                    private int index;
+
+                    @Override
+                    public boolean hasNext() {
+                        LtrRanker.FeatureVector featureVector = getFeatureVector();
+                        if (featureVector != null) {
+                            return index < featureSet.size();
+                        }
+                        return false;
+                    }
+
+                    @Override
+                    public Entry<String, Float> next() {
+                        LtrRanker.FeatureVector featureVector = getFeatureVector();
+                        if (featureVector != null) {
+                            float score = featureVector.getFeatureScore(index);
+                            String featureName = featureSet.feature(index).name();
+                            index++;
+                            return new SimpleImmutableEntry<>(featureName, score);
+                        }
+                        return null;
+                    }
+                };
+            }
+
+            @Override
+            public int size() {
+                LtrRanker.FeatureVector featureVector = getFeatureVector();
+                if (featureVector != null) {
+                    return featureSet.size();
+                }
+                return 0;
+            }
+
+            private LtrRanker.FeatureVector getFeatureVector() {
+                if (vectorSupplier != null) {
+                    return vectorSupplier.get();
+                }
+                return null;
+            }
+        };
+    }
+
+}
+

--- a/src/main/java/com/o19s/es/ltr/feature/store/ScriptFeature.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/ScriptFeature.java
@@ -1,0 +1,193 @@
+package com.o19s.es.ltr.feature.store;
+
+import com.o19s.es.ltr.LtrQueryContext;
+import com.o19s.es.ltr.feature.Feature;
+import com.o19s.es.ltr.feature.FeatureSet;
+import com.o19s.es.ltr.query.FeatureVectorWeight;
+import com.o19s.es.ltr.ranker.LtrRanker;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+import org.elasticsearch.common.lucene.search.function.LeafScoreFunction;
+import org.elasticsearch.common.lucene.search.function.ScriptScoreFunction;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.SearchScript;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public class ScriptFeature implements Feature {
+    public static final String TEMPLATE_LANGUAGE = "script_feature";
+    public static final String FEATURE_VECTOR = "feature_vector";
+
+    private final String name;
+    private final Script script;
+    private final Collection<String> queryParams;
+
+    public ScriptFeature(String name, Script script, Collection<String> queryParams) {
+        this.name = Objects.requireNonNull(name);
+        this.script = Objects.requireNonNull(script);
+        this.queryParams = queryParams;
+    }
+
+    public static ScriptFeature compile(StoredFeature feature) {
+        try {
+            XContentParser xContentParser = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY,
+                    LoggingDeprecationHandler.INSTANCE, feature.template());
+            return new ScriptFeature(feature.name(), Script.parse(xContentParser, "native"), feature.queryParams());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * The feature name
+     */
+    @Override
+    public String name() {
+        return name;
+    }
+
+    /**
+     * Transform this feature into a lucene query
+     *
+     * @param context
+     * @param featureSet
+     * @param params
+     */
+    @Override
+    public Query doToQuery(LtrQueryContext context, FeatureSet featureSet, Map<String, Object> params) {
+        List<String> missingParams = queryParams.stream()
+                .filter((x) -> params == null || !params.containsKey(x))
+                .collect(Collectors.toList());
+        if (!missingParams.isEmpty()) {
+            String names = missingParams.stream().collect(Collectors.joining(","));
+            throw new IllegalArgumentException("Missing required param(s): [" + names + "]");
+        }
+
+        Map<String, Object> queryTimeParams = new HashMap<>();
+        for (String x : queryParams) {
+            if (params.containsKey(x)) {
+                queryTimeParams.put(x, params.get(x));
+            }
+        }
+
+        Map<String, Object> nparams = new HashMap<>();
+        FeatureSupplier featureSupplier = new FeatureSupplier(featureSet);
+        nparams.putAll(script.getParams());
+        nparams.putAll(queryTimeParams);
+        nparams.put(FEATURE_VECTOR, featureSupplier);
+        Script nScript = new Script(
+                this.script.getType(), this.script.getLang(), this.script.getIdOrCode(), this.script.getOptions(), nparams);
+        SearchScript.Factory searchScript = context.getQueryShardContext().getScriptService().compile(script, SearchScript.CONTEXT);
+        return new LtrScript(new ScriptScoreFunction(script, searchScript.newFactory(nparams,
+                context.getQueryShardContext().lookup())), featureSupplier);
+    }
+
+    static class LtrScript extends Query {
+        private final ScriptScoreFunction scoreFunction;
+        private final FeatureSupplier featureSupplier;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            LtrScript ltrScript = (LtrScript) o;
+            return Objects.equals(scoreFunction, ltrScript.scoreFunction) &&
+                    Objects.equals(featureSupplier, ltrScript.featureSupplier);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(scoreFunction, featureSupplier);
+        }
+
+        LtrScript(ScriptScoreFunction scoreFunction, FeatureSupplier featureSupplier) {
+            this.scoreFunction = scoreFunction;
+            this.featureSupplier = featureSupplier;
+        }
+
+        @Override
+        public String toString(String field) {
+            return "LtrScript:" + field;
+        }
+
+
+        @Override
+        public Weight createWeight(IndexSearcher searcher, boolean needsScores, float boost) throws IOException {
+            return new LtrScriptWeight(this);
+        }
+
+
+        class LtrScriptWeight extends FeatureVectorWeight {
+
+            protected LtrScriptWeight(Query query) {
+                super(query);
+            }
+
+            @Override
+            public Explanation explain(LeafReaderContext context, LtrRanker.FeatureVector vector, int doc) throws IOException {
+                LtrScript.this.featureSupplier.set(() -> vector);
+                Scorer scorer = this.scorer(context, () -> vector);
+                int newDoc = scorer.iterator().advance(doc);
+                if (newDoc == doc) {
+                    return Explanation.match(scorer.score(), "weight(" + this.getQuery() + " in doc " + newDoc + ")");
+                }
+                return Explanation.noMatch("no matching term");
+            }
+
+            @Override
+            public Scorer scorer(LeafReaderContext context, Supplier<LtrRanker.FeatureVector> vectorSupplier) throws IOException {
+                LtrScript.this.featureSupplier.set(vectorSupplier);
+                LeafScoreFunction leafScoreFunction = scoreFunction.getLeafScoreFunction(context);
+                DocIdSetIterator iterator = DocIdSetIterator.all(context.reader().maxDoc());
+                return new Scorer(this) {
+                    @Override
+                    public int docID() {
+                        return iterator.docID();
+                    }
+
+                    @Override
+                    public float score() throws IOException {
+                        return (float) leafScoreFunction.score(iterator.docID(), 0F);
+                    }
+
+                    @Override
+                    public DocIdSetIterator iterator() {
+                        return iterator;
+                    }
+                };
+            }
+
+            @Override
+            public void extractTerms(Set<Term> terms) {
+            }
+
+            @Override
+            public boolean isCacheable(LeafReaderContext ctx) {
+                return false;
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/o19s/es/ltr/feature/store/StoredFeature.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/StoredFeature.java
@@ -180,6 +180,8 @@ public class StoredFeature implements Feature, Accountable, StorableElement {
                 return PrecompiledTemplateFeature.compile(this);
             case PrecompiledExpressionFeature.TEMPLATE_LANGUAGE:
                 return PrecompiledExpressionFeature.compile(this);
+            case ScriptFeature.TEMPLATE_LANGUAGE:
+                return ScriptFeature.compile(this);
             default:
                 return this;
         }

--- a/src/main/java/com/o19s/es/ltr/ranker/DenseFeatureVector.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/DenseFeatureVector.java
@@ -26,6 +26,7 @@ public class DenseFeatureVector implements LtrRanker.FeatureVector {
 
     /**
      * New simple array-backed datapoint
+     *
      * @param size size of the internal array
      */
     public DenseFeatureVector(int size) {

--- a/src/main/java/com/o19s/es/ltr/ranker/LtrRanker.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/LtrRanker.java
@@ -60,5 +60,6 @@ public interface LtrRanker {
          * Get the feature score
          */
         float getFeatureScore(int featureId);
+
     }
 }

--- a/src/main/java/com/o19s/es/ltr/ranker/ranklib/DenseProgramaticDataPoint.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/ranklib/DenseProgramaticDataPoint.java
@@ -27,9 +27,9 @@ import java.util.Arrays;
  * to be parsed
  */
 public class DenseProgramaticDataPoint extends DataPoint implements LtrRanker.FeatureVector {
-
+    private static final int RANKLIB_FEATURE_INDEX_OFFSET = 1;
     public DenseProgramaticDataPoint(int numFeatures) {
-        this.fVals = new float[numFeatures+1]; // add 1 because RankLib features 1 based
+        this.fVals = new float[numFeatures+RANKLIB_FEATURE_INDEX_OFFSET]; // add 1 because RankLib features 1 based
     }
 
     public float getFeatureValue(int fid) {

--- a/src/main/java/com/o19s/es/ltr/rest/RestSimpleFeatureStore.java
+++ b/src/main/java/com/o19s/es/ltr/rest/RestSimpleFeatureStore.java
@@ -258,8 +258,7 @@ public abstract class RestSimpleFeatureStore extends FeatureStoreBaseRestHandler
         builder.request().setRouting(routing);
         builder.request().setStore(indexName);
         builder.request().setValidation(parserState.validation);
-        return (channel) -> builder.execute(new RestStatusToXContentListener<FeatureStoreAction.FeatureStoreResponse>(channel,
-                (r) -> r.getResponse().getLocation(routing)));
+        return (channel) -> builder.execute(new RestStatusToXContentListener<>(channel, (r) -> r.getResponse().getLocation(routing)));
     }
 
 

--- a/src/test/java/com/o19s/es/ltr/feature/store/FeatureSupplierTests.java
+++ b/src/test/java/com/o19s/es/ltr/feature/store/FeatureSupplierTests.java
@@ -1,0 +1,87 @@
+package com.o19s.es.ltr.feature.store;
+
+import com.o19s.es.ltr.feature.FeatureSet;
+import com.o19s.es.ltr.ranker.DenseFeatureVector;
+import com.o19s.es.ltr.ranker.LtrRanker;
+import com.o19s.es.ltr.utils.Suppliers;
+import org.apache.lucene.util.LuceneTestCase;
+import org.elasticsearch.index.query.QueryBuilders;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Collections.singletonList;
+
+public class FeatureSupplierTests extends LuceneTestCase {
+    public static FeatureSet getFeatureSet() {
+        String matchQuery = QueryBuilders.matchQuery("test", "{{query_string}}").toString();
+        StoredFeature feature = new StoredFeature("test", singletonList("query_string"), "mustache", matchQuery);
+        Map<String, Object> params = new HashMap<>();
+        params.put("query_string", "a query");
+        return new StoredFeatureSet("my_feature_set", Arrays.asList(feature));
+    }
+
+    public void testGetWhenFeatureVectorNotSet() {
+        FeatureSupplier featureSupplier = new FeatureSupplier(getFeatureSet());
+        expectThrows(NullPointerException.class, () -> featureSupplier.get()).getMessage();
+    }
+
+    public void testGetWhenFeatureVectorSet() {
+        FeatureSupplier featureSupplier = new FeatureSupplier(getFeatureSet());
+        Suppliers.MutableSupplier<LtrRanker.FeatureVector> vectorSupplier = new Suppliers.MutableSupplier<>();
+        LtrRanker.FeatureVector featureVector = new DenseFeatureVector(1);
+        vectorSupplier.set(featureVector);
+        featureSupplier.set(vectorSupplier);
+        assertEquals(featureVector, featureSupplier.get());
+    }
+
+    public void testContainsKey() {
+        FeatureSupplier featureSupplier = new FeatureSupplier(getFeatureSet());
+        assertTrue(featureSupplier.containsKey("test"));
+        assertFalse(featureSupplier.containsKey("bad_test"));
+    }
+
+    public void testGetFeatureScore() {
+        FeatureSupplier featureSupplier = new FeatureSupplier(getFeatureSet());
+        Suppliers.MutableSupplier<LtrRanker.FeatureVector> vectorSupplier = new Suppliers.MutableSupplier<>();
+        LtrRanker.FeatureVector featureVector = new DenseFeatureVector(1);
+        featureVector.setFeatureScore(0, 10.0f);
+        vectorSupplier.set(featureVector);
+        featureSupplier.set(vectorSupplier);
+        assertEquals(10.0f, featureSupplier.get("test"), 0.0f);
+        assertNull(featureSupplier.get("bad_test"));
+    }
+
+    public void testEntrySetWhenFeatureVectorNotSet(){
+        FeatureSupplier featureSupplier = new FeatureSupplier(getFeatureSet());
+        Set<Map.Entry<String, Float>> entrySet = featureSupplier.entrySet();
+        assertTrue(entrySet.isEmpty());
+        Iterator<Map.Entry<String, Float>> iterator = entrySet.iterator();
+        assertFalse(iterator.hasNext());
+        assertNull(iterator.next());
+        assertEquals(0, entrySet.size());
+    }
+
+    public void testEntrySetWhenFeatureVectorIsSet(){
+        FeatureSupplier featureSupplier = new FeatureSupplier(getFeatureSet());
+        Suppliers.MutableSupplier<LtrRanker.FeatureVector> vectorSupplier = new Suppliers.MutableSupplier<>();
+        LtrRanker.FeatureVector featureVector = new DenseFeatureVector(1);
+        featureVector.setFeatureScore(0, 10.0f);
+        vectorSupplier.set(featureVector);
+        featureSupplier.set(vectorSupplier);
+
+        Set<Map.Entry<String, Float>> entrySet = featureSupplier.entrySet();
+        assertFalse(entrySet.isEmpty());
+        Iterator<Map.Entry<String, Float>> iterator = entrySet.iterator();
+        assertTrue(iterator.hasNext());
+        Map.Entry<String, Float> item = iterator.next();
+        assertEquals("test",item.getKey());
+        assertEquals(10.0f,item.getValue(), 0.0f);
+        assertEquals(1, entrySet.size());
+    }
+
+}
+


### PR DESCRIPTION
@nomoa thanks for the POC!

I added some wiring code on top of your [poc: d629523  ](https://github.com/nomoa/elasticsearch-learning-to-rank/commit/d629523d5d29f60a45c7dd5f7ede5844430c84ea) to get this code working end to end.

Maybe I am missing something but although this seems to work, in its current form the native java plugins still seem to have have a compile time dependency on LTR  and need to access the `FeatureVector` with something like:

`((ScriptFeature.SupplierSupplier)queryParams.get("feature_vector")).get().getFeatureScore(0)`

We can make this simpler and use `featureName` like
`((ScriptFeature.SupplierSupplier)queryParams.getFeatureScore(featureName)`

but the native java code still seems to depend on `SupplierSupplier` class from LTR. 

Is there a way we could avoid and this and the native plugin just use a Map<String, double> instead which is provided by `Supplier`?


