### PR TITLE
fix profile queries when using FeatureVectorWeight features

### DIFF
--- a/src/main/java/com/o19s/es/ltr/utils/Suppliers.java
+++ b/src/main/java/com/o19s/es/ltr/utils/Suppliers.java
@@ -23,7 +23,8 @@ public final class Suppliers {
     /**
      * Utility class
      */
-    private Suppliers() {}
+    private Suppliers() {
+    }
 
     /**
      * Build a supplier that stores and return the same instance.
@@ -60,7 +61,7 @@ public final class Suppliers {
     /**
      * A mutable supplier
      */
-    public static class MutableSupplier<T> implements Supplier<T> {
+    public static class MutableSupplier<T> implements MutableSupplierInterface<T> {
         T obj;
 
         @Override
@@ -68,8 +69,16 @@ public final class Suppliers {
             return obj;
         }
 
+        @Override
         public void set(T obj) {
             this.obj = obj;
         }
+    }
+
+    public interface MutableSupplierInterface<T> extends Supplier<T> {
+        @Override
+        T get();
+
+        void set(T obj);
     }
 }


### PR DESCRIPTION
Elasticsearch has the option to profile queries. However currently this seems to break because of `FeatureVectorWeight` where we choose to throw `UnsupportedOperationException` for `Scorer scorer(LeafReaderContext context)` method and choose to implement `scorer(LeafReaderContext context, Supplier<LtrRanker.FeatureVector> vectorSupplier)` instead.

The issue is incase of `profile:true` elasticsearch wraps our `weight` object inside its own `ProfileWeight` and produces a `ProfileScorer`. This ends up calling `scorerSupplier` which falls back to the base `Weight` class and calls the unsupported `scorer(LeafReaderContext context)` method for our wrapped weight. Here is the code in [elasticsearch](https://github.com/elastic/elasticsearch/blob/99f88f15c5febbca2d13b5b5fda27b844153bf1a/server/src/main/java/org/elasticsearch/search/profile/query/ProfileWeight.java#L66)

I try to add our own implementation for `scorerSupplier` in `FeatureVectorWeight` so we can call our supported scorer instead. One issue here is we need access to `vectorSupplier`. I did this by making Query implement MutableSupplierInterface and making sure we set it in `RankerQuery`.

The following [gist](https://gist.github.com/umeshdangat/ae7bb3a7ecf2c10c52fd0e451a1b75ab) has details of broken profile result to a sample query and the fixed result