### PR TITLE
Use DisiPriorityQueue for advancing subIterators instead of looping over all

### DIFF
--- a/src/main/java/com/o19s/es/ltr/query/RankerQuery.java
+++ b/src/main/java/com/o19s/es/ltr/query/RankerQuery.java
@@ -30,6 +30,8 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.ConstantScoreScorer;
 import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.DisiPriorityQueue;
+import org.apache.lucene.search.DisiWrapper;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
@@ -247,7 +249,7 @@ public class RankerQuery extends Query {
         @Override
         public RankerScorer scorer(LeafReaderContext context) throws IOException {
             List<Scorer> scorers = new ArrayList<>(weights.size());
-            List<DocIdSetIterator> subIterators = new ArrayList<>(weights.size());
+            DisiPriorityQueue disiPriorityQueue = new DisiPriorityQueue(weights.size());
             MutableSupplier<LtrRanker.FeatureVector> vectorSupplier = new MutableSupplier<>();
             for (Weight weight : weights) {
                 Scorer scorer;
@@ -260,10 +262,11 @@ public class RankerQuery extends Query {
                     scorer = new NoopScorer(this, DocIdSetIterator.empty());
                 }
                 scorers.add(scorer);
-                subIterators.add(scorer.iterator());
+                disiPriorityQueue.add(new DisiWrapper(scorer));
             }
 
-            NaiveDisjunctionDISI rankerIterator = new NaiveDisjunctionDISI(DocIdSetIterator.all(context.reader().maxDoc()), subIterators);
+            DisjunctionDISI rankerIterator = new DisjunctionDISI(
+                    DocIdSetIterator.all(context.reader().maxDoc()), disiPriorityQueue);
             return new RankerScorer(scorers, rankerIterator, vectorSupplier);
         }
 
@@ -273,10 +276,10 @@ public class RankerQuery extends Query {
              * to be useful for logging
              */
             private final List<Scorer> scorers;
-            private final NaiveDisjunctionDISI iterator;
+            private final DisjunctionDISI iterator;
             private final MutableSupplier<LtrRanker.FeatureVector> featureVector;
 
-            RankerScorer(List<Scorer> scorers, NaiveDisjunctionDISI iterator, MutableSupplier<LtrRanker.FeatureVector> featureVector) {
+            RankerScorer(List<Scorer> scorers, DisjunctionDISI iterator, MutableSupplier<LtrRanker.FeatureVector> featureVector) {
                 super(RankerWeight.this);
                 this.scorers = scorers;
                 this.iterator = iterator;
@@ -326,15 +329,14 @@ public class RankerQuery extends Query {
      * Mostly needed to avoid calling {@link Scorer#iterator()} to directly advance
      * from {@link RankerWeight.RankerScorer#score()} as some Scorer implementations
      * will instantiate new objects every time iterator() is called.
-     * NOTE: consider using {@link org.apache.lucene.search.DisiPriorityQueue}?
      */
-    static class NaiveDisjunctionDISI extends DocIdSetIterator {
+    static class DisjunctionDISI extends DocIdSetIterator {
         private final DocIdSetIterator main;
-        private final List<DocIdSetIterator> subIterators;
+        private final DisiPriorityQueue subIteratorsPriorityQueue;
 
-        NaiveDisjunctionDISI(DocIdSetIterator main, List<DocIdSetIterator> subIterators) {
+        DisjunctionDISI(DocIdSetIterator main, DisiPriorityQueue subIteratorsPriorityQueue) {
             this.main = main;
-            this.subIterators = subIterators;
+            this.subIteratorsPriorityQueue = subIteratorsPriorityQueue;
         }
 
         @Override
@@ -360,11 +362,10 @@ public class RankerQuery extends Query {
             if (target == NO_MORE_DOCS) {
                 return;
             }
-            for (DocIdSetIterator iterator : subIterators) {
-                // FIXME: Probably inefficient
-                if (iterator.docID() < target) {
-                    iterator.advance(target);
-                }
+            DisiWrapper top = subIteratorsPriorityQueue.top();
+            while (top.doc < target) {
+                top.doc = top.iterator.advance(target);
+                top = subIteratorsPriorityQueue.updateTop();
             }
         }
 


### PR DESCRIPTION
We saw this code to be the bottleneck in our tests. Turns out when we use a lot of features/scorers and recall a large amount the `advanceSubIterators` loop becomes the hotspot. I use Lucene's DisiPriorityQueue for this purpose. Initial tests showed us that this hotspot is now removed for us.
@nomoa @softwaredoug  please let me know what you think.


Hotspot Before fix:
<img width="1507" alt="screen shot 2018-08-14 at 12 09 10 pm" src="https://user-images.githubusercontent.com/4211071/44112880-369c78ec-9fbb-11e8-8011-98794acc24da.png">
