### PR TITLE
Add support for parsing lightgbm models exported to json

### DIFF
--- a/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
+++ b/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
@@ -97,6 +97,7 @@ import com.o19s.es.ltr.query.StoredLtrQueryBuilder;
 import com.o19s.es.ltr.query.ValidatingLtrQueryBuilder;
 import com.o19s.es.ltr.ranker.parser.LinearRankerParser;
 import com.o19s.es.ltr.ranker.parser.LtrRankerParserFactory;
+import com.o19s.es.ltr.ranker.parser.LightGBMJsonParser;
 import com.o19s.es.ltr.ranker.parser.XGBoostJsonParser;
 import com.o19s.es.ltr.ranker.ranklib.RankLibScriptEngine;
 import com.o19s.es.ltr.ranker.ranklib.RanklibModelParser;
@@ -121,6 +122,7 @@ public class LtrQueryParserPlugin extends Plugin implements SearchPlugin, Script
                 .register(RanklibModelParser.TYPE, () -> new RanklibModelParser(ranklib.get()))
                 .register(LinearRankerParser.TYPE, LinearRankerParser::new)
                 .register(XGBoostJsonParser.TYPE, XGBoostJsonParser::new)
+                .register(LightGBMJsonParser.TYPE, LightGBMJsonParser::new)
                 .build();
     }
 

--- a/src/main/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTree.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTree.java
@@ -90,12 +90,24 @@ public class NaiveAdditiveDecisionTree extends DenseLtrRanker implements Account
         private final Node right;
         private final int feature;
         private final float threshold;
+        private final Comparer comparer;
+
+        @FunctionalInterface
+        public interface Comparer {
+            static Comparer GT = (t, v) -> t > v;
+            boolean compare(float threshold, float value);
+        }
 
         public Split(Node left, Node right, int feature, float threshold) {
+            this(left, right, feature, threshold, Comparer.GT);
+        }
+
+        public Split(Node left, Node right, int feature, float threshold, Comparer comparer) {
             this.left = Objects.requireNonNull(left);
             this.right = Objects.requireNonNull(right);
             this.feature = feature;
             this.threshold = threshold;
+            this.comparer = comparer;
         }
 
         @Override
@@ -109,7 +121,7 @@ public class NaiveAdditiveDecisionTree extends DenseLtrRanker implements Account
             while (!n.isLeaf()) {
                 assert n instanceof Split;
                 Split s = (Split) n;
-                if (s.threshold > scores[s.feature]) {
+                if (comparer.compare(s.threshold, scores[s.feature])) {
                     n = s.left;
                 } else {
                     n = s.right;

--- a/src/main/java/com/o19s/es/ltr/ranker/parser/LightGBMJsonParser.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/parser/LightGBMJsonParser.java
@@ -1,0 +1,275 @@
+package com.o19s.es.ltr.ranker.parser;
+
+import com.o19s.es.ltr.feature.FeatureSet;
+import com.o19s.es.ltr.ranker.dectree.NaiveAdditiveDecisionTree;
+import com.o19s.es.ltr.ranker.dectree.NaiveAdditiveDecisionTree.Split;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class LightGBMJsonParser implements LtrRankerParser {
+    public static final String TYPE = "model/lightgbm+json";
+    enum MissingType {
+        None, Zero, NaN;
+    }
+
+    @Override
+    public NaiveAdditiveDecisionTree parse(FeatureSet set, String model) {
+        RootParserState root;
+        List<NaiveAdditiveDecisionTree.Node> trees;
+        try (XContentParser parser = JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, model)) {
+            trees = RootParserState.parse(parser, set).toNodes(set);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Cannot parse model", e);
+        }
+        float[] weights = new float[trees.size()];
+        Arrays.fill(weights, 1.F);
+        return new NaiveAdditiveDecisionTree(trees.toArray(new NaiveAdditiveDecisionTree.Node[0]), weights, set.size());
+    }
+
+    private static class SplitParserState {
+        private static final ObjectParser<SplitParserState, FeatureSet> PARSER;
+        static {
+            PARSER = new ObjectParser<>("split", SplitParserState::new);
+
+            PARSER.declareBoolean(SplitParserState::setDefaultLeft, new ParseField("default_left"));
+            PARSER.declareString(SplitParserState::setMissingType, new ParseField("missing_type"));
+            PARSER.declareFloat((p, s) -> {}, new ParseField("split_gain"));
+            PARSER.declareInt((p, s) -> {}, new ParseField("internal_value"));
+            PARSER.declareInt((p, s) -> {}, new ParseField("internal_count"));
+            PARSER.declareString(SplitParserState::setDecisionType, new ParseField("decision_type"));
+            PARSER.declareInt((p, s) -> {}, new ParseField("split_index"));
+            PARSER.declareFloat(SplitParserState::setThreshold, new ParseField("threshold"));
+            PARSER.declareInt(SplitParserState::setSplitFeature, new ParseField("split_feature"));
+            PARSER.declareObject(SplitParserState::setLeftChild, SplitParserState::parse, new ParseField("left_child"));
+            PARSER.declareObject(SplitParserState::setRightChild, SplitParserState::parse, new ParseField("right_child"));
+
+            PARSER.declareFloat(SplitParserState::setLeafValue, new ParseField("leaf_value"));
+            PARSER.declareInt((p, s) -> {}, new ParseField("leaf_count"));
+            PARSER.declareInt((p, s) -> {}, new ParseField("leaf_index"));
+        }
+
+        // Properties found in a split
+        private Boolean defaultLeft;
+        private MissingType missingType;
+        private String decisionType;
+        private float threshold = Float.NaN;
+        private int splitFeature = -1;
+        private SplitParserState rightChild;
+        private SplitParserState leftChild;
+
+        // Properties found in a leaf
+        private Float leafValue;
+
+        public static SplitParserState parse(XContentParser parser, FeatureSet set) {
+            SplitParserState split = PARSER.apply(parser, set);
+            if (split.isSplit()) {
+                if (!split.hasAllSplitFields()) {
+                    throw new ParsingException(parser.getTokenLocation(), "This split does not have all the required fields");
+                }
+                if (!"<=".equals(split.decisionType)) {
+                    throw new ParsingException(parser.getTokenLocation(), "Only the <= decision_type is supported");
+                }
+                if (!split.defaultLeft) {
+                    throw new ParsingException(parser.getTokenLocation(), "default_left must be true");
+                }
+            }
+            return split;
+        }
+
+        // This is the isZero check used in lightgbm.
+        static final float ZERO_THRESHOLD = 1e-35F;
+
+        static boolean isZero(float fval) {
+            return fval > -ZERO_THRESHOLD && fval <= ZERO_THRESHOLD;
+        }
+
+        // See lightgbm src/io/tree.cpp Tree::NumericalDecisionIfElse
+        // TODO: NaN's are invalid lucene scores, should we even check?
+        static private final Split.Comparer COMPARER_ZERO_DEFAULT_LEFT = (threshold, fval) -> fval <= threshold || isZero(fval) || Float.isNaN(fval);
+        static private final Split.Comparer COMPARER_ZERO_DEFAULT_RIGHT = (threshold, fval) -> fval <= threshold && !isZero(fval) && !Float.isNaN(fval);
+        static private final Split.Comparer COMPARER_DEFAULT_LEFT = (threshold, fval) -> fval <= threshold || Float.isNaN(fval);
+        static private final Split.Comparer COMPARER_DEFAULT_RIGHT = (threshold, fval) -> fval <= threshold && !Float.isNaN(fval);
+        static private final Split.Comparer COMPARER_SIMPLE = (threshold, fval) -> fval <= threshold;
+
+        public Split.Comparer numericalDecision() {
+            if (MissingType.None.equals(missingType) || (MissingType.Zero.equals(missingType) && defaultLeft && ZERO_THRESHOLD < threshold)) {
+                return COMPARER_SIMPLE;
+            }
+            if (MissingType.Zero.equals(missingType)) {
+                if (defaultLeft) {
+                    return COMPARER_ZERO_DEFAULT_LEFT;
+                } else {
+                    return COMPARER_ZERO_DEFAULT_RIGHT;
+                }
+            }
+            if (defaultLeft) {
+                return COMPARER_DEFAULT_LEFT;
+            } else {
+                return COMPARER_DEFAULT_RIGHT;
+            }
+        }
+
+        // Setters for all parsed fields
+
+        void setDefaultLeft(boolean defaultLeft) {
+            this.defaultLeft = defaultLeft;
+        }
+
+        void setMissingType(String missingType) {
+            setMissingType(MissingType.valueOf(missingType));
+        }
+
+        void setMissingType(MissingType missingType) {
+            this.missingType = missingType;
+        }
+
+        void setDecisionType(String decisionType) {
+            this.decisionType = decisionType;
+        }
+
+        void setThreshold(float threshold) {
+            this.threshold = threshold;
+        }
+
+        void setSplitFeature(int splitFeature) {
+            this.splitFeature = splitFeature;
+        }
+
+        void setRightChild(SplitParserState child) {
+            rightChild = child;
+        }
+
+        void setLeftChild(SplitParserState child) {
+            leftChild = child;
+        }
+
+        void setLeafValue(float leafValue) {
+            this.leafValue = leafValue;
+        }
+
+        // post-parse validation
+
+        boolean isSplit() {
+            return leafValue == null;
+        }
+
+        boolean hasAllSplitFields() {
+            return defaultLeft != null && missingType != null && decisionType != null && !Float.isNaN(threshold)
+                    && splitFeature >= 0 && rightChild != null && leftChild != null;
+        }
+
+        NaiveAdditiveDecisionTree.Node toNode(List<String> featureNames, FeatureSet set) {
+            if (isSplit()) {
+                String featureName = featureNames.get(splitFeature);
+                if (!set.hasFeature(featureName)) {
+                    // Can't throw parsing exceptions anymore...
+                    throw new RuntimeException("TODO");
+                }
+                int ordinal = set.featureOrdinal(featureName);
+                NaiveAdditiveDecisionTree.Node left = leftChild.toNode(featureNames, set);
+                NaiveAdditiveDecisionTree.Node right = rightChild.toNode(featureNames, set);
+                return new Split(left, right, set.featureOrdinal(featureName), threshold, numericalDecision());
+
+            } else {
+                return new NaiveAdditiveDecisionTree.Leaf(leafValue);
+            }
+        }
+    }
+
+    private static class TreeParserState {
+        private static final ObjectParser<TreeParserState, FeatureSet> PARSER;
+        static {
+            PARSER = new ObjectParser<>("tree", TreeParserState::new);
+            PARSER.declareInt((p, c) -> {}, new ParseField("num_cat"));
+            PARSER.declareInt((p, c) -> {}, new ParseField("tree_index"));
+            PARSER.declareInt((p, c) -> {}, new ParseField("num_leaves"));
+            PARSER.declareInt((p, c) -> {}, new ParseField("shrinkage"));
+            PARSER.declareObject(TreeParserState::setTreeStructure, SplitParserState::parse, new ParseField("tree_structure"));
+        }
+
+        private SplitParserState treeStructure;
+
+        public static TreeParserState parse(XContentParser parser, FeatureSet set) {
+            TreeParserState tree = PARSER.apply(parser, set);
+            if (tree.treeStructure == null) {
+                throw new ParsingException(parser.getTokenLocation(), "The tree_structure field must not be missing");
+            }
+            return tree;
+        }
+
+        void setTreeStructure(SplitParserState treeStructure) {
+            this.treeStructure = treeStructure;
+        }
+    }
+
+    private static class RootParserState {
+        private static final ObjectParser<RootParserState, FeatureSet> PARSER;
+        static {
+            PARSER = new ObjectParser<>("root", RootParserState::new);
+            PARSER.declareString(RootParserState::setVersion, new ParseField("version"));
+            PARSER.declareStringArray(RootParserState::setFeatureNames, new ParseField("feature_names"));
+            PARSER.declareObjectArray(RootParserState::setTreeInfo, TreeParserState::parse, new ParseField("tree_info"));
+            PARSER.declareInt((p, c) -> {}, new ParseField("num_class"));
+            PARSER.declareInt((p, c) -> {}, new ParseField("label_index"));
+            PARSER.declareInt((p, c) -> {}, new ParseField("num_tree_per_iteration"));
+            PARSER.declareString((p, c) -> {}, new ParseField("name"));
+            PARSER.declareInt((p, c) -> {}, new ParseField("max_feature_idx"));
+        }
+
+        private String version;
+        private List<String> featureNames;
+        private List<TreeParserState> treeInfo;
+
+        public static RootParserState parse(XContentParser parser, FeatureSet set) {
+            RootParserState root = PARSER.apply(parser, set);
+            if (!"v2".equals(root.version)) {
+                throw new ParsingException(parser.getTokenLocation(), "Only version v2 is supported");
+            }
+            if (root.featureNames == null || root.featureNames.size() == 0) {
+                throw new ParsingException(parser.getTokenLocation(), "feature_names must not be empty");
+            }
+            if (!root.featureNames.stream().allMatch(set::hasFeature)) {
+                String unknownFeatures = root.featureNames.stream()
+                        .filter(n -> !set.hasFeature(n))
+                        .collect(Collectors.joining(", ", "Unknown feature names: ", ""));
+                throw new ParsingException(parser.getTokenLocation(), unknownFeatures);
+            }
+            if (root.treeInfo == null) {
+                throw new ParsingException(parser.getTokenLocation(), "The tree_info field must not be missing");
+            }
+            return root;
+        }
+
+        void setVersion(String version) {
+            this.version = version;
+        }
+
+        void setFeatureNames(List<String> featureNames) {
+            this.featureNames = featureNames;
+        }
+
+        void setTreeInfo(List<TreeParserState> treeInfo) {
+            this.treeInfo = treeInfo;
+        }
+
+        List<NaiveAdditiveDecisionTree.Node> toNodes(FeatureSet set) {
+            List<NaiveAdditiveDecisionTree.Node> trees = new ArrayList<>();
+            for (TreeParserState tree : treeInfo) {
+                trees.add(tree.treeStructure.toNode(featureNames, set));
+            }
+            return trees;
+        }
+    }
+}

--- a/src/test/java/com/o19s/es/ltr/ranker/parser/LightGBMJsonParserTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/parser/LightGBMJsonParserTests.java
@@ -1,0 +1,163 @@
+package com.o19s.es.ltr.ranker.parser;
+
+import com.o19s.es.ltr.LtrTestUtils;
+import com.o19s.es.ltr.feature.FeatureSet;
+import com.o19s.es.ltr.feature.store.StoredFeature;
+import com.o19s.es.ltr.feature.store.StoredFeatureSet;
+import com.o19s.es.ltr.ranker.DenseFeatureVector;
+import com.o19s.es.ltr.ranker.LtrRanker;
+import com.o19s.es.ltr.ranker.dectree.NaiveAdditiveDecisionTree;
+import com.o19s.es.ltr.ranker.linear.LinearRankerTests;
+import org.apache.lucene.util.LuceneTestCase;
+import org.elasticsearch.common.io.Streams;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.o19s.es.ltr.LtrTestUtils.randomFeatureSet;
+
+public class LightGBMJsonParserTests extends LuceneTestCase {
+    private final LightGBMJsonParser parser = new LightGBMJsonParser();
+
+    public void testReadLeaf() throws IOException {
+        FeatureSet set = randomFeatureSet();
+        String featureNames = generateFeatureNames(set);
+        String model = generateRoot(generateFeatureNames(set), generateTree(generateLeaf(3.14F)));
+        NaiveAdditiveDecisionTree tree = parser.parse(set, model);
+        assertEquals(3.14F, tree.score(tree.newFeatureVector(null)), Math.ulp(3.14F));
+    }
+
+    public void testReadSimpleSplit() throws IOException {
+        FeatureSet set = randomFeatureSet();
+        String model = generateRoot(generateFeatureNames(set), generateTree(generateSplit(
+                4.321F, 0, generateLeaf(3.14F), generateLeaf(0.234F))));
+        NaiveAdditiveDecisionTree tree = parser.parse(set, model);
+        LtrRanker.FeatureVector v = tree.newFeatureVector(null);
+        v.setFeatureScore(0, 4.320F);
+        assertEquals(3.14F, tree.score(v), Math.ulp(3.14F));
+        v.setFeatureScore(0, 4.321F);
+        assertEquals(3.14F, tree.score(v), Math.ulp(3.14F));
+        v.setFeatureScore(0, 4.322F);
+        assertEquals(0.234F, tree.score(v), Math.ulp(0.234F));
+    }
+
+    public void testFeaturesInCorrectOrder() throws IOException {
+        FeatureSet set = randomFeatureSet(2);
+        String featureNames = "[\"" + set.feature(1).name() + "\",\"" + set.feature(0).name() + "\"]";
+        String model = generateRoot(featureNames, generateTree(
+                generateSplit(0F, 0, generateLeaf(-1F), generateLeaf(1F))));
+        NaiveAdditiveDecisionTree tree = parser.parse(set, model);
+        LtrRanker.FeatureVector v = tree.newFeatureVector(null);
+        v.setFeatureScore(0, 10F);
+        v.setFeatureScore(1, -10F);
+        // splitFeature was set to 0, but that pointed to feature 1 in the featureNames.
+        // lightgbm uses approx `fval <= threshold ? left : right`
+        // or for our case, -10F <= 0 ? -1F : 1F
+        assertEquals(-1F, tree.score(v), Math.ulp(1F));
+    }
+
+    private String generateRandomRoot(String featureNames) {
+        String[] trees = new String[random().nextInt(20)];
+        for (int i = 0; i < trees.length; i++) {
+            trees[i] = generateRandomTree();
+        }
+        return generateRoot(featureNames, trees);
+    }
+
+    private String generateRoot(String featureNames, String... trees) {
+        return "{\"version\": \"v2\", \"feature_names\": " + featureNames
+            + ",\"tree_info\": [" + String.join(",", trees) + "]}";
+    }
+
+    private String generateRandomTree() {
+        return generateTree(generateRandomSplit());
+    }
+
+    private String generateTree(String node) {
+        return "{\"tree_structure\":" + node + "}";
+    }
+
+    private String generateRandomSplit() {
+        String left = random().nextBoolean() ? generateRandomSplit() : generateRandomLeaf();
+        String right = random().nextBoolean() ? generateRandomSplit() : generateRandomLeaf();
+        return generateRandomSplit(left, right);
+    }
+
+    private String generateRandomSplit(String left, String right) {
+        return generateSplit(random().nextFloat(), random().nextInt(), left, right);
+    }
+
+    private String generateSplit(float threshold, int splitFeature, String left, String right) {
+        return "{\"default_left\": true, \"missing_type\": \"None\", \"decision_type\": \"<=\""
+            + ",\"threshold\":" + Float.toString(threshold)
+            + ",\"split_feature\":" + Integer.toString(splitFeature)
+            + ",\"left_child\":" + left
+            + ",\"right_child\":" + right
+            + "}";
+    }
+
+    private String generateRandomLeaf() {
+        return generateLeaf(random().nextFloat());
+    }
+
+    private String generateLeaf(float value) {
+        return "{\"leaf_value\": " + Float.toString(value) + "}";
+    }
+
+    private String generateFeatureNames(FeatureSet set) {
+        return generateFeatureNames(
+                IntStream.range(0, set.size())
+                        .mapToObj(i -> set.feature(i).name())
+                        .collect(Collectors.toList()));
+    }
+
+    private String generateFeatureNames(List<String> featureNames) {
+        return "[\"" + String.join("\",\"", featureNames) + "\"]";
+    }
+
+    public void testComplexModel() throws IOException {
+        String model = readModel("/models/lightgbm-example.json");
+        List<StoredFeature> features = new ArrayList<>();
+        for (int i = 0; i < 28; i++) {
+            features.add(LtrTestUtils.randomFeature("feature_" + Integer.toString(i)));
+        }
+        StoredFeatureSet set = new StoredFeatureSet("set", features);
+        NaiveAdditiveDecisionTree tree = parser.parse(set, model);
+        DenseFeatureVector v = tree.newFeatureVector(null);
+        assertEquals(v.scores.length, features.size());
+
+        for (int i = random().nextInt(5000) + 1000; i > 0; i--) {
+            LinearRankerTests.fillRandomWeights(v.scores);
+            assertFalse(Float.isNaN(tree.score(v)));
+        }
+
+        // Example values sourced from same model in python Booster.predict(x, raw_score=True)
+        Arrays.fill(v.scores, 0F);
+        assertAlmostEquals(-0.12437760472589514F, tree.score(v));
+        Arrays.fill(v.scores, 1F);
+        assertAlmostEquals(0.1487958284969602F, tree.score(v));
+        v.scores[0] = 0F;
+        assertAlmostEquals(0.190454992666586F, tree.score(v));
+        Arrays.fill(v.scores, 1, 6, 0F);
+        assertAlmostEquals(0.017346924463503843F, tree.score(v));
+    }
+
+    private static void assertAlmostEquals(float expected, float actual) {
+        assertEquals(expected, actual, Math.ulp(expected));
+    }
+
+    private String readModel(String model) throws IOException {
+        try (InputStream is = this.getClass().getResourceAsStream(model)) {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            Streams.copy(is, bos);
+            return bos.toString(StandardCharsets.UTF_8.name());
+        }
+    }
+}

--- a/src/test/resources/models/lightgbm-example.json
+++ b/src/test/resources/models/lightgbm-example.json
@@ -1,0 +1,4950 @@
+{
+    "version": "v2",
+    "feature_names": [
+        "feature_0",
+        "feature_1",
+        "feature_2",
+        "feature_3",
+        "feature_4",
+        "feature_5",
+        "feature_6",
+        "feature_7",
+        "feature_8",
+        "feature_9",
+        "feature_10",
+        "feature_11",
+        "feature_12",
+        "feature_13",
+        "feature_14",
+        "feature_15",
+        "feature_16",
+        "feature_17",
+        "feature_18",
+        "feature_19",
+        "feature_20",
+        "feature_21",
+        "feature_22",
+        "feature_23",
+        "feature_24",
+        "feature_25",
+        "feature_26",
+        "feature_27"
+    ],
+    "tree_info": [
+        {
+            "num_cat": 0,
+            "tree_index": 0,
+            "num_leaves": 31,
+            "shrinkage": 1,
+            "tree_structure": {
+                "default_left": true,
+                "missing_type": "None",
+                "split_gain": 266.46099853515625,
+                "internal_value": 0,
+                "internal_count": 5600,
+                "decision_type": "<=",
+                "split_index": 0,
+                "threshold": 1.2045000000000001,
+                "split_feature": 25,
+                "right_child": {
+                    "default_left": true,
+                    "missing_type": "None",
+                    "split_gain": 29.663400650024414,
+                    "internal_value": -0.814029,
+                    "internal_count": 1216,
+                    "decision_type": "<=",
+                    "split_index": 8,
+                    "threshold": 1.8325000000000002,
+                    "split_feature": 25,
+                    "right_child": {
+                        "leaf_value": 0.05740236977280788,
+                        "leaf_count": 333,
+                        "leaf_index": 9
+                    },
+                    "left_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 25.40920066833496,
+                        "internal_value": -0.621833,
+                        "internal_count": 883,
+                        "decision_type": "<=",
+                        "split_index": 9,
+                        "threshold": 1.0545000000000002,
+                        "split_feature": 22,
+                        "right_child": {
+                            "leaf_value": 0.11894692045622379,
+                            "leaf_count": 258,
+                            "leaf_index": 10
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 25.388700485229492,
+                            "internal_value": -0.840229,
+                            "internal_count": 625,
+                            "decision_type": "<=",
+                            "split_index": 10,
+                            "threshold": 0.9615000000000001,
+                            "split_feature": 27,
+                            "right_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 20.111499786376953,
+                                "internal_value": -1.30182,
+                                "internal_count": 271,
+                                "decision_type": "<=",
+                                "split_index": 13,
+                                "threshold": 0.7525000000000001,
+                                "split_feature": 22,
+                                "right_child": {
+                                    "leaf_value": 0.04922976816328009,
+                                    "leaf_count": 243,
+                                    "leaf_index": 14
+                                },
+                                "left_child": {
+                                    "leaf_value": 0.13890110332917907,
+                                    "leaf_count": 28,
+                                    "leaf_index": 11
+                                }
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 17.949600219726562,
+                                "internal_value": -0.486865,
+                                "internal_count": 354,
+                                "decision_type": "<=",
+                                "split_index": 17,
+                                "threshold": 0.8965000000000001,
+                                "split_feature": 5,
+                                "right_child": {
+                                    "leaf_value": 0.11836519102611735,
+                                    "leaf_count": 206,
+                                    "leaf_index": 18
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 15.497900009155273,
+                                    "internal_value": -1.0192,
+                                    "internal_count": 148,
+                                    "decision_type": "<=",
+                                    "split_index": 20,
+                                    "threshold": 0.9265000000000001,
+                                    "split_feature": 9,
+                                    "right_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 12.946800231933594,
+                                        "internal_value": -0.388064,
+                                        "internal_count": 76,
+                                        "decision_type": "<=",
+                                        "split_index": 27,
+                                        "threshold": -0.1185,
+                                        "split_feature": 10,
+                                        "right_child": {
+                                            "leaf_value": 0.06597526874225855,
+                                            "leaf_count": 41,
+                                            "leaf_index": 28
+                                        },
+                                        "left_child": {
+                                            "leaf_value": 0.1489393357159638,
+                                            "leaf_count": 35,
+                                            "leaf_index": 21
+                                        }
+                                    },
+                                    "left_child": {
+                                        "leaf_value": 0.03931546457139393,
+                                        "leaf_count": 72,
+                                        "leaf_index": 1
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "left_child": {
+                    "default_left": true,
+                    "missing_type": "None",
+                    "split_gain": 163.77099609375,
+                    "internal_value": 0.246122,
+                    "internal_count": 4384,
+                    "decision_type": "<=",
+                    "split_index": 1,
+                    "threshold": 0.6175,
+                    "split_feature": 25,
+                    "right_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 92.28119659423828,
+                        "internal_value": 0.46823,
+                        "internal_count": 3299,
+                        "decision_type": "<=",
+                        "split_index": 2,
+                        "threshold": 0.8695000000000002,
+                        "split_feature": 5,
+                        "right_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 100.69599914550781,
+                            "internal_value": 0.803267,
+                            "internal_count": 1650,
+                            "decision_type": "<=",
+                            "split_index": 3,
+                            "threshold": 0.9025000000000002,
+                            "split_feature": 27,
+                            "right_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 33.82460021972656,
+                                "internal_value": 0.281737,
+                                "internal_count": 782,
+                                "decision_type": "<=",
+                                "split_index": 7,
+                                "threshold": 1.7305000000000004,
+                                "split_feature": 0,
+                                "right_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 13.776700019836426,
+                                    "internal_value": -0.618538,
+                                    "internal_count": 138,
+                                    "decision_type": "<=",
+                                    "split_index": 24,
+                                    "threshold": 1.0755000000000001,
+                                    "split_feature": 24,
+                                    "right_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 15.901300430297852,
+                                        "internal_value": -0.0123646,
+                                        "internal_count": 72,
+                                        "decision_type": "<=",
+                                        "split_index": 25,
+                                        "threshold": 1.4775000000000003,
+                                        "split_feature": 24,
+                                        "right_child": {
+                                            "leaf_value": 0.06881851316337775,
+                                            "leaf_count": 31,
+                                            "leaf_index": 26
+                                        },
+                                        "left_child": {
+                                            "leaf_value": 0.16390924324747552,
+                                            "leaf_count": 41,
+                                            "leaf_index": 25
+                                        }
+                                    },
+                                    "left_child": {
+                                        "leaf_value": 0.059594721918433805,
+                                        "leaf_count": 66,
+                                        "leaf_index": 8
+                                    }
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 21.06089973449707,
+                                    "internal_value": 0.474653,
+                                    "internal_count": 644,
+                                    "decision_type": "<=",
+                                    "split_index": 12,
+                                    "threshold": 2.6165000000000007,
+                                    "split_feature": 3,
+                                    "right_child": {
+                                        "leaf_value": 0.05716121103678902,
+                                        "leaf_count": 25,
+                                        "leaf_index": 13
+                                    },
+                                    "left_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 19.104799270629883,
+                                        "internal_value": 0.547477,
+                                        "internal_count": 619,
+                                        "decision_type": "<=",
+                                        "split_index": 16,
+                                        "threshold": 0.9895000000000002,
+                                        "split_feature": 25,
+                                        "right_child": {
+                                            "leaf_value": 0.12471014980619469,
+                                            "leaf_count": 192,
+                                            "leaf_index": 17
+                                        },
+                                        "left_child": {
+                                            "leaf_value": 0.1627624753961264,
+                                            "leaf_count": 427,
+                                            "leaf_index": 4
+                                        }
+                                    }
+                                }
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 14.254400253295898,
+                                "internal_value": 1.27313,
+                                "internal_count": 868,
+                                "decision_type": "<=",
+                                "split_index": 22,
+                                "threshold": 0.8565000000000002,
+                                "split_feature": 26,
+                                "right_child": {
+                                    "leaf_value": 0.19603191830303615,
+                                    "leaf_count": 591,
+                                    "leaf_index": 23
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 17.1200008392334,
+                                    "internal_value": 0.898042,
+                                    "internal_count": 277,
+                                    "decision_type": "<=",
+                                    "split_index": 23,
+                                    "threshold": 0.8425000000000001,
+                                    "split_feature": 25,
+                                    "right_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 13.599200248718262,
+                                        "internal_value": 0.270124,
+                                        "internal_count": 107,
+                                        "decision_type": "<=",
+                                        "split_index": 26,
+                                        "threshold": 1.1865000000000003,
+                                        "split_feature": 0,
+                                        "right_child": {
+                                            "leaf_value": 0.06480938809338692,
+                                            "leaf_count": 21,
+                                            "leaf_index": 27
+                                        },
+                                        "left_child": {
+                                            "leaf_value": 0.15474216772692906,
+                                            "leaf_count": 86,
+                                            "leaf_index": 24
+                                        }
+                                    },
+                                    "left_child": {
+                                        "leaf_value": 0.18824871632303683,
+                                        "leaf_count": 170,
+                                        "leaf_index": 3
+                                    }
+                                }
+                            }
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 85.54399871826172,
+                            "internal_value": 0.132991,
+                            "internal_count": 1649,
+                            "decision_type": "<=",
+                            "split_index": 4,
+                            "threshold": 0.7765000000000001,
+                            "split_feature": 26,
+                            "right_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 59.44729995727539,
+                                "internal_value": 0.363867,
+                                "internal_count": 1313,
+                                "decision_type": "<=",
+                                "split_index": 5,
+                                "threshold": 0.9655000000000001,
+                                "split_feature": 25,
+                                "right_child": {
+                                    "leaf_value": 0.10655387721267304,
+                                    "leaf_count": 352,
+                                    "leaf_index": 6
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 40.56779861450195,
+                                    "internal_value": 0.621916,
+                                    "internal_count": 961,
+                                    "decision_type": "<=",
+                                    "split_index": 6,
+                                    "threshold": 0.9045000000000002,
+                                    "split_feature": 27,
+                                    "right_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 15.083800315856934,
+                                        "internal_value": 0.0392208,
+                                        "internal_count": 320,
+                                        "decision_type": "<=",
+                                        "split_index": 21,
+                                        "threshold": 1.3345000000000002,
+                                        "split_feature": 3,
+                                        "right_child": {
+                                            "leaf_value": 0.09280717910414708,
+                                            "leaf_count": 98,
+                                            "leaf_index": 22
+                                        },
+                                        "left_child": {
+                                            "leaf_value": 0.1399992368592649,
+                                            "leaf_count": 222,
+                                            "leaf_index": 7
+                                        }
+                                    },
+                                    "left_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 19.661800384521484,
+                                        "internal_value": 0.912809,
+                                        "internal_count": 641,
+                                        "decision_type": "<=",
+                                        "split_index": 14,
+                                        "threshold": 0.8695000000000002,
+                                        "split_feature": 26,
+                                        "right_child": {
+                                            "leaf_value": 0.18477818210443683,
+                                            "leaf_count": 359,
+                                            "leaf_index": 15
+                                        },
+                                        "left_child": {
+                                            "default_left": true,
+                                            "missing_type": "None",
+                                            "split_gain": 24.027999877929688,
+                                            "internal_value": 0.516838,
+                                            "internal_count": 282,
+                                            "decision_type": "<=",
+                                            "split_index": 15,
+                                            "threshold": 0.7995000000000002,
+                                            "split_feature": 27,
+                                            "right_child": {
+                                                "leaf_value": 0.09901074324084935,
+                                                "leaf_count": 71,
+                                                "leaf_index": 16
+                                            },
+                                            "left_child": {
+                                                "leaf_value": 0.16639240326455096,
+                                                "leaf_count": 211,
+                                                "leaf_index": 5
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 17.783899307250977,
+                                "internal_value": -0.769215,
+                                "internal_count": 336,
+                                "decision_type": "<=",
+                                "split_index": 18,
+                                "threshold": 0.6415000000000001,
+                                "split_feature": 24,
+                                "right_child": {
+                                    "leaf_value": 0.07416026150200114,
+                                    "leaf_count": 274,
+                                    "leaf_index": 19
+                                },
+                                "left_child": {
+                                    "leaf_value": 0.13358130275553737,
+                                    "leaf_count": 62,
+                                    "leaf_index": 2
+                                }
+                            }
+                        }
+                    },
+                    "left_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 24.138700485229492,
+                        "internal_value": -0.429211,
+                        "internal_count": 1085,
+                        "decision_type": "<=",
+                        "split_index": 11,
+                        "threshold": 1.0365000000000002,
+                        "split_feature": 9,
+                        "right_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 12.029800415039062,
+                            "internal_value": 0.117017,
+                            "internal_count": 250,
+                            "decision_type": "<=",
+                            "split_index": 29,
+                            "threshold": 0.8265000000000001,
+                            "split_feature": 27,
+                            "right_child": {
+                                "leaf_value": 0.10797976249488678,
+                                "leaf_count": 128,
+                                "leaf_index": 30
+                            },
+                            "left_child": {
+                                "leaf_value": 0.15194845455790396,
+                                "leaf_count": 122,
+                                "leaf_index": 12
+                            }
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 17.105499267578125,
+                            "internal_value": -0.592752,
+                            "internal_count": 835,
+                            "decision_type": "<=",
+                            "split_index": 19,
+                            "threshold": 1.6175000000000004,
+                            "split_feature": 3,
+                            "right_child": {
+                                "leaf_value": 0.05944633710857741,
+                                "leaf_count": 123,
+                                "leaf_index": 20
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 12.652199745178223,
+                                "internal_value": -0.473547,
+                                "internal_count": 712,
+                                "decision_type": "<=",
+                                "split_index": 28,
+                                "threshold": 1.3085000000000002,
+                                "split_feature": 13,
+                                "right_child": {
+                                    "leaf_value": 0.14100997567934392,
+                                    "leaf_count": 68,
+                                    "leaf_index": 29
+                                },
+                                "left_child": {
+                                    "leaf_value": 0.09556836103840022,
+                                    "leaf_count": 644,
+                                    "leaf_index": 0
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "num_cat": 0,
+            "tree_index": 1,
+            "num_leaves": 31,
+            "shrinkage": 0.05,
+            "tree_structure": {
+                "default_left": true,
+                "missing_type": "None",
+                "split_gain": 241.6999969482422,
+                "internal_value": 0,
+                "internal_count": 5600,
+                "decision_type": "<=",
+                "split_index": 0,
+                "threshold": 1.0675000000000001,
+                "split_feature": 25,
+                "right_child": {
+                    "default_left": true,
+                    "missing_type": "None",
+                    "split_gain": 39.420101165771484,
+                    "internal_value": -0.640902,
+                    "internal_count": 1605,
+                    "decision_type": "<=",
+                    "split_index": 5,
+                    "threshold": 1.8325000000000002,
+                    "split_feature": 25,
+                    "right_child": {
+                        "leaf_value": -0.06268069780328002,
+                        "leaf_count": 333,
+                        "leaf_index": 6
+                    },
+                    "left_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 36.56439971923828,
+                        "internal_value": -0.480159,
+                        "internal_count": 1272,
+                        "decision_type": "<=",
+                        "split_index": 6,
+                        "threshold": 1.0375000000000003,
+                        "split_feature": 22,
+                        "right_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 13.529500007629395,
+                            "internal_value": 0.00893546,
+                            "internal_count": 414,
+                            "decision_type": "<=",
+                            "split_index": 15,
+                            "threshold": 1.3295000000000001,
+                            "split_feature": 24,
+                            "right_child": {
+                                "leaf_value": 0.034090039530450277,
+                                "leaf_count": 93,
+                                "leaf_index": 16
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 20.33340072631836,
+                                "internal_value": -0.186028,
+                                "internal_count": 321,
+                                "decision_type": "<=",
+                                "split_index": 16,
+                                "threshold": 1.0880000000000003,
+                                "split_feature": 2,
+                                "right_child": {
+                                    "leaf_value": 0.044970470476595144,
+                                    "leaf_count": 57,
+                                    "leaf_index": 17
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 12.022000312805176,
+                                    "internal_value": -0.420295,
+                                    "internal_count": 264,
+                                    "decision_type": "<=",
+                                    "split_index": 22,
+                                    "threshold": 1.2875000000000003,
+                                    "split_feature": 19,
+                                    "right_child": {
+                                        "leaf_value": 0.04232460815577489,
+                                        "leaf_count": 27,
+                                        "leaf_index": 23
+                                    },
+                                    "left_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 13.207599639892578,
+                                        "internal_value": -0.56459,
+                                        "internal_count": 237,
+                                        "decision_type": "<=",
+                                        "split_index": 23,
+                                        "threshold": 0.3615000000000001,
+                                        "split_feature": 3,
+                                        "right_child": {
+                                            "leaf_value": -0.03757153827180391,
+                                            "leaf_count": 205,
+                                            "leaf_index": 24
+                                        },
+                                        "left_child": {
+                                            "leaf_value": 0.03163214553705176,
+                                            "leaf_count": 32,
+                                            "leaf_index": 7
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 21.627599716186523,
+                            "internal_value": -0.715944,
+                            "internal_count": 858,
+                            "decision_type": "<=",
+                            "split_index": 9,
+                            "threshold": 0.7795000000000002,
+                            "split_feature": 22,
+                            "right_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 13.937999725341797,
+                                "internal_value": -0.845924,
+                                "internal_count": 735,
+                                "decision_type": "<=",
+                                "split_index": 12,
+                                "threshold": 0.6625000000000001,
+                                "split_feature": 24,
+                                "right_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 11.487799644470215,
+                                    "internal_value": -0.913777,
+                                    "internal_count": 693,
+                                    "decision_type": "<=",
+                                    "split_index": 27,
+                                    "threshold": 0.9775000000000001,
+                                    "split_feature": 24,
+                                    "right_child": {
+                                        "leaf_value": -0.03224714273452647,
+                                        "leaf_count": 332,
+                                        "leaf_index": 28
+                                    },
+                                    "left_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 15.534700393676758,
+                                        "internal_value": -1.16102,
+                                        "internal_count": 361,
+                                        "decision_type": "<=",
+                                        "split_index": 28,
+                                        "threshold": 0.9935000000000002,
+                                        "split_feature": 26,
+                                        "right_child": {
+                                            "leaf_value": -0.07969007707522499,
+                                            "leaf_count": 173,
+                                            "leaf_index": 29
+                                        },
+                                        "left_child": {
+                                            "leaf_value": -0.038116619214668836,
+                                            "leaf_count": 188,
+                                            "leaf_index": 13
+                                        }
+                                    }
+                                },
+                                "left_child": {
+                                    "leaf_value": 0.013736046313204065,
+                                    "leaf_count": 42,
+                                    "leaf_index": 10
+                                }
+                            },
+                            "left_child": {
+                                "leaf_value": 0.0030918733958899066,
+                                "leaf_count": 123,
+                                "leaf_index": 1
+                            }
+                        }
+                    }
+                },
+                "left_child": {
+                    "default_left": true,
+                    "missing_type": "None",
+                    "split_gain": 176.6840057373047,
+                    "internal_value": 0.2795,
+                    "internal_count": 3995,
+                    "decision_type": "<=",
+                    "split_index": 1,
+                    "threshold": 0.6655000000000001,
+                    "split_feature": 25,
+                    "right_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 89.61630249023438,
+                        "internal_value": 0.572973,
+                        "internal_count": 2694,
+                        "decision_type": "<=",
+                        "split_index": 2,
+                        "threshold": 0.8055000000000001,
+                        "split_feature": 26,
+                        "right_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 41.31679916381836,
+                            "internal_value": 0.743995,
+                            "internal_count": 2212,
+                            "decision_type": "<=",
+                            "split_index": 4,
+                            "threshold": 1.0825000000000002,
+                            "split_feature": 26,
+                            "right_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 15.446200370788574,
+                                "internal_value": 0.285588,
+                                "internal_count": 582,
+                                "decision_type": "<=",
+                                "split_index": 10,
+                                "threshold": 2.4510000000000005,
+                                "split_feature": 3,
+                                "right_child": {
+                                    "leaf_value": -0.06799734820041292,
+                                    "leaf_count": 22,
+                                    "leaf_index": 11
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 11.77400016784668,
+                                    "internal_value": 0.350415,
+                                    "internal_count": 560,
+                                    "decision_type": "<=",
+                                    "split_index": 25,
+                                    "threshold": 1.8455000000000001,
+                                    "split_feature": 9,
+                                    "right_child": {
+                                        "leaf_value": 0.06250578394411599,
+                                        "leaf_count": 53,
+                                        "leaf_index": 26
+                                    },
+                                    "left_child": {
+                                        "leaf_value": 0.01282376516790686,
+                                        "leaf_count": 507,
+                                        "leaf_index": 5
+                                    }
+                                }
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 23.739700317382812,
+                                "internal_value": 0.90806,
+                                "internal_count": 1630,
+                                "decision_type": "<=",
+                                "split_index": 8,
+                                "threshold": 0.8695000000000002,
+                                "split_feature": 5,
+                                "right_child": {
+                                    "leaf_value": 0.05714537279350665,
+                                    "leaf_count": 841,
+                                    "leaf_index": 9
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 13.601400375366211,
+                                    "internal_value": 0.658198,
+                                    "internal_count": 789,
+                                    "decision_type": "<=",
+                                    "split_index": 14,
+                                    "threshold": 1.2475000000000003,
+                                    "split_feature": 9,
+                                    "right_child": {
+                                        "leaf_value": 0.06894429489909389,
+                                        "leaf_count": 93,
+                                        "leaf_index": 15
+                                    },
+                                    "left_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 12.924099922180176,
+                                        "internal_value": 0.561917,
+                                        "internal_count": 696,
+                                        "decision_type": "<=",
+                                        "split_index": 17,
+                                        "threshold": 1.1435000000000002,
+                                        "split_feature": 3,
+                                        "right_child": {
+                                            "leaf_value": 0.005878168168179054,
+                                            "leaf_count": 191,
+                                            "leaf_index": 18
+                                        },
+                                        "left_child": {
+                                            "default_left": true,
+                                            "missing_type": "None",
+                                            "split_gain": 12.088899612426758,
+                                            "internal_value": 0.730121,
+                                            "internal_count": 505,
+                                            "decision_type": "<=",
+                                            "split_index": 19,
+                                            "threshold": 0.9845000000000002,
+                                            "split_feature": 25,
+                                            "right_child": {
+                                                "leaf_value": -0.0037949488266837343,
+                                                "leaf_count": 65,
+                                                "leaf_index": 20
+                                            },
+                                            "left_child": {
+                                                "default_left": true,
+                                                "missing_type": "None",
+                                                "split_gain": 11.820099830627441,
+                                                "internal_value": 0.849691,
+                                                "internal_count": 440,
+                                                "decision_type": "<=",
+                                                "split_index": 24,
+                                                "threshold": 0.8435000000000001,
+                                                "split_feature": 26,
+                                                "right_child": {
+                                                    "leaf_value": 0.05006513257582589,
+                                                    "leaf_count": 363,
+                                                    "leaf_index": 25
+                                                },
+                                                "left_child": {
+                                                    "leaf_value": 0.006797326449375746,
+                                                    "leaf_count": 77,
+                                                    "leaf_index": 3
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 49.0817985534668,
+                            "internal_value": -0.209851,
+                            "internal_count": 482,
+                            "decision_type": "<=",
+                            "split_index": 3,
+                            "threshold": 0.8205000000000001,
+                            "split_feature": 5,
+                            "right_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 10.652999877929688,
+                                "internal_value": 0.662249,
+                                "internal_count": 169,
+                                "decision_type": "<=",
+                                "split_index": 29,
+                                "threshold": -0.5464999999999999,
+                                "split_feature": 6,
+                                "right_child": {
+                                    "leaf_value": 0.04851613870015829,
+                                    "leaf_count": 123,
+                                    "leaf_index": 30
+                                },
+                                "left_child": {
+                                    "leaf_value": -0.008085309840076358,
+                                    "leaf_count": 46,
+                                    "leaf_index": 4
+                                }
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 11.559499740600586,
+                                "internal_value": -0.678783,
+                                "internal_count": 313,
+                                "decision_type": "<=",
+                                "split_index": 26,
+                                "threshold": 0.8125000000000001,
+                                "split_feature": 14,
+                                "right_child": {
+                                    "leaf_value": 0.004781013470717321,
+                                    "leaf_count": 62,
+                                    "leaf_index": 27
+                                },
+                                "left_child": {
+                                    "leaf_value": -0.04350162778586604,
+                                    "leaf_count": 251,
+                                    "leaf_index": 2
+                                }
+                            }
+                        }
+                    },
+                    "left_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 32.87540054321289,
+                        "internal_value": -0.326434,
+                        "internal_count": 1301,
+                        "decision_type": "<=",
+                        "split_index": 7,
+                        "threshold": 1.1375000000000002,
+                        "split_feature": 9,
+                        "right_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 12.683799743652344,
+                            "internal_value": 0.352415,
+                            "internal_count": 235,
+                            "decision_type": "<=",
+                            "split_index": 18,
+                            "threshold": 1.2315000000000003,
+                            "split_feature": 19,
+                            "right_child": {
+                                "leaf_value": -0.03998296090879053,
+                                "leaf_count": 33,
+                                "leaf_index": 19
+                            },
+                            "left_child": {
+                                "leaf_value": 0.027035079205045068,
+                                "leaf_count": 202,
+                                "leaf_index": 8
+                            }
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 15.32759952545166,
+                            "internal_value": -0.47581,
+                            "internal_count": 1066,
+                            "decision_type": "<=",
+                            "split_index": 11,
+                            "threshold": 1.2955000000000003,
+                            "split_feature": 13,
+                            "right_child": {
+                                "leaf_value": 0.011290446351300587,
+                                "leaf_count": 112,
+                                "leaf_index": 12
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 13.917499542236328,
+                                "internal_value": -0.558021,
+                                "internal_count": 954,
+                                "decision_type": "<=",
+                                "split_index": 13,
+                                "threshold": 0.7185000000000001,
+                                "split_feature": 24,
+                                "right_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 12.07610034942627,
+                                    "internal_value": -0.724244,
+                                    "internal_count": 648,
+                                    "decision_type": "<=",
+                                    "split_index": 20,
+                                    "threshold": 0.7335000000000002,
+                                    "split_feature": 26,
+                                    "right_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 12.026700019836426,
+                                        "internal_value": -0.550063,
+                                        "internal_count": 461,
+                                        "decision_type": "<=",
+                                        "split_index": 21,
+                                        "threshold": 0.8235000000000001,
+                                        "split_feature": 22,
+                                        "right_child": {
+                                            "leaf_value": -0.03671849001139318,
+                                            "leaf_count": 348,
+                                            "leaf_index": 22
+                                        },
+                                        "left_child": {
+                                            "leaf_value": 0.00088775000323056,
+                                            "leaf_count": 113,
+                                            "leaf_index": 21
+                                        }
+                                    },
+                                    "left_child": {
+                                        "leaf_value": -0.05766818631609604,
+                                        "leaf_count": 187,
+                                        "leaf_index": 14
+                                    }
+                                },
+                                "left_child": {
+                                    "leaf_value": -0.010300734056099013,
+                                    "leaf_count": 306,
+                                    "leaf_index": 0
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "num_cat": 0,
+            "tree_index": 2,
+            "num_leaves": 31,
+            "shrinkage": 0.05,
+            "tree_structure": {
+                "default_left": true,
+                "missing_type": "None",
+                "split_gain": 159.6510009765625,
+                "internal_value": 0,
+                "internal_count": 5600,
+                "decision_type": "<=",
+                "split_index": 0,
+                "threshold": 0.9045000000000002,
+                "split_feature": 27,
+                "right_child": {
+                    "default_left": true,
+                    "missing_type": "None",
+                    "split_gain": 76.71510314941406,
+                    "internal_value": -0.37057,
+                    "internal_count": 2438,
+                    "decision_type": "<=",
+                    "split_index": 2,
+                    "threshold": 1.0465000000000002,
+                    "split_feature": 22,
+                    "right_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 17.420900344848633,
+                        "internal_value": 0.0429447,
+                        "internal_count": 1037,
+                        "decision_type": "<=",
+                        "split_index": 9,
+                        "threshold": 1.1225000000000003,
+                        "split_feature": 27,
+                        "right_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 14.729100227355957,
+                            "internal_value": -0.184866,
+                            "internal_count": 586,
+                            "decision_type": "<=",
+                            "split_index": 11,
+                            "threshold": 2.4510000000000005,
+                            "split_feature": 3,
+                            "right_child": {
+                                "leaf_value": -0.07316392558836865,
+                                "leaf_count": 34,
+                                "leaf_index": 12
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 11.678799629211426,
+                                "internal_value": -0.105885,
+                                "internal_count": 552,
+                                "decision_type": "<=",
+                                "split_index": 17,
+                                "threshold": 1.0000000180025095e-35,
+                                "split_feature": 8,
+                                "right_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 10.735799789428711,
+                                    "internal_value": -0.407942,
+                                    "internal_count": 266,
+                                    "decision_type": "<=",
+                                    "split_index": 23,
+                                    "threshold": 1.3095000000000003,
+                                    "split_feature": 24,
+                                    "right_child": {
+                                        "leaf_value": -0.0014381822119344694,
+                                        "leaf_count": 141,
+                                        "leaf_index": 24
+                                    },
+                                    "left_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 18.466999053955078,
+                                        "internal_value": -0.835216,
+                                        "internal_count": 125,
+                                        "decision_type": "<=",
+                                        "split_index": 24,
+                                        "threshold": 0.8055000000000001,
+                                        "split_feature": 24,
+                                        "right_child": {
+                                            "leaf_value": -0.06147164847261946,
+                                            "leaf_count": 99,
+                                            "leaf_index": 25
+                                        },
+                                        "left_child": {
+                                            "leaf_value": 0.03341576596060593,
+                                            "leaf_count": 26,
+                                            "leaf_index": 18
+                                        }
+                                    }
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 15.007100105285645,
+                                    "internal_value": 0.175538,
+                                    "internal_count": 286,
+                                    "decision_type": "<=",
+                                    "split_index": 18,
+                                    "threshold": 1.7625000000000002,
+                                    "split_feature": 5,
+                                    "right_child": {
+                                        "leaf_value": 0.048406208810428945,
+                                        "leaf_count": 72,
+                                        "leaf_index": 19
+                                    },
+                                    "left_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 12.763999938964844,
+                                        "internal_value": -0.0906795,
+                                        "internal_count": 214,
+                                        "decision_type": "<=",
+                                        "split_index": 19,
+                                        "threshold": 0.9875000000000002,
+                                        "split_feature": 23,
+                                        "right_child": {
+                                            "leaf_value": -0.024019755895592822,
+                                            "leaf_count": 131,
+                                            "leaf_index": 20
+                                        },
+                                        "left_child": {
+                                            "leaf_value": 0.026224436034278528,
+                                            "leaf_count": 83,
+                                            "leaf_index": 10
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 10.453700065612793,
+                            "internal_value": 0.339353,
+                            "internal_count": 451,
+                            "decision_type": "<=",
+                            "split_index": 26,
+                            "threshold": 1.6515000000000002,
+                            "split_feature": 5,
+                            "right_child": {
+                                "leaf_value": 0.07753416021135058,
+                                "leaf_count": 27,
+                                "leaf_index": 27
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 10.260000228881836,
+                                "internal_value": 0.26238,
+                                "internal_count": 424,
+                                "decision_type": "<=",
+                                "split_index": 27,
+                                "threshold": -1.8214999999999997,
+                                "split_feature": 6,
+                                "right_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 10.319999694824219,
+                                    "internal_value": 0.331802,
+                                    "internal_count": 404,
+                                    "decision_type": "<=",
+                                    "split_index": 28,
+                                    "threshold": 1.3790000000000002,
+                                    "split_feature": 6,
+                                    "right_child": {
+                                        "leaf_value": -0.03627620401473077,
+                                        "leaf_count": 34,
+                                        "leaf_index": 29
+                                    },
+                                    "left_child": {
+                                        "leaf_value": 0.021448774119830268,
+                                        "leaf_count": 370,
+                                        "leaf_index": 28
+                                    }
+                                },
+                                "left_child": {
+                                    "leaf_value": -0.05697873445614221,
+                                    "leaf_count": 20,
+                                    "leaf_index": 3
+                                }
+                            }
+                        }
+                    },
+                    "left_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 107.13600158691406,
+                        "internal_value": -0.676145,
+                        "internal_count": 1401,
+                        "decision_type": "<=",
+                        "split_index": 3,
+                        "threshold": 1.0755000000000001,
+                        "split_feature": 24,
+                        "right_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 20.433300018310547,
+                            "internal_value": -0.158268,
+                            "internal_count": 748,
+                            "decision_type": "<=",
+                            "split_index": 7,
+                            "threshold": 0.7625000000000001,
+                            "split_feature": 22,
+                            "right_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 11.626700401306152,
+                                "internal_value": -0.294202,
+                                "internal_count": 640,
+                                "decision_type": "<=",
+                                "split_index": 20,
+                                "threshold": 1.6295000000000002,
+                                "split_feature": 3,
+                                "right_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 12.0024995803833,
+                                    "internal_value": -0.769524,
+                                    "internal_count": 156,
+                                    "decision_type": "<=",
+                                    "split_index": 21,
+                                    "threshold": 0.5235000000000002,
+                                    "split_feature": 2,
+                                    "right_child": {
+                                        "leaf_value": -0.0755916881783845,
+                                        "leaf_count": 56,
+                                        "leaf_index": 22
+                                    },
+                                    "left_child": {
+                                        "leaf_value": -0.01769559522301732,
+                                        "leaf_count": 100,
+                                        "leaf_index": 21
+                                    }
+                                },
+                                "left_child": {
+                                    "leaf_value": -0.007039271027358638,
+                                    "leaf_count": 484,
+                                    "leaf_index": 8
+                                }
+                            },
+                            "left_child": {
+                                "leaf_value": 0.032429175319730594,
+                                "leaf_count": 108,
+                                "leaf_index": 4
+                            }
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 14.503299713134766,
+                            "internal_value": -1.2687,
+                            "internal_count": 653,
+                            "decision_type": "<=",
+                            "split_index": 12,
+                            "threshold": 1.0885000000000002,
+                            "split_feature": 27,
+                            "right_child": {
+                                "leaf_value": -0.08255849708085812,
+                                "leaf_count": 247,
+                                "leaf_index": 13
+                            },
+                            "left_child": {
+                                "leaf_value": -0.05179036936618299,
+                                "leaf_count": 406,
+                                "leaf_index": 1
+                            }
+                        }
+                    }
+                },
+                "left_child": {
+                    "default_left": true,
+                    "missing_type": "None",
+                    "split_gain": 173.33200073242188,
+                    "internal_value": 0.312313,
+                    "internal_count": 3162,
+                    "decision_type": "<=",
+                    "split_index": 1,
+                    "threshold": 0.8115000000000001,
+                    "split_feature": 26,
+                    "right_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 39.52510070800781,
+                        "internal_value": 0.675454,
+                        "internal_count": 1984,
+                        "decision_type": "<=",
+                        "split_index": 5,
+                        "threshold": 0.9005000000000001,
+                        "split_feature": 5,
+                        "right_child": {
+                            "leaf_value": 0.049000849466304994,
+                            "leaf_count": 923,
+                            "leaf_index": 6
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 21.92329978942871,
+                            "internal_value": 0.411413,
+                            "internal_count": 1061,
+                            "decision_type": "<=",
+                            "split_index": 6,
+                            "threshold": 1.0605000000000002,
+                            "split_feature": 22,
+                            "right_child": {
+                                "leaf_value": 0.05188989333995982,
+                                "leaf_count": 186,
+                                "leaf_index": 7
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 18.226499557495117,
+                                "internal_value": 0.278467,
+                                "internal_count": 875,
+                                "decision_type": "<=",
+                                "split_index": 8,
+                                "threshold": 0.8405000000000001,
+                                "split_feature": 27,
+                                "right_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 17.263999938964844,
+                                    "internal_value": -0.184474,
+                                    "internal_count": 246,
+                                    "decision_type": "<=",
+                                    "split_index": 10,
+                                    "threshold": 0.8985000000000002,
+                                    "split_feature": 26,
+                                    "right_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 12.519000053405762,
+                                        "internal_value": 0.134507,
+                                        "internal_count": 181,
+                                        "decision_type": "<=",
+                                        "split_index": 15,
+                                        "threshold": 1.0405000000000002,
+                                        "split_feature": 24,
+                                        "right_child": {
+                                            "leaf_value": 0.03576066684218174,
+                                            "leaf_count": 82,
+                                            "leaf_index": 16
+                                        },
+                                        "left_child": {
+                                            "leaf_value": -0.017265484990750087,
+                                            "leaf_count": 99,
+                                            "leaf_index": 11
+                                        }
+                                    },
+                                    "left_child": {
+                                        "leaf_value": -0.05350408819922112,
+                                        "leaf_count": 65,
+                                        "leaf_index": 9
+                                    }
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 13.598699569702148,
+                                    "internal_value": 0.459758,
+                                    "internal_count": 629,
+                                    "decision_type": "<=",
+                                    "split_index": 13,
+                                    "threshold": 0.8605000000000002,
+                                    "split_feature": 26,
+                                    "right_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 10.985699653625488,
+                                        "internal_value": 0.695078,
+                                        "internal_count": 385,
+                                        "decision_type": "<=",
+                                        "split_index": 22,
+                                        "threshold": 0.7045000000000001,
+                                        "split_feature": 0,
+                                        "right_child": {
+                                            "leaf_value": 0.046602766207869746,
+                                            "leaf_count": 259,
+                                            "leaf_index": 23
+                                        },
+                                        "left_child": {
+                                            "leaf_value": 0.010462531936424057,
+                                            "leaf_count": 126,
+                                            "leaf_index": 14
+                                        }
+                                    },
+                                    "left_child": {
+                                        "leaf_value": 0.004472817761251297,
+                                        "leaf_count": 244,
+                                        "leaf_index": 2
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "left_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 44.12229919433594,
+                        "internal_value": -0.295682,
+                        "internal_count": 1178,
+                        "decision_type": "<=",
+                        "split_index": 4,
+                        "threshold": 0.8205000000000001,
+                        "split_feature": 5,
+                        "right_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 12.12559986114502,
+                            "internal_value": 0.253417,
+                            "internal_count": 393,
+                            "decision_type": "<=",
+                            "split_index": 16,
+                            "threshold": 0.8065000000000001,
+                            "split_feature": 27,
+                            "right_child": {
+                                "leaf_value": -0.027991901020518514,
+                                "leaf_count": 62,
+                                "leaf_index": 17
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 10.714599609375,
+                                "internal_value": 0.406094,
+                                "internal_count": 331,
+                                "decision_type": "<=",
+                                "split_index": 25,
+                                "threshold": -1.5134999999999998,
+                                "split_feature": 2,
+                                "right_child": {
+                                    "leaf_value": 0.025007519941969515,
+                                    "leaf_count": 310,
+                                    "leaf_index": 26
+                                },
+                                "left_child": {
+                                    "leaf_value": -0.04897015016333461,
+                                    "leaf_count": 21,
+                                    "leaf_index": 5
+                                }
+                            }
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 12.656700134277344,
+                            "internal_value": -0.569404,
+                            "internal_count": 785,
+                            "decision_type": "<=",
+                            "split_index": 14,
+                            "threshold": 1.6475000000000002,
+                            "split_feature": 0,
+                            "right_child": {
+                                "leaf_value": 0.019253110144024338,
+                                "leaf_count": 52,
+                                "leaf_index": 15
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 9.446089744567871,
+                                "internal_value": -0.637092,
+                                "internal_count": 733,
+                                "decision_type": "<=",
+                                "split_index": 29,
+                                "threshold": 1.1935000000000002,
+                                "split_feature": 9,
+                                "right_child": {
+                                    "leaf_value": 0.02423901688029484,
+                                    "leaf_count": 29,
+                                    "leaf_index": 30
+                                },
+                                "left_child": {
+                                    "leaf_value": -0.03415599501638049,
+                                    "leaf_count": 704,
+                                    "leaf_index": 0
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "num_cat": 0,
+            "tree_index": 3,
+            "num_leaves": 31,
+            "shrinkage": 0.05,
+            "tree_structure": {
+                "default_left": true,
+                "missing_type": "None",
+                "split_gain": 214.03900146484375,
+                "internal_value": 0,
+                "internal_count": 5600,
+                "decision_type": "<=",
+                "split_index": 0,
+                "threshold": 1.2450000000000003,
+                "split_feature": 25,
+                "right_child": {
+                    "default_left": true,
+                    "missing_type": "None",
+                    "split_gain": 21.115100860595703,
+                    "internal_value": -0.766035,
+                    "internal_count": 1126,
+                    "decision_type": "<=",
+                    "split_index": 8,
+                    "threshold": 1.8535000000000004,
+                    "split_feature": 3,
+                    "right_child": {
+                        "leaf_value": -0.08687802908552661,
+                        "leaf_count": 83,
+                        "leaf_index": 9
+                    },
+                    "left_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 17.150100708007812,
+                        "internal_value": -0.688642,
+                        "internal_count": 1043,
+                        "decision_type": "<=",
+                        "split_index": 11,
+                        "threshold": 1.3235000000000003,
+                        "split_feature": 24,
+                        "right_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 15.38290023803711,
+                            "internal_value": -0.19494,
+                            "internal_count": 222,
+                            "decision_type": "<=",
+                            "split_index": 16,
+                            "threshold": 1.6815000000000002,
+                            "split_feature": 17,
+                            "right_child": {
+                                "leaf_value": 0.04918061225282081,
+                                "leaf_count": 37,
+                                "leaf_index": 17
+                            },
+                            "left_child": {
+                                "leaf_value": -0.021531212566068155,
+                                "leaf_count": 185,
+                                "leaf_index": 12
+                            }
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 29.59440040588379,
+                            "internal_value": -0.822194,
+                            "internal_count": 821,
+                            "decision_type": "<=",
+                            "split_index": 12,
+                            "threshold": 1.0245000000000002,
+                            "split_feature": 27,
+                            "right_child": {
+                                "leaf_value": -0.06434412752900669,
+                                "leaf_count": 329,
+                                "leaf_index": 13
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 18.85689926147461,
+                                "internal_value": -0.511112,
+                                "internal_count": 492,
+                                "decision_type": "<=",
+                                "split_index": 13,
+                                "threshold": -1.5714999999999997,
+                                "split_feature": 15,
+                                "right_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 14.384099960327148,
+                                    "internal_value": -0.593887,
+                                    "internal_count": 471,
+                                    "decision_type": "<=",
+                                    "split_index": 22,
+                                    "threshold": 1.1135000000000004,
+                                    "split_feature": 22,
+                                    "right_child": {
+                                        "leaf_value": 0.018028174110985395,
+                                        "leaf_count": 56,
+                                        "leaf_index": 23
+                                    },
+                                    "left_child": {
+                                        "leaf_value": -0.036112837690524834,
+                                        "leaf_count": 415,
+                                        "leaf_index": 14
+                                    }
+                                },
+                                "left_child": {
+                                    "leaf_value": 0.06732756705191072,
+                                    "leaf_count": 21,
+                                    "leaf_index": 1
+                                }
+                            }
+                        }
+                    }
+                },
+                "left_child": {
+                    "default_left": true,
+                    "missing_type": "None",
+                    "split_gain": 127.28900146484375,
+                    "internal_value": 0.21125,
+                    "internal_count": 4474,
+                    "decision_type": "<=",
+                    "split_index": 1,
+                    "threshold": 0.5925000000000001,
+                    "split_feature": 25,
+                    "right_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 75.0647964477539,
+                        "internal_value": 0.391624,
+                        "internal_count": 3491,
+                        "decision_type": "<=",
+                        "split_index": 2,
+                        "threshold": 0.8765000000000001,
+                        "split_feature": 5,
+                        "right_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 89.79830169677734,
+                            "internal_value": 0.692289,
+                            "internal_count": 1716,
+                            "decision_type": "<=",
+                            "split_index": 3,
+                            "threshold": 0.9025000000000002,
+                            "split_feature": 27,
+                            "right_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 28.470300674438477,
+                                "internal_value": 0.217663,
+                                "internal_count": 827,
+                                "decision_type": "<=",
+                                "split_index": 7,
+                                "threshold": 1.7305000000000004,
+                                "split_feature": 0,
+                                "right_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 16.017499923706055,
+                                    "internal_value": -0.591865,
+                                    "internal_count": 144,
+                                    "decision_type": "<=",
+                                    "split_index": 15,
+                                    "threshold": 1.1275000000000002,
+                                    "split_feature": 6,
+                                    "right_child": {
+                                        "leaf_value": 0.05370827311217738,
+                                        "leaf_count": 20,
+                                        "leaf_index": 16
+                                    },
+                                    "left_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 14.138799667358398,
+                                        "internal_value": -0.859986,
+                                        "internal_count": 124,
+                                        "decision_type": "<=",
+                                        "split_index": 23,
+                                        "threshold": 1.0895000000000004,
+                                        "split_feature": 24,
+                                        "right_child": {
+                                            "leaf_value": -0.008535357073457612,
+                                            "leaf_count": 61,
+                                            "leaf_index": 24
+                                        },
+                                        "left_child": {
+                                            "leaf_value": -0.0762049779108417,
+                                            "leaf_count": 63,
+                                            "leaf_index": 8
+                                        }
+                                    }
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 18.510900497436523,
+                                    "internal_value": 0.388928,
+                                    "internal_count": 683,
+                                    "decision_type": "<=",
+                                    "split_index": 9,
+                                    "threshold": 2.031,
+                                    "split_feature": 3,
+                                    "right_child": {
+                                        "leaf_value": -0.027525204923811993,
+                                        "leaf_count": 75,
+                                        "leaf_index": 10
+                                    },
+                                    "left_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 16.840099334716797,
+                                        "internal_value": 0.505185,
+                                        "internal_count": 608,
+                                        "decision_type": "<=",
+                                        "split_index": 14,
+                                        "threshold": 0.9925,
+                                        "split_feature": 25,
+                                        "right_child": {
+                                            "leaf_value": 0.0010081991369034508,
+                                            "leaf_count": 195,
+                                            "leaf_index": 15
+                                        },
+                                        "left_child": {
+                                            "leaf_value": 0.03676942750097848,
+                                            "leaf_count": 413,
+                                            "leaf_index": 4
+                                        }
+                                    }
+                                }
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 13.226300239562988,
+                                "internal_value": 1.13902,
+                                "internal_count": 889,
+                                "decision_type": "<=",
+                                "split_index": 24,
+                                "threshold": 0.8565000000000002,
+                                "split_feature": 26,
+                                "right_child": {
+                                    "leaf_value": 0.0656137190872182,
+                                    "leaf_count": 596,
+                                    "leaf_index": 25
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 15.933199882507324,
+                                    "internal_value": 0.789112,
+                                    "internal_count": 293,
+                                    "decision_type": "<=",
+                                    "split_index": 25,
+                                    "threshold": 0.9455000000000001,
+                                    "split_feature": 25,
+                                    "right_child": {
+                                        "leaf_value": -0.011575603885787758,
+                                        "leaf_count": 51,
+                                        "leaf_index": 26
+                                    },
+                                    "left_child": {
+                                        "leaf_value": 0.05025890850804274,
+                                        "leaf_count": 242,
+                                        "leaf_index": 3
+                                    }
+                                }
+                            }
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 65.25769805908203,
+                            "internal_value": 0.102792,
+                            "internal_count": 1775,
+                            "decision_type": "<=",
+                            "split_index": 4,
+                            "threshold": 0.7765000000000001,
+                            "split_feature": 26,
+                            "right_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 58.82550048828125,
+                                "internal_value": 0.301926,
+                                "internal_count": 1402,
+                                "decision_type": "<=",
+                                "split_index": 5,
+                                "threshold": 0.9655000000000001,
+                                "split_feature": 25,
+                                "right_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 14.998299598693848,
+                                    "internal_value": -0.352583,
+                                    "internal_count": 395,
+                                    "decision_type": "<=",
+                                    "split_index": 17,
+                                    "threshold": 1.0415000000000003,
+                                    "split_feature": 9,
+                                    "right_child": {
+                                        "leaf_value": 0.014820358184345026,
+                                        "leaf_count": 105,
+                                        "leaf_index": 18
+                                    },
+                                    "left_child": {
+                                        "leaf_value": -0.029367002834117247,
+                                        "leaf_count": 290,
+                                        "leaf_index": 6
+                                    }
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 34.0713996887207,
+                                    "internal_value": 0.560404,
+                                    "internal_count": 1007,
+                                    "decision_type": "<=",
+                                    "split_index": 6,
+                                    "threshold": 0.8575,
+                                    "split_feature": 27,
+                                    "right_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 12.619400024414062,
+                                        "internal_value": 0.147835,
+                                        "internal_count": 447,
+                                        "decision_type": "<=",
+                                        "split_index": 26,
+                                        "threshold": 1.2680000000000005,
+                                        "split_feature": 9,
+                                        "right_child": {
+                                            "leaf_value": 0.04946410316157826,
+                                            "leaf_count": 62,
+                                            "leaf_index": 27
+                                        },
+                                        "left_child": {
+                                            "default_left": true,
+                                            "missing_type": "None",
+                                            "split_gain": 12.267200469970703,
+                                            "internal_value": 0.012748,
+                                            "internal_count": 385,
+                                            "decision_type": "<=",
+                                            "split_index": 28,
+                                            "threshold": 1.7720000000000002,
+                                            "split_feature": 1,
+                                            "right_child": {
+                                                "leaf_value": -0.07028350502438806,
+                                                "leaf_count": 23,
+                                                "leaf_index": 29
+                                            },
+                                            "left_child": {
+                                                "leaf_value": 0.005157775937748892,
+                                                "leaf_count": 362,
+                                                "leaf_index": 7
+                                            }
+                                        }
+                                    },
+                                    "left_child": {
+                                        "leaf_value": 0.04458500618102909,
+                                        "leaf_count": 560,
+                                        "leaf_index": 5
+                                    }
+                                }
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 17.95330047607422,
+                                "internal_value": -0.64053,
+                                "internal_count": 373,
+                                "decision_type": "<=",
+                                "split_index": 10,
+                                "threshold": 0.6415000000000001,
+                                "split_feature": 24,
+                                "right_child": {
+                                    "leaf_value": -0.0428366543858682,
+                                    "leaf_count": 300,
+                                    "leaf_index": 11
+                                },
+                                "left_child": {
+                                    "leaf_value": 0.012545078600408033,
+                                    "leaf_count": 73,
+                                    "leaf_index": 2
+                                }
+                            }
+                        }
+                    },
+                    "left_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 14.63479995727539,
+                        "internal_value": -0.424786,
+                        "internal_count": 983,
+                        "decision_type": "<=",
+                        "split_index": 18,
+                        "threshold": 1.6725,
+                        "split_feature": 9,
+                        "right_child": {
+                            "leaf_value": 0.03982719921284532,
+                            "leaf_count": 38,
+                            "leaf_index": 19
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 15.09160041809082,
+                            "internal_value": -0.473668,
+                            "internal_count": 945,
+                            "decision_type": "<=",
+                            "split_index": 19,
+                            "threshold": 0.9045000000000002,
+                            "split_feature": 27,
+                            "right_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 12.489899635314941,
+                                "internal_value": -0.878815,
+                                "internal_count": 265,
+                                "decision_type": "<=",
+                                "split_index": 27,
+                                "threshold": 1.0025000000000002,
+                                "split_feature": 22,
+                                "right_child": {
+                                    "leaf_value": -0.019859824732034872,
+                                    "leaf_count": 119,
+                                    "leaf_index": 28
+                                },
+                                "left_child": {
+                                    "leaf_value": -0.06354519479303222,
+                                    "leaf_count": 146,
+                                    "leaf_index": 20
+                                }
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 15.638199806213379,
+                                "internal_value": -0.315628,
+                                "internal_count": 680,
+                                "decision_type": "<=",
+                                "split_index": 20,
+                                "threshold": 0.9635000000000001,
+                                "split_feature": 0,
+                                "right_child": {
+                                    "leaf_value": 0.0008553658189908699,
+                                    "leaf_count": 309,
+                                    "leaf_index": 21
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 20.738000869750977,
+                                    "internal_value": -0.592814,
+                                    "internal_count": 371,
+                                    "decision_type": "<=",
+                                    "split_index": 21,
+                                    "threshold": 0.7625000000000001,
+                                    "split_feature": 9,
+                                    "right_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 12.022000312805176,
+                                        "internal_value": -0.109584,
+                                        "internal_count": 182,
+                                        "decision_type": "<=",
+                                        "split_index": 29,
+                                        "threshold": 1.2495000000000003,
+                                        "split_feature": 17,
+                                        "right_child": {
+                                            "leaf_value": 0.04736468922327096,
+                                            "leaf_count": 35,
+                                            "leaf_index": 30
+                                        },
+                                        "left_child": {
+                                            "leaf_value": -0.018032048507286454,
+                                            "leaf_count": 147,
+                                            "leaf_index": 22
+                                        }
+                                    },
+                                    "left_child": {
+                                        "leaf_value": -0.05283813512203198,
+                                        "leaf_count": 189,
+                                        "leaf_index": 0
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "num_cat": 0,
+            "tree_index": 4,
+            "num_leaves": 31,
+            "shrinkage": 0.05,
+            "tree_structure": {
+                "default_left": true,
+                "missing_type": "None",
+                "split_gain": 194.6909942626953,
+                "internal_value": 0,
+                "internal_count": 5600,
+                "decision_type": "<=",
+                "split_index": 0,
+                "threshold": 1.0675000000000001,
+                "split_feature": 25,
+                "right_child": {
+                    "default_left": true,
+                    "missing_type": "None",
+                    "split_gain": 31.62350082397461,
+                    "internal_value": -0.575422,
+                    "internal_count": 1605,
+                    "decision_type": "<=",
+                    "split_index": 7,
+                    "threshold": 1.8325000000000002,
+                    "split_feature": 25,
+                    "right_child": {
+                        "leaf_value": -0.05623356494309058,
+                        "leaf_count": 333,
+                        "leaf_index": 8
+                    },
+                    "left_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 30.778200149536133,
+                        "internal_value": -0.431434,
+                        "internal_count": 1272,
+                        "decision_type": "<=",
+                        "split_index": 8,
+                        "threshold": 1.0375000000000003,
+                        "split_feature": 22,
+                        "right_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 12.146900177001953,
+                            "internal_value": 0.0176726,
+                            "internal_count": 414,
+                            "decision_type": "<=",
+                            "split_index": 21,
+                            "threshold": 1.3295000000000001,
+                            "split_feature": 24,
+                            "right_child": {
+                                "leaf_value": 0.03280330323126142,
+                                "leaf_count": 93,
+                                "leaf_index": 22
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 17.579500198364258,
+                                "internal_value": -0.167076,
+                                "internal_count": 321,
+                                "decision_type": "<=",
+                                "split_index": 22,
+                                "threshold": 1.0880000000000003,
+                                "split_feature": 2,
+                                "right_child": {
+                                    "leaf_value": 0.04227664296685561,
+                                    "leaf_count": 57,
+                                    "leaf_index": 23
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 13.672699928283691,
+                                    "internal_value": -0.384424,
+                                    "internal_count": 264,
+                                    "decision_type": "<=",
+                                    "split_index": 23,
+                                    "threshold": 1.1575000000000002,
+                                    "split_feature": 27,
+                                    "right_child": {
+                                        "leaf_value": -0.05535261970841046,
+                                        "leaf_count": 75,
+                                        "leaf_index": 24
+                                    },
+                                    "left_child": {
+                                        "leaf_value": -0.004834990648004064,
+                                        "leaf_count": 189,
+                                        "leaf_index": 9
+                                    }
+                                }
+                            }
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 28.887399673461914,
+                            "internal_value": -0.647751,
+                            "internal_count": 858,
+                            "decision_type": "<=",
+                            "split_index": 9,
+                            "threshold": 1.0025000000000002,
+                            "split_feature": 27,
+                            "right_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 10.882499694824219,
+                                "internal_value": -1.18864,
+                                "internal_count": 271,
+                                "decision_type": "<=",
+                                "split_index": 29,
+                                "threshold": 1.5145000000000002,
+                                "split_feature": 24,
+                                "right_child": {
+                                    "leaf_value": -0.026094703207454883,
+                                    "leaf_count": 72,
+                                    "leaf_index": 30
+                                },
+                                "left_child": {
+                                    "leaf_value": -0.07151355565317757,
+                                    "leaf_count": 199,
+                                    "leaf_index": 10
+                                }
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 19.760499954223633,
+                                "internal_value": -0.397977,
+                                "internal_count": 587,
+                                "decision_type": "<=",
+                                "split_index": 11,
+                                "threshold": 1.1885000000000001,
+                                "split_feature": 5,
+                                "right_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 13.227800369262695,
+                                    "internal_value": 0.381001,
+                                    "internal_count": 107,
+                                    "decision_type": "<=",
+                                    "split_index": 19,
+                                    "threshold": 0.9895000000000002,
+                                    "split_feature": 24,
+                                    "right_child": {
+                                        "leaf_value": 0.05809328072381867,
+                                        "leaf_count": 48,
+                                        "leaf_index": 20
+                                    },
+                                    "left_child": {
+                                        "leaf_value": -0.012749956914877451,
+                                        "leaf_count": 59,
+                                        "leaf_index": 12
+                                    }
+                                },
+                                "left_child": {
+                                    "leaf_value": -0.02856991413064194,
+                                    "leaf_count": 480,
+                                    "leaf_index": 1
+                                }
+                            }
+                        }
+                    }
+                },
+                "left_child": {
+                    "default_left": true,
+                    "missing_type": "None",
+                    "split_gain": 142.1219940185547,
+                    "internal_value": 0.25167,
+                    "internal_count": 3995,
+                    "decision_type": "<=",
+                    "split_index": 1,
+                    "threshold": 0.6655000000000001,
+                    "split_feature": 25,
+                    "right_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 71.64900207519531,
+                        "internal_value": 0.516861,
+                        "internal_count": 2694,
+                        "decision_type": "<=",
+                        "split_index": 2,
+                        "threshold": 0.7765000000000001,
+                        "split_feature": 26,
+                        "right_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 76.30500030517578,
+                            "internal_value": 0.648531,
+                            "internal_count": 2325,
+                            "decision_type": "<=",
+                            "split_index": 3,
+                            "threshold": 0.9045000000000002,
+                            "split_feature": 27,
+                            "right_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 18.418399810791016,
+                                "internal_value": 0.218695,
+                                "internal_count": 967,
+                                "decision_type": "<=",
+                                "split_index": 13,
+                                "threshold": 1.7675000000000003,
+                                "split_feature": 3,
+                                "right_child": {
+                                    "leaf_value": -0.01900973069715526,
+                                    "leaf_count": 170,
+                                    "leaf_index": 14
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 18.214500427246094,
+                                    "internal_value": 0.34697,
+                                    "internal_count": 797,
+                                    "decision_type": "<=",
+                                    "split_index": 14,
+                                    "threshold": 1.1805,
+                                    "split_feature": 24,
+                                    "right_child": {
+                                        "leaf_value": 0.034352233131797014,
+                                        "leaf_count": 354,
+                                        "leaf_index": 15
+                                    },
+                                    "left_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 32.4541015625,
+                                        "internal_value": 0.0757222,
+                                        "internal_count": 443,
+                                        "decision_type": "<=",
+                                        "split_index": 15,
+                                        "threshold": 1.0215000000000003,
+                                        "split_feature": 22,
+                                        "right_child": {
+                                            "leaf_value": 0.027188767307502644,
+                                            "leaf_count": 255,
+                                            "leaf_index": 16
+                                        },
+                                        "left_child": {
+                                            "default_left": true,
+                                            "missing_type": "None",
+                                            "split_gain": 18.22089958190918,
+                                            "internal_value": -0.555514,
+                                            "internal_count": 188,
+                                            "decision_type": "<=",
+                                            "split_index": 16,
+                                            "threshold": 0.9995000000000002,
+                                            "split_feature": 24,
+                                            "right_child": {
+                                                "leaf_value": 0.015253321605778136,
+                                                "leaf_count": 65,
+                                                "leaf_index": 17
+                                            },
+                                            "left_child": {
+                                                "leaf_value": -0.05041086767644968,
+                                                "leaf_count": 123,
+                                                "leaf_index": 4
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 37.636600494384766,
+                                "internal_value": 0.959129,
+                                "internal_count": 1358,
+                                "decision_type": "<=",
+                                "split_index": 5,
+                                "threshold": 0.8585000000000002,
+                                "split_feature": 26,
+                                "right_child": {
+                                    "leaf_value": 0.05910022902797499,
+                                    "leaf_count": 948,
+                                    "leaf_index": 6
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 32.012699127197266,
+                                    "internal_value": 0.450172,
+                                    "internal_count": 410,
+                                    "decision_type": "<=",
+                                    "split_index": 6,
+                                    "threshold": 0.8395000000000001,
+                                    "split_feature": 25,
+                                    "right_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 19.6466007232666,
+                                        "internal_value": -0.172072,
+                                        "internal_count": 184,
+                                        "decision_type": "<=",
+                                        "split_index": 12,
+                                        "threshold": 1.3185000000000002,
+                                        "split_feature": 0,
+                                        "right_child": {
+                                            "leaf_value": -0.0787620355812596,
+                                            "leaf_count": 33,
+                                            "leaf_index": 13
+                                        },
+                                        "left_child": {
+                                            "leaf_value": 0.006792059247597521,
+                                            "leaf_count": 151,
+                                            "leaf_index": 7
+                                        }
+                                    },
+                                    "left_child": {
+                                        "leaf_value": 0.04796597637468507,
+                                        "leaf_count": 226,
+                                        "leaf_index": 3
+                                    }
+                                }
+                            }
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 38.332401275634766,
+                            "internal_value": -0.30355,
+                            "internal_count": 369,
+                            "decision_type": "<=",
+                            "split_index": 4,
+                            "threshold": 0.8205000000000001,
+                            "split_feature": 5,
+                            "right_child": {
+                                "leaf_value": 0.030596900733977667,
+                                "leaf_count": 124,
+                                "leaf_index": 5
+                            },
+                            "left_child": {
+                                "leaf_value": -0.03800082533041335,
+                                "leaf_count": 245,
+                                "leaf_index": 2
+                            }
+                        }
+                    },
+                    "left_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 26.565099716186523,
+                        "internal_value": -0.291137,
+                        "internal_count": 1301,
+                        "decision_type": "<=",
+                        "split_index": 10,
+                        "threshold": 1.1375000000000002,
+                        "split_feature": 9,
+                        "right_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 11.410300254821777,
+                            "internal_value": 0.320646,
+                            "internal_count": 235,
+                            "decision_type": "<=",
+                            "split_index": 28,
+                            "threshold": 0.8265000000000001,
+                            "split_feature": 27,
+                            "right_child": {
+                                "leaf_value": -0.0034574710212144106,
+                                "leaf_count": 132,
+                                "leaf_index": 29
+                            },
+                            "left_child": {
+                                "leaf_value": 0.04117025094658683,
+                                "leaf_count": 103,
+                                "leaf_index": 11
+                            }
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 13.878700256347656,
+                            "internal_value": -0.425138,
+                            "internal_count": 1066,
+                            "decision_type": "<=",
+                            "split_index": 17,
+                            "threshold": 0.8525000000000001,
+                            "split_feature": 27,
+                            "right_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 11.951199531555176,
+                                "internal_value": -0.743008,
+                                "internal_count": 363,
+                                "decision_type": "<=",
+                                "split_index": 24,
+                                "threshold": 1.1665000000000003,
+                                "split_feature": 22,
+                                "right_child": {
+                                    "leaf_value": -0.0018264826784593865,
+                                    "leaf_count": 76,
+                                    "leaf_index": 25
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 12.767399787902832,
+                                    "internal_value": -0.929805,
+                                    "internal_count": 287,
+                                    "decision_type": "<=",
+                                    "split_index": 25,
+                                    "threshold": 1.0405000000000002,
+                                    "split_feature": 24,
+                                    "right_child": {
+                                        "leaf_value": -0.022621308658177658,
+                                        "leaf_count": 126,
+                                        "leaf_index": 26
+                                    },
+                                    "left_child": {
+                                        "leaf_value": -0.06516053461874326,
+                                        "leaf_count": 161,
+                                        "leaf_index": 18
+                                    }
+                                }
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 23.319599151611328,
+                                "internal_value": -0.260887,
+                                "internal_count": 703,
+                                "decision_type": "<=",
+                                "split_index": 18,
+                                "threshold": 0.7905000000000001,
+                                "split_feature": 26,
+                                "right_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 12.370800018310547,
+                                    "internal_value": 0.309007,
+                                    "internal_count": 205,
+                                    "decision_type": "<=",
+                                    "split_index": 20,
+                                    "threshold": 1.3735000000000004,
+                                    "split_feature": 13,
+                                    "right_child": {
+                                        "leaf_value": 0.09062970417681511,
+                                        "leaf_count": 20,
+                                        "leaf_index": 21
+                                    },
+                                    "left_child": {
+                                        "leaf_value": 0.007373786447235033,
+                                        "leaf_count": 185,
+                                        "leaf_index": 19
+                                    }
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 11.443699836730957,
+                                    "internal_value": -0.494363,
+                                    "internal_count": 498,
+                                    "decision_type": "<=",
+                                    "split_index": 26,
+                                    "threshold": 1.1035000000000001,
+                                    "split_feature": 22,
+                                    "right_child": {
+                                        "leaf_value": 0.04424699827030071,
+                                        "leaf_count": 23,
+                                        "leaf_index": 27
+                                    },
+                                    "left_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 11.86050033569336,
+                                        "internal_value": -0.561096,
+                                        "internal_count": 475,
+                                        "decision_type": "<=",
+                                        "split_index": 27,
+                                        "threshold": -1.1714999999999998,
+                                        "split_feature": 19,
+                                        "right_child": {
+                                            "leaf_value": -0.03532916464807494,
+                                            "leaf_count": 392,
+                                            "leaf_index": 28
+                                        },
+                                        "left_child": {
+                                            "leaf_value": 0.006317139306399872,
+                                            "leaf_count": 83,
+                                            "leaf_index": 0
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "num_cat": 0,
+            "tree_index": 5,
+            "num_leaves": 31,
+            "shrinkage": 0.05,
+            "tree_structure": {
+                "default_left": true,
+                "missing_type": "None",
+                "split_gain": 192.88999938964844,
+                "internal_value": 0,
+                "internal_count": 5600,
+                "decision_type": "<=",
+                "split_index": 0,
+                "threshold": 1.1785000000000003,
+                "split_feature": 25,
+                "right_child": {
+                    "default_left": true,
+                    "missing_type": "None",
+                    "split_gain": 23.936800003051758,
+                    "internal_value": -0.680014,
+                    "internal_count": 1267,
+                    "decision_type": "<=",
+                    "split_index": 6,
+                    "threshold": 1.4915,
+                    "split_feature": 25,
+                    "right_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 14.924699783325195,
+                        "internal_value": -0.93448,
+                        "internal_count": 684,
+                        "decision_type": "<=",
+                        "split_index": 18,
+                        "threshold": 1.8335000000000004,
+                        "split_feature": 3,
+                        "right_child": {
+                            "leaf_value": -0.09214831430659225,
+                            "leaf_count": 66,
+                            "leaf_index": 19
+                        },
+                        "left_child": {
+                            "leaf_value": -0.04189663114073873,
+                            "leaf_count": 618,
+                            "leaf_index": 7
+                        }
+                    },
+                    "left_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 19.76849937438965,
+                        "internal_value": -0.381653,
+                        "internal_count": 583,
+                        "decision_type": "<=",
+                        "split_index": 8,
+                        "threshold": 1.0105000000000002,
+                        "split_feature": 22,
+                        "right_child": {
+                            "leaf_value": 0.005720407493428572,
+                            "leaf_count": 208,
+                            "leaf_index": 9
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 16.37299919128418,
+                            "internal_value": -0.656255,
+                            "internal_count": 375,
+                            "decision_type": "<=",
+                            "split_index": 11,
+                            "threshold": 0.8815000000000001,
+                            "split_feature": 22,
+                            "right_child": {
+                                "leaf_value": -0.05260998884468659,
+                                "leaf_count": 198,
+                                "leaf_index": 12
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 10.255800247192383,
+                                "internal_value": -0.213576,
+                                "internal_count": 177,
+                                "decision_type": "<=",
+                                "split_index": 27,
+                                "threshold": 1.0515,
+                                "split_feature": 24,
+                                "right_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 11.539999961853027,
+                                    "internal_value": 0.375319,
+                                    "internal_count": 71,
+                                    "decision_type": "<=",
+                                    "split_index": 28,
+                                    "threshold": 0.9885000000000002,
+                                    "split_feature": 23,
+                                    "right_child": {
+                                        "leaf_value": 0.05330846300802286,
+                                        "leaf_count": 41,
+                                        "leaf_index": 29
+                                    },
+                                    "left_child": {
+                                        "leaf_value": -0.02841342076721462,
+                                        "leaf_count": 30,
+                                        "leaf_index": 28
+                                    }
+                                },
+                                "left_child": {
+                                    "leaf_value": -0.03042250385328801,
+                                    "leaf_count": 106,
+                                    "leaf_index": 1
+                                }
+                            }
+                        }
+                    }
+                },
+                "left_child": {
+                    "default_left": true,
+                    "missing_type": "None",
+                    "split_gain": 108.44499969482422,
+                    "internal_value": 0.210161,
+                    "internal_count": 4333,
+                    "decision_type": "<=",
+                    "split_index": 1,
+                    "threshold": 0.5925000000000001,
+                    "split_feature": 25,
+                    "right_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 69.7510986328125,
+                        "internal_value": 0.386299,
+                        "internal_count": 3330,
+                        "decision_type": "<=",
+                        "split_index": 2,
+                        "threshold": 0.7765000000000001,
+                        "split_feature": 26,
+                        "right_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 59.1077995300293,
+                            "internal_value": 0.509124,
+                            "internal_count": 2835,
+                            "decision_type": "<=",
+                            "split_index": 3,
+                            "threshold": 0.9845000000000002,
+                            "split_feature": 25,
+                            "right_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 17.105899810791016,
+                                "internal_value": -0.0228187,
+                                "internal_count": 649,
+                                "decision_type": "<=",
+                                "split_index": 10,
+                                "threshold": 1.1815000000000002,
+                                "split_feature": 5,
+                                "right_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 15.56820011138916,
+                                    "internal_value": 0.535939,
+                                    "internal_count": 166,
+                                    "decision_type": "<=",
+                                    "split_index": 15,
+                                    "threshold": 1.4105,
+                                    "split_feature": 0,
+                                    "right_child": {
+                                        "leaf_value": -0.023702451850464618,
+                                        "leaf_count": 45,
+                                        "leaf_index": 16
+                                    },
+                                    "left_child": {
+                                        "leaf_value": 0.045662040532870804,
+                                        "leaf_count": 121,
+                                        "leaf_index": 11
+                                    }
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 10.899399757385254,
+                                    "internal_value": -0.213419,
+                                    "internal_count": 483,
+                                    "decision_type": "<=",
+                                    "split_index": 22,
+                                    "threshold": 0.4035,
+                                    "split_feature": 0,
+                                    "right_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 9.953969955444336,
+                                        "internal_value": -0.297791,
+                                        "internal_count": 448,
+                                        "decision_type": "<=",
+                                        "split_index": 29,
+                                        "threshold": 0.8865000000000001,
+                                        "split_feature": 26,
+                                        "right_child": {
+                                            "leaf_value": -0.006850568907481543,
+                                            "leaf_count": 348,
+                                            "leaf_index": 30
+                                        },
+                                        "left_child": {
+                                            "leaf_value": -0.04275786918907786,
+                                            "leaf_count": 100,
+                                            "leaf_index": 23
+                                        }
+                                    },
+                                    "left_child": {
+                                        "leaf_value": 0.04326081205557945,
+                                        "leaf_count": 35,
+                                        "leaf_index": 4
+                                    }
+                                }
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 32.762001037597656,
+                                "internal_value": 0.668984,
+                                "internal_count": 2186,
+                                "decision_type": "<=",
+                                "split_index": 4,
+                                "threshold": 1.5465000000000002,
+                                "split_feature": 3,
+                                "right_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 18.736000061035156,
+                                    "internal_value": 0.0871953,
+                                    "internal_count": 332,
+                                    "decision_type": "<=",
+                                    "split_index": 9,
+                                    "threshold": 0.7325,
+                                    "split_feature": 13,
+                                    "right_child": {
+                                        "leaf_value": -0.012200638452234373,
+                                        "leaf_count": 224,
+                                        "leaf_index": 10
+                                    },
+                                    "left_child": {
+                                        "leaf_value": 0.0388735743305588,
+                                        "leaf_count": 108,
+                                        "leaf_index": 5
+                                    }
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 21.602100372314453,
+                                    "internal_value": 0.774345,
+                                    "internal_count": 1854,
+                                    "decision_type": "<=",
+                                    "split_index": 7,
+                                    "threshold": 1.4035000000000004,
+                                    "split_feature": 0,
+                                    "right_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 16.007999420166016,
+                                        "internal_value": 0.353689,
+                                        "internal_count": 393,
+                                        "decision_type": "<=",
+                                        "split_index": 12,
+                                        "threshold": 0.6815000000000001,
+                                        "split_feature": 1,
+                                        "right_child": {
+                                            "leaf_value": -0.02081601113206544,
+                                            "leaf_count": 86,
+                                            "leaf_index": 13
+                                        },
+                                        "left_child": {
+                                            "leaf_value": 0.028496265126571413,
+                                            "leaf_count": 307,
+                                            "leaf_index": 8
+                                        }
+                                    },
+                                    "left_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 15.257499694824219,
+                                        "internal_value": 0.887829,
+                                        "internal_count": 1461,
+                                        "decision_type": "<=",
+                                        "split_index": 16,
+                                        "threshold": 0.8815000000000001,
+                                        "split_feature": 5,
+                                        "right_child": {
+                                            "leaf_value": 0.054817500910836175,
+                                            "leaf_count": 729,
+                                            "leaf_index": 17
+                                        },
+                                        "left_child": {
+                                            "default_left": true,
+                                            "missing_type": "None",
+                                            "split_gain": 10.266599655151367,
+                                            "internal_value": 0.682512,
+                                            "internal_count": 732,
+                                            "decision_type": "<=",
+                                            "split_index": 25,
+                                            "threshold": 0.7465,
+                                            "split_feature": 25,
+                                            "right_child": {
+                                                "leaf_value": 0.0415258994986579,
+                                                "leaf_count": 530,
+                                                "leaf_index": 26
+                                            },
+                                            "left_child": {
+                                                "default_left": true,
+                                                "missing_type": "None",
+                                                "split_gain": 13.502799987792969,
+                                                "internal_value": 0.296217,
+                                                "internal_count": 202,
+                                                "decision_type": "<=",
+                                                "split_index": 26,
+                                                "threshold": 0.7515000000000001,
+                                                "split_feature": 24,
+                                                "right_child": {
+                                                    "leaf_value": 0.0020889430227382993,
+                                                    "leaf_count": 163,
+                                                    "leaf_index": 27
+                                                },
+                                                "left_child": {
+                                                    "leaf_value": 0.06815505066066214,
+                                                    "leaf_count": 39,
+                                                    "leaf_index": 3
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 31.91699981689453,
+                            "internal_value": -0.307886,
+                            "internal_count": 495,
+                            "decision_type": "<=",
+                            "split_index": 5,
+                            "threshold": 0.8015000000000001,
+                            "split_feature": 5,
+                            "right_child": {
+                                "leaf_value": 0.019758702390676477,
+                                "leaf_count": 172,
+                                "leaf_index": 6
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 11.817000389099121,
+                                "internal_value": -0.677018,
+                                "internal_count": 323,
+                                "decision_type": "<=",
+                                "split_index": 21,
+                                "threshold": 0.7185000000000001,
+                                "split_feature": 24,
+                                "right_child": {
+                                    "leaf_value": -0.048471081074360683,
+                                    "leaf_count": 204,
+                                    "leaf_index": 22
+                                },
+                                "left_child": {
+                                    "leaf_value": -0.008794143061896144,
+                                    "leaf_count": 119,
+                                    "leaf_index": 2
+                                }
+                            }
+                        }
+                    },
+                    "left_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 15.962400436401367,
+                        "internal_value": -0.366302,
+                        "internal_count": 1003,
+                        "decision_type": "<=",
+                        "split_index": 13,
+                        "threshold": 0.9405,
+                        "split_feature": 13,
+                        "right_child": {
+                            "leaf_value": -0.00017050800913077392,
+                            "leaf_count": 328,
+                            "leaf_index": 14
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 19.261499404907227,
+                            "internal_value": -0.542276,
+                            "internal_count": 675,
+                            "decision_type": "<=",
+                            "split_index": 14,
+                            "threshold": 0.9075000000000001,
+                            "split_feature": 0,
+                            "right_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 14.959400177001953,
+                                "internal_value": -0.224843,
+                                "internal_count": 359,
+                                "decision_type": "<=",
+                                "split_index": 17,
+                                "threshold": 1.0115,
+                                "split_feature": 9,
+                                "right_child": {
+                                    "leaf_value": 0.030413765878151307,
+                                    "leaf_count": 70,
+                                    "leaf_index": 18
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 12.595399856567383,
+                                    "internal_value": -0.425445,
+                                    "internal_count": 289,
+                                    "decision_type": "<=",
+                                    "split_index": 19,
+                                    "threshold": 0.8965000000000001,
+                                    "split_feature": 22,
+                                    "right_child": {
+                                        "leaf_value": -0.043279421705698415,
+                                        "leaf_count": 137,
+                                        "leaf_index": 20
+                                    },
+                                    "left_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 12.414999961853027,
+                                        "internal_value": -0.0287622,
+                                        "internal_count": 152,
+                                        "decision_type": "<=",
+                                        "split_index": 20,
+                                        "threshold": 1.0955000000000001,
+                                        "split_feature": 5,
+                                        "right_child": {
+                                            "leaf_value": -0.06750766322312073,
+                                            "leaf_count": 24,
+                                            "leaf_index": 21
+                                        },
+                                        "left_child": {
+                                            "leaf_value": 0.010942769989479764,
+                                            "leaf_count": 128,
+                                            "leaf_index": 15
+                                        }
+                                    }
+                                }
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 10.872300148010254,
+                                "internal_value": -0.902745,
+                                "internal_count": 316,
+                                "decision_type": "<=",
+                                "split_index": 23,
+                                "threshold": 0.7325,
+                                "split_feature": 24,
+                                "right_child": {
+                                    "leaf_value": -0.061493200221684474,
+                                    "leaf_count": 178,
+                                    "leaf_index": 24
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 13.132399559020996,
+                                    "internal_value": -0.481086,
+                                    "internal_count": 138,
+                                    "decision_type": "<=",
+                                    "split_index": 24,
+                                    "threshold": 0.9405,
+                                    "split_feature": 22,
+                                    "right_child": {
+                                        "leaf_value": 0.018257287940461338,
+                                        "leaf_count": 48,
+                                        "leaf_index": 25
+                                    },
+                                    "left_child": {
+                                        "leaf_value": -0.04658716920028107,
+                                        "leaf_count": 90,
+                                        "leaf_index": 0
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "num_cat": 0,
+            "tree_index": 6,
+            "num_leaves": 31,
+            "shrinkage": 0.05,
+            "tree_structure": {
+                "default_left": true,
+                "missing_type": "None",
+                "split_gain": 108.2030029296875,
+                "internal_value": 0,
+                "internal_count": 5600,
+                "decision_type": "<=",
+                "split_index": 0,
+                "threshold": 0.9045000000000002,
+                "split_feature": 27,
+                "right_child": {
+                    "default_left": true,
+                    "missing_type": "None",
+                    "split_gain": 62.4817008972168,
+                    "internal_value": -0.31354,
+                    "internal_count": 2411,
+                    "decision_type": "<=",
+                    "split_index": 2,
+                    "threshold": 1.0265000000000002,
+                    "split_feature": 24,
+                    "right_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 18.01959991455078,
+                        "internal_value": -0.0377304,
+                        "internal_count": 1396,
+                        "decision_type": "<=",
+                        "split_index": 8,
+                        "threshold": 1.0105000000000002,
+                        "split_feature": 27,
+                        "right_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 12.04170036315918,
+                            "internal_value": -0.180886,
+                            "internal_count": 1002,
+                            "decision_type": "<=",
+                            "split_index": 14,
+                            "threshold": 2.3415000000000004,
+                            "split_feature": 24,
+                            "right_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 9.282190322875977,
+                                "internal_value": -0.972273,
+                                "internal_count": 72,
+                                "decision_type": "<=",
+                                "split_index": 29,
+                                "threshold": 0.6590000000000001,
+                                "split_feature": 1,
+                                "right_child": {
+                                    "leaf_value": 0.009491327274361198,
+                                    "leaf_count": 20,
+                                    "leaf_index": 30
+                                },
+                                "left_child": {
+                                    "leaf_value": -0.0709941702823386,
+                                    "leaf_count": 52,
+                                    "leaf_index": 15
+                                }
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 14.077099800109863,
+                                "internal_value": -0.119579,
+                                "internal_count": 930,
+                                "decision_type": "<=",
+                                "split_index": 15,
+                                "threshold": 1.0465000000000002,
+                                "split_feature": 22,
+                                "right_child": {
+                                    "leaf_value": 0.006585673395599512,
+                                    "leaf_count": 458,
+                                    "leaf_index": 16
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 11.094400405883789,
+                                    "internal_value": -0.362772,
+                                    "internal_count": 472,
+                                    "decision_type": "<=",
+                                    "split_index": 21,
+                                    "threshold": 0.7445000000000002,
+                                    "split_feature": 22,
+                                    "right_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 11.15530014038086,
+                                        "internal_value": -0.469777,
+                                        "internal_count": 421,
+                                        "decision_type": "<=",
+                                        "split_index": 22,
+                                        "threshold": 1.1485,
+                                        "split_feature": 13,
+                                        "right_child": {
+                                            "leaf_value": -0.04479038577435308,
+                                            "leaf_count": 156,
+                                            "leaf_index": 23
+                                        },
+                                        "left_child": {
+                                            "default_left": true,
+                                            "missing_type": "None",
+                                            "split_gain": 14.96310043334961,
+                                            "internal_value": -0.219072,
+                                            "internal_count": 265,
+                                            "decision_type": "<=",
+                                            "split_index": 23,
+                                            "threshold": -0.9654999999999999,
+                                            "split_feature": 11,
+                                            "right_child": {
+                                                "leaf_value": -0.024415656538543464,
+                                                "leaf_count": 201,
+                                                "leaf_index": 24
+                                            },
+                                            "left_child": {
+                                                "leaf_value": 0.031308673960816456,
+                                                "leaf_count": 64,
+                                                "leaf_index": 22
+                                            }
+                                        }
+                                    },
+                                    "left_child": {
+                                        "leaf_value": 0.026146556963151303,
+                                        "leaf_count": 51,
+                                        "leaf_index": 9
+                                    }
+                                }
+                            }
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 9.770009994506836,
+                            "internal_value": 0.32628,
+                            "internal_count": 394,
+                            "decision_type": "<=",
+                            "split_index": 28,
+                            "threshold": 1.3115,
+                            "split_feature": 9,
+                            "right_child": {
+                                "leaf_value": 0.05012936507903981,
+                                "leaf_count": 71,
+                                "leaf_index": 29
+                            },
+                            "left_child": {
+                                "leaf_value": 0.008913876847150155,
+                                "leaf_count": 323,
+                                "leaf_index": 3
+                            }
+                        }
+                    },
+                    "left_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 71.55719757080078,
+                        "internal_value": -0.692847,
+                        "internal_count": 1015,
+                        "decision_type": "<=",
+                        "split_index": 3,
+                        "threshold": 1.0485000000000004,
+                        "split_feature": 22,
+                        "right_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 16.84440040588379,
+                            "internal_value": -0.0747375,
+                            "internal_count": 434,
+                            "decision_type": "<=",
+                            "split_index": 9,
+                            "threshold": 1.3665,
+                            "split_feature": 26,
+                            "right_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 11.896200180053711,
+                                "internal_value": -0.657533,
+                                "internal_count": 137,
+                                "decision_type": "<=",
+                                "split_index": 16,
+                                "threshold": 1.7005000000000003,
+                                "split_feature": 22,
+                                "right_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 11.761199951171875,
+                                    "internal_value": -0.0688789,
+                                    "internal_count": 69,
+                                    "decision_type": "<=",
+                                    "split_index": 18,
+                                    "threshold": 1.6300000000000001,
+                                    "split_feature": 8,
+                                    "right_child": {
+                                        "leaf_value": -0.06403378697672668,
+                                        "leaf_count": 22,
+                                        "leaf_index": 19
+                                    },
+                                    "left_child": {
+                                        "leaf_value": 0.024997454064979333,
+                                        "leaf_count": 47,
+                                        "leaf_index": 17
+                                    }
+                                },
+                                "left_child": {
+                                    "leaf_value": -0.06266528806447566,
+                                    "leaf_count": 68,
+                                    "leaf_index": 10
+                                }
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 11.84469985961914,
+                                "internal_value": 0.194527,
+                                "internal_count": 297,
+                                "decision_type": "<=",
+                                "split_index": 17,
+                                "threshold": 0.7935000000000001,
+                                "split_feature": 24,
+                                "right_child": {
+                                    "leaf_value": -0.004249383994449662,
+                                    "leaf_count": 200,
+                                    "leaf_index": 18
+                                },
+                                "left_child": {
+                                    "leaf_value": 0.038585601480803866,
+                                    "leaf_count": 97,
+                                    "leaf_index": 4
+                                }
+                            }
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 18.084299087524414,
+                            "internal_value": -1.15326,
+                            "internal_count": 581,
+                            "decision_type": "<=",
+                            "split_index": 7,
+                            "threshold": 0.7325,
+                            "split_feature": 24,
+                            "right_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 11.423100471496582,
+                                "internal_value": -1.30305,
+                                "internal_count": 493,
+                                "decision_type": "<=",
+                                "split_index": 20,
+                                "threshold": 0.7885000000000001,
+                                "split_feature": 22,
+                                "right_child": {
+                                    "leaf_value": -0.07074454221847941,
+                                    "leaf_count": 435,
+                                    "leaf_index": 21
+                                },
+                                "left_child": {
+                                    "leaf_value": -0.02337641076875526,
+                                    "leaf_count": 58,
+                                    "leaf_index": 8
+                                }
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 10.204299926757812,
+                                "internal_value": -0.315494,
+                                "internal_count": 88,
+                                "decision_type": "<=",
+                                "split_index": 24,
+                                "threshold": 1.0925000000000002,
+                                "split_feature": 27,
+                                "right_child": {
+                                    "leaf_value": -0.05893210023055978,
+                                    "leaf_count": 34,
+                                    "leaf_index": 25
+                                },
+                                "left_child": {
+                                    "leaf_value": 0.011268058191336488,
+                                    "leaf_count": 54,
+                                    "leaf_index": 1
+                                }
+                            }
+                        }
+                    }
+                },
+                "left_child": {
+                    "default_left": true,
+                    "missing_type": "None",
+                    "split_gain": 113.88800048828125,
+                    "internal_value": 0.251708,
+                    "internal_count": 3189,
+                    "decision_type": "<=",
+                    "split_index": 1,
+                    "threshold": 0.8115000000000001,
+                    "split_feature": 26,
+                    "right_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 23.191999435424805,
+                        "internal_value": 0.552723,
+                        "internal_count": 1981,
+                        "decision_type": "<=",
+                        "split_index": 5,
+                        "threshold": 0.8815000000000001,
+                        "split_feature": 5,
+                        "right_child": {
+                            "leaf_value": 0.038698875035779894,
+                            "leaf_count": 989,
+                            "leaf_index": 6
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 19.90559959411621,
+                            "internal_value": 0.335319,
+                            "internal_count": 992,
+                            "decision_type": "<=",
+                            "split_index": 6,
+                            "threshold": 1.0375000000000003,
+                            "split_feature": 22,
+                            "right_child": {
+                                "leaf_value": 0.04437270577922282,
+                                "leaf_count": 211,
+                                "leaf_index": 7
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 10.099200248718262,
+                                "internal_value": 0.187072,
+                                "internal_count": 781,
+                                "decision_type": "<=",
+                                "split_index": 25,
+                                "threshold": 0.7775000000000002,
+                                "split_feature": 0,
+                                "right_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 17.909000396728516,
+                                    "internal_value": 0.381773,
+                                    "internal_count": 455,
+                                    "decision_type": "<=",
+                                    "split_index": 26,
+                                    "threshold": 0.8385000000000001,
+                                    "split_feature": 27,
+                                    "right_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 10.777199745178223,
+                                        "internal_value": -0.26667,
+                                        "internal_count": 125,
+                                        "decision_type": "<=",
+                                        "split_index": 27,
+                                        "threshold": 0.9015000000000001,
+                                        "split_feature": 26,
+                                        "right_child": {
+                                            "leaf_value": 0.00860103163412414,
+                                            "leaf_count": 81,
+                                            "leaf_index": 28
+                                        },
+                                        "left_child": {
+                                            "leaf_value": -0.05319114381872993,
+                                            "leaf_count": 44,
+                                            "leaf_index": 27
+                                        }
+                                    },
+                                    "left_child": {
+                                        "leaf_value": 0.03147509770493691,
+                                        "leaf_count": 330,
+                                        "leaf_index": 26
+                                    }
+                                },
+                                "left_child": {
+                                    "leaf_value": -0.004174484751935473,
+                                    "leaf_count": 326,
+                                    "leaf_index": 2
+                                }
+                            }
+                        }
+                    },
+                    "left_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 28.303199768066406,
+                        "internal_value": -0.231998,
+                        "internal_count": 1208,
+                        "decision_type": "<=",
+                        "split_index": 4,
+                        "threshold": 1.3365000000000002,
+                        "split_feature": 5,
+                        "right_child": {
+                            "leaf_value": 0.04758087728215744,
+                            "leaf_count": 77,
+                            "leaf_index": 5
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 12.439399719238281,
+                            "internal_value": -0.311695,
+                            "internal_count": 1131,
+                            "decision_type": "<=",
+                            "split_index": 10,
+                            "threshold": 0.7045000000000001,
+                            "split_feature": 5,
+                            "right_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 11.641900062561035,
+                                "internal_value": -0.0793613,
+                                "internal_count": 511,
+                                "decision_type": "<=",
+                                "split_index": 19,
+                                "threshold": 0.7605000000000001,
+                                "split_feature": 27,
+                                "right_child": {
+                                    "leaf_value": -0.030174783997138344,
+                                    "leaf_count": 128,
+                                    "leaf_index": 20
+                                },
+                                "left_child": {
+                                    "leaf_value": 0.004801831932042917,
+                                    "leaf_count": 383,
+                                    "leaf_index": 11
+                                }
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 13.33899974822998,
+                                "internal_value": -0.502155,
+                                "internal_count": 620,
+                                "decision_type": "<=",
+                                "split_index": 11,
+                                "threshold": 0.7675000000000002,
+                                "split_feature": 26,
+                                "right_child": {
+                                    "leaf_value": 0.0020291256574576553,
+                                    "leaf_count": 141,
+                                    "leaf_index": 12
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 12.144800186157227,
+                                    "internal_value": -0.661254,
+                                    "internal_count": 479,
+                                    "decision_type": "<=",
+                                    "split_index": 12,
+                                    "threshold": 0.7105,
+                                    "split_feature": 24,
+                                    "right_child": {
+                                        "leaf_value": -0.046398978090121,
+                                        "leaf_count": 282,
+                                        "leaf_index": 13
+                                    },
+                                    "left_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 12.526300430297852,
+                                        "internal_value": -0.280095,
+                                        "internal_count": 197,
+                                        "decision_type": "<=",
+                                        "split_index": 13,
+                                        "threshold": 0.5815000000000001,
+                                        "split_feature": 11,
+                                        "right_child": {
+                                            "leaf_value": -0.050802504037295006,
+                                            "leaf_count": 63,
+                                            "leaf_index": 14
+                                        },
+                                        "left_child": {
+                                            "leaf_value": 0.0032995230748587637,
+                                            "leaf_count": 134,
+                                            "leaf_index": 0
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "num_cat": 0,
+            "tree_index": 7,
+            "num_leaves": 31,
+            "shrinkage": 0.05,
+            "tree_structure": {
+                "default_left": true,
+                "missing_type": "None",
+                "split_gain": 169.53199768066406,
+                "internal_value": 0,
+                "internal_count": 5600,
+                "decision_type": "<=",
+                "split_index": 0,
+                "threshold": 1.1785000000000003,
+                "split_feature": 25,
+                "right_child": {
+                    "default_left": true,
+                    "missing_type": "None",
+                    "split_gain": 21.396099090576172,
+                    "internal_value": -0.639023,
+                    "internal_count": 1267,
+                    "decision_type": "<=",
+                    "split_index": 9,
+                    "threshold": 1.8335000000000004,
+                    "split_feature": 3,
+                    "right_child": {
+                        "leaf_value": -0.07497982359677494,
+                        "leaf_count": 108,
+                        "leaf_index": 10
+                    },
+                    "left_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 16.394500732421875,
+                        "internal_value": -0.559812,
+                        "internal_count": 1159,
+                        "decision_type": "<=",
+                        "split_index": 13,
+                        "threshold": 1.4915,
+                        "split_feature": 25,
+                        "right_child": {
+                            "leaf_value": -0.03917322462952416,
+                            "leaf_count": 618,
+                            "leaf_index": 14
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 14.21780014038086,
+                            "internal_value": -0.304772,
+                            "internal_count": 541,
+                            "decision_type": "<=",
+                            "split_index": 16,
+                            "threshold": 0.8865000000000001,
+                            "split_feature": 5,
+                            "right_child": {
+                                "leaf_value": -0.001396712090264106,
+                                "leaf_count": 314,
+                                "leaf_index": 17
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 11.138799667358398,
+                                "internal_value": -0.68722,
+                                "internal_count": 227,
+                                "decision_type": "<=",
+                                "split_index": 21,
+                                "threshold": 1.1195000000000002,
+                                "split_feature": 23,
+                                "right_child": {
+                                    "leaf_value": 0.031804648696817144,
+                                    "leaf_count": 23,
+                                    "leaf_index": 22
+                                },
+                                "left_child": {
+                                    "leaf_value": -0.0418247326284625,
+                                    "leaf_count": 204,
+                                    "leaf_index": 1
+                                }
+                            }
+                        }
+                    }
+                },
+                "left_child": {
+                    "default_left": true,
+                    "missing_type": "None",
+                    "split_gain": 95.0873031616211,
+                    "internal_value": 0.19749,
+                    "internal_count": 4333,
+                    "decision_type": "<=",
+                    "split_index": 1,
+                    "threshold": 0.5925000000000001,
+                    "split_feature": 25,
+                    "right_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 59.42610168457031,
+                        "internal_value": 0.3633,
+                        "internal_count": 3330,
+                        "decision_type": "<=",
+                        "split_index": 2,
+                        "threshold": 0.7765000000000001,
+                        "split_feature": 26,
+                        "right_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 64.09249877929688,
+                            "internal_value": 0.477289,
+                            "internal_count": 2835,
+                            "decision_type": "<=",
+                            "split_index": 3,
+                            "threshold": 0.9045000000000002,
+                            "split_feature": 27,
+                            "right_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 23.425899505615234,
+                                "internal_value": 0.131671,
+                                "internal_count": 1222,
+                                "decision_type": "<=",
+                                "split_index": 8,
+                                "threshold": 1.3475000000000004,
+                                "split_feature": 0,
+                                "right_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 20.351999282836914,
+                                    "internal_value": -0.361281,
+                                    "internal_count": 295,
+                                    "decision_type": "<=",
+                                    "split_index": 10,
+                                    "threshold": 0.9445000000000001,
+                                    "split_feature": 24,
+                                    "right_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 14.638799667358398,
+                                        "internal_value": -0.0442501,
+                                        "internal_count": 217,
+                                        "decision_type": "<=",
+                                        "split_index": 14,
+                                        "threshold": 1.7695000000000003,
+                                        "split_feature": 24,
+                                        "right_child": {
+                                            "leaf_value": -0.07776611461910429,
+                                            "leaf_count": 23,
+                                            "leaf_index": 15
+                                        },
+                                        "left_child": {
+                                            "default_left": true,
+                                            "missing_type": "None",
+                                            "split_gain": 12.763400077819824,
+                                            "internal_value": 0.136181,
+                                            "internal_count": 194,
+                                            "decision_type": "<=",
+                                            "split_index": 19,
+                                            "threshold": 1.0315,
+                                            "split_feature": 5,
+                                            "right_child": {
+                                                "leaf_value": 0.031584975162989797,
+                                                "leaf_count": 101,
+                                                "leaf_index": 20
+                                            },
+                                            "left_child": {
+                                                "default_left": true,
+                                                "missing_type": "None",
+                                                "split_gain": 10.202899932861328,
+                                                "internal_value": -0.400832,
+                                                "internal_count": 93,
+                                                "decision_type": "<=",
+                                                "split_index": 29,
+                                                "threshold": 1.2680000000000005,
+                                                "split_feature": 9,
+                                                "right_child": {
+                                                    "leaf_value": 0.04179058159378995,
+                                                    "leaf_count": 21,
+                                                    "leaf_index": 30
+                                                },
+                                                "left_child": {
+                                                    "leaf_value": -0.03796301140143466,
+                                                    "leaf_count": 72,
+                                                    "leaf_index": 11
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "left_child": {
+                                        "leaf_value": -0.061994196753216546,
+                                        "leaf_count": 78,
+                                        "leaf_index": 9
+                                    }
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 18.669099807739258,
+                                    "internal_value": 0.289116,
+                                    "internal_count": 927,
+                                    "decision_type": "<=",
+                                    "split_index": 11,
+                                    "threshold": 0.8695000000000002,
+                                    "split_feature": 5,
+                                    "right_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 16.411100387573242,
+                                        "internal_value": 0.521404,
+                                        "internal_count": 560,
+                                        "decision_type": "<=",
+                                        "split_index": 12,
+                                        "threshold": -1.6564999999999996,
+                                        "split_feature": 1,
+                                        "right_child": {
+                                            "default_left": true,
+                                            "missing_type": "None",
+                                            "split_gain": 13.500699996948242,
+                                            "internal_value": 0.605067,
+                                            "internal_count": 529,
+                                            "decision_type": "<=",
+                                            "split_index": 18,
+                                            "threshold": 2.6165000000000007,
+                                            "split_feature": 3,
+                                            "right_child": {
+                                                "leaf_value": -0.044823479902650155,
+                                                "leaf_count": 23,
+                                                "leaf_index": 19
+                                            },
+                                            "left_child": {
+                                                "leaf_value": 0.03370958077150066,
+                                                "leaf_count": 506,
+                                                "leaf_index": 13
+                                            }
+                                        },
+                                        "left_child": {
+                                            "leaf_value": -0.04514977823185195,
+                                            "leaf_count": 31,
+                                            "leaf_index": 12
+                                        }
+                                    },
+                                    "left_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 10.556599617004395,
+                                        "internal_value": -0.0622088,
+                                        "internal_count": 367,
+                                        "decision_type": "<=",
+                                        "split_index": 22,
+                                        "threshold": 0.9695000000000001,
+                                        "split_feature": 25,
+                                        "right_child": {
+                                            "leaf_value": -0.029926691246848793,
+                                            "leaf_count": 105,
+                                            "leaf_index": 23
+                                        },
+                                        "left_child": {
+                                            "default_left": true,
+                                            "missing_type": "None",
+                                            "split_gain": 11.477299690246582,
+                                            "internal_value": 0.153966,
+                                            "internal_count": 262,
+                                            "decision_type": "<=",
+                                            "split_index": 23,
+                                            "threshold": 0.9855000000000002,
+                                            "split_feature": 26,
+                                            "right_child": {
+                                                "leaf_value": 0.020041389472716265,
+                                                "leaf_count": 195,
+                                                "leaf_index": 24
+                                            },
+                                            "left_child": {
+                                                "default_left": true,
+                                                "missing_type": "None",
+                                                "split_gain": 12.562899589538574,
+                                                "internal_value": -0.562461,
+                                                "internal_count": 67,
+                                                "decision_type": "<=",
+                                                "split_index": 24,
+                                                "threshold": 1.3345000000000002,
+                                                "split_feature": 3,
+                                                "right_child": {
+                                                    "leaf_value": -0.08421536008309705,
+                                                    "leaf_count": 25,
+                                                    "leaf_index": 25
+                                                },
+                                                "left_child": {
+                                                    "leaf_value": 0.005544926422277354,
+                                                    "leaf_count": 42,
+                                                    "leaf_index": 4
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 37.70600128173828,
+                                "internal_value": 0.746066,
+                                "internal_count": 1613,
+                                "decision_type": "<=",
+                                "split_index": 4,
+                                "threshold": 0.8735000000000002,
+                                "split_feature": 26,
+                                "right_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 13.857199668884277,
+                                    "internal_value": 0.993268,
+                                    "internal_count": 998,
+                                    "decision_type": "<=",
+                                    "split_index": 17,
+                                    "threshold": 1.0025000000000002,
+                                    "split_feature": 25,
+                                    "right_child": {
+                                        "leaf_value": 0.024716716365395245,
+                                        "leaf_count": 185,
+                                        "leaf_index": 18
+                                    },
+                                    "left_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 12.045299530029297,
+                                        "internal_value": 1.10984,
+                                        "internal_count": 813,
+                                        "decision_type": "<=",
+                                        "split_index": 20,
+                                        "threshold": 0.6785000000000001,
+                                        "split_feature": 25,
+                                        "right_child": {
+                                            "leaf_value": 0.059117299883434005,
+                                            "leaf_count": 751,
+                                            "leaf_index": 21
+                                        },
+                                        "left_child": {
+                                            "leaf_value": 0.012483624069613142,
+                                            "leaf_count": 62,
+                                            "leaf_index": 5
+                                        }
+                                    }
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 37.8760986328125,
+                                    "internal_value": 0.353066,
+                                    "internal_count": 615,
+                                    "decision_type": "<=",
+                                    "split_index": 5,
+                                    "threshold": 0.9455000000000001,
+                                    "split_feature": 25,
+                                    "right_child": {
+                                        "leaf_value": -0.029276284457426388,
+                                        "leaf_count": 135,
+                                        "leaf_index": 6
+                                    },
+                                    "left_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 29.79509925842285,
+                                        "internal_value": 0.622336,
+                                        "internal_count": 480,
+                                        "decision_type": "<=",
+                                        "split_index": 6,
+                                        "threshold": 0.7905000000000001,
+                                        "split_feature": 27,
+                                        "right_child": {
+                                            "default_left": true,
+                                            "missing_type": "None",
+                                            "split_gain": 10.219599723815918,
+                                            "internal_value": -0.142692,
+                                            "internal_count": 145,
+                                            "decision_type": "<=",
+                                            "split_index": 28,
+                                            "threshold": 0.7735000000000002,
+                                            "split_feature": 14,
+                                            "right_child": {
+                                                "leaf_value": 0.03644230522471116,
+                                                "leaf_count": 40,
+                                                "leaf_index": 29
+                                            },
+                                            "left_child": {
+                                                "leaf_value": -0.023685758625010114,
+                                                "leaf_count": 105,
+                                                "leaf_index": 7
+                                            }
+                                        },
+                                        "left_child": {
+                                            "leaf_value": 0.04783837801376453,
+                                            "leaf_count": 335,
+                                            "leaf_index": 3
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 27.150100708007812,
+                            "internal_value": -0.278318,
+                            "internal_count": 495,
+                            "decision_type": "<=",
+                            "split_index": 7,
+                            "threshold": 0.8015000000000001,
+                            "split_feature": 5,
+                            "right_child": {
+                                "leaf_value": 0.0185646036468994,
+                                "leaf_count": 172,
+                                "leaf_index": 8
+                            },
+                            "left_child": {
+                                "leaf_value": -0.0309643157415804,
+                                "leaf_count": 323,
+                                "leaf_index": 2
+                            }
+                        }
+                    },
+                    "left_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 14.363499641418457,
+                        "internal_value": -0.342488,
+                        "internal_count": 1003,
+                        "decision_type": "<=",
+                        "split_index": 15,
+                        "threshold": 1.3365000000000002,
+                        "split_feature": 5,
+                        "right_child": {
+                            "leaf_value": 0.0173454092412304,
+                            "leaf_count": 109,
+                            "leaf_index": 16
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 10.5423002243042,
+                            "internal_value": -0.425995,
+                            "internal_count": 894,
+                            "decision_type": "<=",
+                            "split_index": 25,
+                            "threshold": 0.8405000000000001,
+                            "split_feature": 27,
+                            "right_child": {
+                                "leaf_value": -0.036350630488561096,
+                                "leaf_count": 307,
+                                "leaf_index": 26
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 16.916400909423828,
+                                "internal_value": -0.268623,
+                                "internal_count": 587,
+                                "decision_type": "<=",
+                                "split_index": 26,
+                                "threshold": 0.9635000000000001,
+                                "split_feature": 0,
+                                "right_child": {
+                                    "leaf_value": 0.005708011720059202,
+                                    "leaf_count": 259,
+                                    "leaf_index": 27
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 14.704700469970703,
+                                    "internal_value": -0.571023,
+                                    "internal_count": 328,
+                                    "decision_type": "<=",
+                                    "split_index": 27,
+                                    "threshold": 1.2365000000000002,
+                                    "split_feature": 13,
+                                    "right_child": {
+                                        "leaf_value": 0.03720901285482702,
+                                        "leaf_count": 31,
+                                        "leaf_index": 28
+                                    },
+                                    "left_child": {
+                                        "leaf_value": -0.03539834386050844,
+                                        "leaf_count": 297,
+                                        "leaf_index": 0
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "num_cat": 0,
+            "tree_index": 8,
+            "num_leaves": 31,
+            "shrinkage": 0.05,
+            "tree_structure": {
+                "default_left": true,
+                "missing_type": "None",
+                "split_gain": 153.63299560546875,
+                "internal_value": 0,
+                "internal_count": 5600,
+                "decision_type": "<=",
+                "split_index": 0,
+                "threshold": 1.0675000000000001,
+                "split_feature": 25,
+                "right_child": {
+                    "default_left": true,
+                    "missing_type": "None",
+                    "split_gain": 29.55699920654297,
+                    "internal_value": -0.517093,
+                    "internal_count": 1609,
+                    "decision_type": "<=",
+                    "split_index": 5,
+                    "threshold": 1.4915,
+                    "split_feature": 25,
+                    "right_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 12.743399620056152,
+                        "internal_value": -0.834933,
+                        "internal_count": 684,
+                        "decision_type": "<=",
+                        "split_index": 16,
+                        "threshold": 1.8335000000000004,
+                        "split_feature": 3,
+                        "right_child": {
+                            "leaf_value": -0.08439060259058967,
+                            "leaf_count": 66,
+                            "leaf_index": 17
+                        },
+                        "left_child": {
+                            "leaf_value": -0.03731552475746116,
+                            "leaf_count": 618,
+                            "leaf_index": 6
+                        }
+                    },
+                    "left_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 25.457500457763672,
+                        "internal_value": -0.283365,
+                        "internal_count": 925,
+                        "decision_type": "<=",
+                        "split_index": 7,
+                        "threshold": 1.0065000000000002,
+                        "split_feature": 22,
+                        "right_child": {
+                            "leaf_value": 0.007186420843371854,
+                            "leaf_count": 350,
+                            "leaf_index": 8
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 14.391599655151367,
+                            "internal_value": -0.543345,
+                            "internal_count": 575,
+                            "decision_type": "<=",
+                            "split_index": 14,
+                            "threshold": 0.8725000000000002,
+                            "split_feature": 22,
+                            "right_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 18.034500122070312,
+                                "internal_value": -0.839483,
+                                "internal_count": 308,
+                                "decision_type": "<=",
+                                "split_index": 15,
+                                "threshold": 0.8895000000000001,
+                                "split_feature": 27,
+                                "right_child": {
+                                    "leaf_value": -0.06577728469055975,
+                                    "leaf_count": 158,
+                                    "leaf_index": 16
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 10.697799682617188,
+                                    "internal_value": -0.342831,
+                                    "internal_count": 150,
+                                    "decision_type": "<=",
+                                    "split_index": 29,
+                                    "threshold": 1.0145000000000002,
+                                    "split_feature": 5,
+                                    "right_child": {
+                                        "leaf_value": 0.035407145119752244,
+                                        "leaf_count": 31,
+                                        "leaf_index": 30
+                                    },
+                                    "left_child": {
+                                        "leaf_value": -0.030774968050762564,
+                                        "leaf_count": 119,
+                                        "leaf_index": 15
+                                    }
+                                }
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 12.181300163269043,
+                                "internal_value": -0.202353,
+                                "internal_count": 267,
+                                "decision_type": "<=",
+                                "split_index": 18,
+                                "threshold": 0.8605000000000002,
+                                "split_feature": 13,
+                                "right_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 12.135100364685059,
+                                    "internal_value": 0.215133,
+                                    "internal_count": 137,
+                                    "decision_type": "<=",
+                                    "split_index": 19,
+                                    "threshold": 0.9075000000000001,
+                                    "split_feature": 9,
+                                    "right_child": {
+                                        "leaf_value": 0.03794817021284827,
+                                        "leaf_count": 75,
+                                        "leaf_index": 20
+                                    },
+                                    "left_child": {
+                                        "leaf_value": -0.022050065022213277,
+                                        "leaf_count": 62,
+                                        "leaf_index": 19
+                                    }
+                                },
+                                "left_child": {
+                                    "leaf_value": -0.03214107835942885,
+                                    "leaf_count": 130,
+                                    "leaf_index": 1
+                                }
+                            }
+                        }
+                    }
+                },
+                "left_child": {
+                    "default_left": true,
+                    "missing_type": "None",
+                    "split_gain": 104.00900268554688,
+                    "internal_value": 0.220506,
+                    "internal_count": 3991,
+                    "decision_type": "<=",
+                    "split_index": 1,
+                    "threshold": 0.6695000000000001,
+                    "split_feature": 25,
+                    "right_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 57.45209884643555,
+                        "internal_value": 0.455154,
+                        "internal_count": 2657,
+                        "decision_type": "<=",
+                        "split_index": 2,
+                        "threshold": 0.7765000000000001,
+                        "split_feature": 26,
+                        "right_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 49.84769821166992,
+                            "internal_value": 0.577915,
+                            "internal_count": 2282,
+                            "decision_type": "<=",
+                            "split_index": 3,
+                            "threshold": 0.9045000000000002,
+                            "split_feature": 27,
+                            "right_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 16.17970085144043,
+                                "internal_value": 0.229325,
+                                "internal_count": 955,
+                                "decision_type": "<=",
+                                "split_index": 10,
+                                "threshold": 1.0465000000000002,
+                                "split_feature": 22,
+                                "right_child": {
+                                    "leaf_value": 0.025611705237204643,
+                                    "leaf_count": 444,
+                                    "leaf_index": 11
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 17.106399536132812,
+                                    "internal_value": -0.0141496,
+                                    "internal_count": 511,
+                                    "decision_type": "<=",
+                                    "split_index": 11,
+                                    "threshold": 0.9955000000000002,
+                                    "split_feature": 0,
+                                    "right_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 16.903600692749023,
+                                        "internal_value": -0.422155,
+                                        "internal_count": 229,
+                                        "decision_type": "<=",
+                                        "split_index": 13,
+                                        "threshold": 1.2915,
+                                        "split_feature": 27,
+                                        "right_child": {
+                                            "leaf_value": -0.08648550513219944,
+                                            "leaf_count": 34,
+                                            "leaf_index": 14
+                                        },
+                                        "left_child": {
+                                            "default_left": true,
+                                            "missing_type": "None",
+                                            "split_gain": 10.765199661254883,
+                                            "internal_value": -0.19395,
+                                            "internal_count": 195,
+                                            "decision_type": "<=",
+                                            "split_index": 28,
+                                            "threshold": 0.9675000000000001,
+                                            "split_feature": 22,
+                                            "right_child": {
+                                                "leaf_value": 0.03347029970732867,
+                                                "leaf_count": 45,
+                                                "leaf_index": 29
+                                            },
+                                            "left_child": {
+                                                "leaf_value": -0.02262370931513515,
+                                                "leaf_count": 150,
+                                                "leaf_index": 12
+                                            }
+                                        }
+                                    },
+                                    "left_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 17.94930076599121,
+                                        "internal_value": 0.317959,
+                                        "internal_count": 282,
+                                        "decision_type": "<=",
+                                        "split_index": 12,
+                                        "threshold": 1.2545000000000002,
+                                        "split_feature": 18,
+                                        "right_child": {
+                                            "leaf_value": -0.05480017432260434,
+                                            "leaf_count": 32,
+                                            "leaf_index": 13
+                                        },
+                                        "left_child": {
+                                            "leaf_value": 0.025018082913893513,
+                                            "leaf_count": 250,
+                                            "leaf_index": 4
+                                        }
+                                    }
+                                }
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 32.75600051879883,
+                                "internal_value": 0.838108,
+                                "internal_count": 1327,
+                                "decision_type": "<=",
+                                "split_index": 4,
+                                "threshold": 0.8715,
+                                "split_feature": 26,
+                                "right_child": {
+                                    "leaf_value": 0.054176003221229986,
+                                    "leaf_count": 850,
+                                    "leaf_index": 5
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 28.285900115966797,
+                                    "internal_value": 0.41397,
+                                    "internal_count": 477,
+                                    "decision_type": "<=",
+                                    "split_index": 6,
+                                    "threshold": 0.7865000000000001,
+                                    "split_feature": 27,
+                                    "right_child": {
+                                        "leaf_value": -0.013533431015470271,
+                                        "leaf_count": 162,
+                                        "leaf_index": 7
+                                    },
+                                    "left_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 12.623000144958496,
+                                        "internal_value": 0.772155,
+                                        "internal_count": 315,
+                                        "decision_type": "<=",
+                                        "split_index": 17,
+                                        "threshold": 0.9485000000000001,
+                                        "split_feature": 25,
+                                        "right_child": {
+                                            "leaf_value": -0.010632450462638228,
+                                            "leaf_count": 45,
+                                            "leaf_index": 18
+                                        },
+                                        "left_child": {
+                                            "leaf_value": 0.04707089324527601,
+                                            "leaf_count": 270,
+                                            "leaf_index": 3
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 19.135299682617188,
+                            "internal_value": -0.273632,
+                            "internal_count": 375,
+                            "decision_type": "<=",
+                            "split_index": 9,
+                            "threshold": 0.8015000000000001,
+                            "split_feature": 5,
+                            "right_child": {
+                                "leaf_value": 0.01652709635451674,
+                                "leaf_count": 137,
+                                "leaf_index": 10
+                            },
+                            "left_child": {
+                                "leaf_value": -0.030787474857073744,
+                                "leaf_count": 238,
+                                "leaf_index": 2
+                            }
+                        }
+                    },
+                    "left_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 19.663299560546875,
+                        "internal_value": -0.235099,
+                        "internal_count": 1334,
+                        "decision_type": "<=",
+                        "split_index": 8,
+                        "threshold": 1.3365000000000002,
+                        "split_feature": 5,
+                        "right_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 11.721099853515625,
+                            "internal_value": 0.465794,
+                            "internal_count": 145,
+                            "decision_type": "<=",
+                            "split_index": 20,
+                            "threshold": 0.9965,
+                            "split_feature": 27,
+                            "right_child": {
+                                "leaf_value": -0.01107705464304861,
+                                "leaf_count": 59,
+                                "leaf_index": 21
+                            },
+                            "left_child": {
+                                "leaf_value": 0.047169688006767505,
+                                "leaf_count": 86,
+                                "leaf_index": 9
+                            }
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 11.639599800109863,
+                            "internal_value": -0.319926,
+                            "internal_count": 1189,
+                            "decision_type": "<=",
+                            "split_index": 21,
+                            "threshold": 0.8385000000000001,
+                            "split_feature": 27,
+                            "right_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 12.32349967956543,
+                                "internal_value": -0.58089,
+                                "internal_count": 436,
+                                "decision_type": "<=",
+                                "split_index": 25,
+                                "threshold": 1.102,
+                                "split_feature": 2,
+                                "right_child": {
+                                    "leaf_value": -0.06732010392614145,
+                                    "leaf_count": 71,
+                                    "leaf_index": 26
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 11.030900001525879,
+                                    "internal_value": -0.432133,
+                                    "internal_count": 365,
+                                    "decision_type": "<=",
+                                    "split_index": 27,
+                                    "threshold": 0.9015000000000001,
+                                    "split_feature": 2,
+                                    "right_child": {
+                                        "leaf_value": 0.03777638681015756,
+                                        "leaf_count": 29,
+                                        "leaf_index": 28
+                                    },
+                                    "left_child": {
+                                        "leaf_value": -0.026731808732088025,
+                                        "leaf_count": 336,
+                                        "leaf_index": 22
+                                    }
+                                }
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 17.714500427246094,
+                                "internal_value": -0.168744,
+                                "internal_count": 753,
+                                "decision_type": "<=",
+                                "split_index": 22,
+                                "threshold": 1.2815,
+                                "split_feature": 9,
+                                "right_child": {
+                                    "leaf_value": 0.052403227674410684,
+                                    "leaf_count": 46,
+                                    "leaf_index": 23
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 14.7391996383667,
+                                    "internal_value": -0.246677,
+                                    "internal_count": 707,
+                                    "decision_type": "<=",
+                                    "split_index": 23,
+                                    "threshold": 0.41250000000000003,
+                                    "split_feature": 3,
+                                    "right_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 18.673900604248047,
+                                        "internal_value": -0.372316,
+                                        "internal_count": 595,
+                                        "decision_type": "<=",
+                                        "split_index": 24,
+                                        "threshold": 1.5795000000000001,
+                                        "split_feature": 0,
+                                        "right_child": {
+                                            "leaf_value": 0.03445676770188608,
+                                            "leaf_count": 60,
+                                            "leaf_index": 25
+                                        },
+                                        "left_child": {
+                                            "default_left": true,
+                                            "missing_type": "None",
+                                            "split_gain": 11.28849983215332,
+                                            "internal_value": -0.491366,
+                                            "internal_count": 535,
+                                            "decision_type": "<=",
+                                            "split_index": 26,
+                                            "threshold": 1.3085000000000002,
+                                            "split_feature": 13,
+                                            "right_child": {
+                                                "leaf_value": 0.02550567127709747,
+                                                "leaf_count": 42,
+                                                "leaf_index": 27
+                                            },
+                                            "left_child": {
+                                                "leaf_value": -0.028809867285906045,
+                                                "leaf_count": 493,
+                                                "leaf_index": 24
+                                            }
+                                        }
+                                    },
+                                    "left_child": {
+                                        "leaf_value": 0.02107758010509224,
+                                        "leaf_count": 112,
+                                        "leaf_index": 0
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "num_cat": 0,
+            "tree_index": 9,
+            "num_leaves": 31,
+            "shrinkage": 0.05,
+            "tree_structure": {
+                "default_left": true,
+                "missing_type": "None",
+                "split_gain": 139.61900329589844,
+                "internal_value": 0,
+                "internal_count": 5600,
+                "decision_type": "<=",
+                "split_index": 0,
+                "threshold": 1.1785000000000003,
+                "split_feature": 25,
+                "right_child": {
+                    "default_left": true,
+                    "missing_type": "None",
+                    "split_gain": 18.720500946044922,
+                    "internal_value": -0.581277,
+                    "internal_count": 1267,
+                    "decision_type": "<=",
+                    "split_index": 10,
+                    "threshold": 1.8335000000000004,
+                    "split_feature": 3,
+                    "right_child": {
+                        "leaf_value": -0.06979762459445489,
+                        "leaf_count": 108,
+                        "leaf_index": 11
+                    },
+                    "left_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 15.2746000289917,
+                        "internal_value": -0.507647,
+                        "internal_count": 1159,
+                        "decision_type": "<=",
+                        "split_index": 12,
+                        "threshold": 1.2805000000000002,
+                        "split_feature": 24,
+                        "right_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 10.891599655151367,
+                            "internal_value": -0.10037,
+                            "internal_count": 281,
+                            "decision_type": "<=",
+                            "split_index": 21,
+                            "threshold": 1.1825000000000003,
+                            "split_feature": 1,
+                            "right_child": {
+                                "leaf_value": 0.053153476484952035,
+                                "leaf_count": 29,
+                                "leaf_index": 22
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 13.185700416564941,
+                                "internal_value": -0.23474,
+                                "internal_count": 252,
+                                "decision_type": "<=",
+                                "split_index": 22,
+                                "threshold": -0.9654999999999999,
+                                "split_feature": 11,
+                                "right_child": {
+                                    "leaf_value": -0.02429353736855552,
+                                    "leaf_count": 194,
+                                    "leaf_index": 23
+                                },
+                                "left_child": {
+                                    "leaf_value": 0.030295954084735083,
+                                    "leaf_count": 58,
+                                    "leaf_index": 13
+                                }
+                            }
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 20.494800567626953,
+                            "internal_value": -0.638679,
+                            "internal_count": 878,
+                            "decision_type": "<=",
+                            "split_index": 13,
+                            "threshold": 2.0800000000000005,
+                            "split_feature": 25,
+                            "right_child": {
+                                "leaf_value": -0.07725102411767627,
+                                "leaf_count": 92,
+                                "leaf_index": 14
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 13.650699615478516,
+                                "internal_value": -0.534257,
+                                "internal_count": 786,
+                                "decision_type": "<=",
+                                "split_index": 14,
+                                "threshold": 0.7285000000000001,
+                                "split_feature": 24,
+                                "right_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 13.59939956665039,
+                                    "internal_value": -0.622453,
+                                    "internal_count": 708,
+                                    "decision_type": "<=",
+                                    "split_index": 15,
+                                    "threshold": -1.5714999999999997,
+                                    "split_feature": 15,
+                                    "right_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 12.897299766540527,
+                                        "internal_value": -0.683115,
+                                        "internal_count": 676,
+                                        "decision_type": "<=",
+                                        "split_index": 17,
+                                        "threshold": 0.6805000000000001,
+                                        "split_feature": 22,
+                                        "right_child": {
+                                            "default_left": true,
+                                            "missing_type": "None",
+                                            "split_gain": 12.520099639892578,
+                                            "internal_value": -0.733038,
+                                            "internal_count": 655,
+                                            "decision_type": "<=",
+                                            "split_index": 18,
+                                            "threshold": 0.9695000000000001,
+                                            "split_feature": 22,
+                                            "right_child": {
+                                                "leaf_value": -0.021788905189662422,
+                                                "leaf_count": 305,
+                                                "leaf_index": 19
+                                            },
+                                            "left_child": {
+                                                "leaf_value": -0.0496739185959528,
+                                                "leaf_count": 350,
+                                                "leaf_index": 18
+                                            }
+                                        },
+                                        "left_child": {
+                                            "leaf_value": 0.04322188293195508,
+                                            "leaf_count": 21,
+                                            "leaf_index": 16
+                                        }
+                                    },
+                                    "left_child": {
+                                        "leaf_value": 0.032990623614766505,
+                                        "leaf_count": 32,
+                                        "leaf_index": 15
+                                    }
+                                },
+                                "left_child": {
+                                    "leaf_value": 0.013141400406795557,
+                                    "leaf_count": 78,
+                                    "leaf_index": 1
+                                }
+                            }
+                        }
+                    }
+                },
+                "left_child": {
+                    "default_left": true,
+                    "missing_type": "None",
+                    "split_gain": 79.58309936523438,
+                    "internal_value": 0.180272,
+                    "internal_count": 4333,
+                    "decision_type": "<=",
+                    "split_index": 1,
+                    "threshold": 0.5925000000000001,
+                    "split_feature": 25,
+                    "right_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 49.39950180053711,
+                        "internal_value": 0.333236,
+                        "internal_count": 3330,
+                        "decision_type": "<=",
+                        "split_index": 2,
+                        "threshold": 0.7765000000000001,
+                        "split_feature": 26,
+                        "right_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 54.1775016784668,
+                            "internal_value": 0.438087,
+                            "internal_count": 2835,
+                            "decision_type": "<=",
+                            "split_index": 3,
+                            "threshold": 0.9045000000000002,
+                            "split_feature": 27,
+                            "right_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 21.00629997253418,
+                                "internal_value": 0.120565,
+                                "internal_count": 1222,
+                                "decision_type": "<=",
+                                "split_index": 8,
+                                "threshold": 1.0465000000000002,
+                                "split_feature": 22,
+                                "right_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 10.014100074768066,
+                                    "internal_value": 0.410361,
+                                    "internal_count": 558,
+                                    "decision_type": "<=",
+                                    "split_index": 27,
+                                    "threshold": 1.2405000000000002,
+                                    "split_feature": 5,
+                                    "right_child": {
+                                        "leaf_value": 0.03996384523286442,
+                                        "leaf_count": 183,
+                                        "leaf_index": 28
+                                    },
+                                    "left_child": {
+                                        "leaf_value": 0.011087544399115586,
+                                        "leaf_count": 375,
+                                        "leaf_index": 9
+                                    }
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 47.76369857788086,
+                                    "internal_value": -0.120604,
+                                    "internal_count": 664,
+                                    "decision_type": "<=",
+                                    "split_index": 9,
+                                    "threshold": 0.9995000000000002,
+                                    "split_feature": 24,
+                                    "right_child": {
+                                        "leaf_value": 0.012884385167891872,
+                                        "leaf_count": 446,
+                                        "leaf_index": 10
+                                    },
+                                    "left_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 17.79990005493164,
+                                        "internal_value": -0.890285,
+                                        "internal_count": 218,
+                                        "decision_type": "<=",
+                                        "split_index": 11,
+                                        "threshold": 0.7325,
+                                        "split_feature": 24,
+                                        "right_child": {
+                                            "leaf_value": -0.05833205371034644,
+                                            "leaf_count": 177,
+                                            "leaf_index": 12
+                                        },
+                                        "left_child": {
+                                            "leaf_value": 0.01506070555200767,
+                                            "leaf_count": 41,
+                                            "leaf_index": 4
+                                        }
+                                    }
+                                }
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 32.477298736572266,
+                                "internal_value": 0.688256,
+                                "internal_count": 1613,
+                                "decision_type": "<=",
+                                "split_index": 4,
+                                "threshold": 0.8735000000000002,
+                                "split_feature": 26,
+                                "right_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 12.066300392150879,
+                                    "internal_value": 0.921336,
+                                    "internal_count": 998,
+                                    "decision_type": "<=",
+                                    "split_index": 20,
+                                    "threshold": 1.0025000000000002,
+                                    "split_feature": 25,
+                                    "right_child": {
+                                        "leaf_value": 0.022735306237207455,
+                                        "leaf_count": 185,
+                                        "leaf_index": 21
+                                    },
+                                    "left_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 10.335000038146973,
+                                        "internal_value": 1.03237,
+                                        "internal_count": 813,
+                                        "decision_type": "<=",
+                                        "split_index": 24,
+                                        "threshold": 0.6785000000000001,
+                                        "split_feature": 25,
+                                        "right_child": {
+                                            "default_left": true,
+                                            "missing_type": "None",
+                                            "split_gain": 10.479299545288086,
+                                            "internal_value": 1.10127,
+                                            "internal_count": 751,
+                                            "decision_type": "<=",
+                                            "split_index": 25,
+                                            "threshold": 0.48450000000000004,
+                                            "split_feature": 5,
+                                            "right_child": {
+                                                "leaf_value": 0.058271443977055276,
+                                                "leaf_count": 704,
+                                                "leaf_index": 26
+                                            },
+                                            "left_child": {
+                                                "leaf_value": 0.007900385034348154,
+                                                "leaf_count": 47,
+                                                "leaf_index": 25
+                                            }
+                                        },
+                                        "left_child": {
+                                            "leaf_value": 0.011745737164143587,
+                                            "leaf_count": 62,
+                                            "leaf_index": 5
+                                        }
+                                    }
+                                },
+                                "left_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 32.425899505615234,
+                                    "internal_value": 0.322996,
+                                    "internal_count": 615,
+                                    "decision_type": "<=",
+                                    "split_index": 5,
+                                    "threshold": 0.9455000000000001,
+                                    "split_feature": 25,
+                                    "right_child": {
+                                        "leaf_value": -0.027173701844035725,
+                                        "leaf_count": 135,
+                                        "leaf_index": 6
+                                    },
+                                    "left_child": {
+                                        "default_left": true,
+                                        "missing_type": "None",
+                                        "split_gain": 25.007400512695312,
+                                        "internal_value": 0.574826,
+                                        "internal_count": 480,
+                                        "decision_type": "<=",
+                                        "split_index": 6,
+                                        "threshold": 0.7905000000000001,
+                                        "split_feature": 27,
+                                        "right_child": {
+                                            "leaf_value": -0.0061694846701946075,
+                                            "leaf_count": 145,
+                                            "leaf_index": 7
+                                        },
+                                        "left_child": {
+                                            "leaf_value": 0.044294654823137644,
+                                            "leaf_count": 335,
+                                            "leaf_index": 3
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 22.407400131225586,
+                            "internal_value": -0.252697,
+                            "internal_count": 495,
+                            "decision_type": "<=",
+                            "split_index": 7,
+                            "threshold": 0.8015000000000001,
+                            "split_feature": 5,
+                            "right_child": {
+                                "leaf_value": 0.01694564723319499,
+                                "leaf_count": 172,
+                                "leaf_index": 8
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 10.223699569702148,
+                                "internal_value": -0.563026,
+                                "internal_count": 323,
+                                "decision_type": "<=",
+                                "split_index": 26,
+                                "threshold": 0.7185000000000001,
+                                "split_feature": 24,
+                                "right_child": {
+                                    "default_left": true,
+                                    "missing_type": "None",
+                                    "split_gain": 9.640910148620605,
+                                    "internal_value": -0.837079,
+                                    "internal_count": 204,
+                                    "decision_type": "<=",
+                                    "split_index": 29,
+                                    "threshold": -1.2554999999999998,
+                                    "split_feature": 19,
+                                    "right_child": {
+                                        "leaf_value": -0.05039781234131188,
+                                        "leaf_count": 177,
+                                        "leaf_index": 30
+                                    },
+                                    "left_child": {
+                                        "leaf_value": 0.014107705460097564,
+                                        "leaf_count": 27,
+                                        "leaf_index": 27
+                                    }
+                                },
+                                "left_child": {
+                                    "leaf_value": -0.00485146534642485,
+                                    "leaf_count": 119,
+                                    "leaf_index": 2
+                                }
+                            }
+                        }
+                    },
+                    "left_child": {
+                        "default_left": true,
+                        "missing_type": "None",
+                        "split_gain": 13.15429973602295,
+                        "internal_value": -0.313794,
+                        "internal_count": 1003,
+                        "decision_type": "<=",
+                        "split_index": 16,
+                        "threshold": 0.9405,
+                        "split_feature": 13,
+                        "right_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 12.463800430297852,
+                            "internal_value": 0.0161213,
+                            "internal_count": 328,
+                            "decision_type": "<=",
+                            "split_index": 19,
+                            "threshold": 0.9135000000000001,
+                            "split_feature": 27,
+                            "right_child": {
+                                "leaf_value": -0.02647693085040184,
+                                "leaf_count": 111,
+                                "leaf_index": 20
+                            },
+                            "left_child": {
+                                "default_left": true,
+                                "missing_type": "None",
+                                "split_gain": 10.818499565124512,
+                                "internal_value": 0.296876,
+                                "internal_count": 217,
+                                "decision_type": "<=",
+                                "split_index": 23,
+                                "threshold": 0.5235000000000002,
+                                "split_feature": 25,
+                                "right_child": {
+                                    "leaf_value": 0.049991761717806435,
+                                    "leaf_count": 63,
+                                    "leaf_index": 24
+                                },
+                                "left_child": {
+                                    "leaf_value": 0.0005192454277685481,
+                                    "leaf_count": 154,
+                                    "leaf_index": 17
+                                }
+                            }
+                        },
+                        "left_child": {
+                            "default_left": true,
+                            "missing_type": "None",
+                            "split_gain": 9.830439567565918,
+                            "internal_value": -0.473954,
+                            "internal_count": 675,
+                            "decision_type": "<=",
+                            "split_index": 28,
+                            "threshold": 1.0065000000000002,
+                            "split_feature": 9,
+                            "right_child": {
+                                "leaf_value": 0.000678600171508302,
+                                "leaf_count": 134,
+                                "leaf_index": 29
+                            },
+                            "left_child": {
+                                "leaf_value": -0.029713527040870404,
+                                "leaf_count": 541,
+                                "leaf_index": 0
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ],
+    "num_class": 1,
+    "label_index": 0,
+    "num_tree_per_iteration": 1,
+    "name": "tree",
+    "max_feature_idx": 27
+}


### PR DESCRIPTION
* Parses models exported via python lightgbm.Booster.dump_model
* Example model here generated with advanced_example.py from lightgbm examples
* Supports various missing value handling
* Does not support categorical features
* Model type is `model/lightgbm+json`