### PR TITLE
allow ltr query param names to be different from source es script par…

### DIFF
--- a/src/main/java/com/o19s/es/ltr/feature/store/ScriptFeature.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/ScriptFeature.java
@@ -39,11 +39,17 @@ public class ScriptFeature implements Feature {
     private final String name;
     private final Script script;
     private final Collection<String> queryParams;
+    private final Map<String, String> ltrToScriptParams;
 
     public ScriptFeature(String name, Script script, Collection<String> queryParams) {
         this.name = Objects.requireNonNull(name);
         this.script = Objects.requireNonNull(script);
         this.queryParams = queryParams;
+        Map<String, String> ltrScriptParams = new HashMap<>();
+        for (Map.Entry<String, Object> entry : script.getParams().entrySet()) {
+            ltrScriptParams.put(String.valueOf(entry.getValue()), entry.getKey());
+        }
+        this.ltrToScriptParams = ltrScriptParams;
     }
 
     public static ScriptFeature compile(StoredFeature feature) {
@@ -84,7 +90,7 @@ public class ScriptFeature implements Feature {
         Map<String, Object> queryTimeParams = new HashMap<>();
         for (String x : queryParams) {
             if (params.containsKey(x)) {
-                queryTimeParams.put(x, params.get(x));
+                queryTimeParams.put(ltrToScriptParams.get(x), params.get(x));
             }
         }
 

--- a/src/main/java/com/o19s/es/ltr/feature/store/ScriptFeature.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/ScriptFeature.java
@@ -35,21 +35,30 @@ import java.util.stream.Collectors;
 public class ScriptFeature implements Feature {
     public static final String TEMPLATE_LANGUAGE = "script_feature";
     public static final String FEATURE_VECTOR = "feature_vector";
+    public static final String EXTRA_SCRIPT_PARAMS = "extra_script_params";
 
     private final String name;
     private final Script script;
     private final Collection<String> queryParams;
-    private final Map<String, String> ltrToScriptParams;
+    private final Map<String, Object> baseScriptParams;
+    private final Map<String, String> extraScriptParams;
 
+    @SuppressWarnings("unchecked")
     public ScriptFeature(String name, Script script, Collection<String> queryParams) {
         this.name = Objects.requireNonNull(name);
         this.script = Objects.requireNonNull(script);
         this.queryParams = queryParams;
-        Map<String, String> ltrScriptParams = new HashMap<>();
+        Map<String, Object> ltrScriptParams = new HashMap<>();
+        Map<String, String> ltrExtraScriptParams = new HashMap<>();
         for (Map.Entry<String, Object> entry : script.getParams().entrySet()) {
-            ltrScriptParams.put(String.valueOf(entry.getValue()), entry.getKey());
+            if (!entry.getKey().equals(EXTRA_SCRIPT_PARAMS)) {
+                ltrScriptParams.put(String.valueOf(entry.getKey()), entry.getValue());
+            } else {
+                ltrExtraScriptParams = (Map<String, String>) entry.getValue();
+            }
         }
-        this.ltrToScriptParams = ltrScriptParams;
+        this.baseScriptParams = ltrScriptParams;
+        this.extraScriptParams = ltrExtraScriptParams;
     }
 
     public static ScriptFeature compile(StoredFeature feature) {
@@ -88,17 +97,25 @@ public class ScriptFeature implements Feature {
         }
 
         Map<String, Object> queryTimeParams = new HashMap<>();
+        Map<String, Object> extraQueryTimeParams = new HashMap<>();
         for (String x : queryParams) {
             if (params.containsKey(x)) {
-                queryTimeParams.put(ltrToScriptParams.get(x), params.get(x));
+                /* If extra_script_param then add the appropriate param name for the script else add name:value as is */
+                if (extraScriptParams.containsKey(x)) {
+                    extraQueryTimeParams.put(extraScriptParams.get(x), params.get(x));
+                } else {
+                    queryTimeParams.put(x, params.get(x));
+                }
             }
         }
 
         Map<String, Object> nparams = new HashMap<>();
         FeatureSupplier featureSupplier = new FeatureSupplier(featureSet);
-        nparams.putAll(script.getParams());
+        nparams.putAll(baseScriptParams);
         nparams.putAll(queryTimeParams);
+        nparams.putAll(extraQueryTimeParams);
         nparams.put(FEATURE_VECTOR, featureSupplier);
+
         Script nScript = new Script(
                 this.script.getType(), this.script.getLang(), this.script.getIdOrCode(), this.script.getOptions(), nparams);
         SearchScript.Factory searchScript = context.getQueryShardContext().getScriptService().compile(script, SearchScript.CONTEXT);

--- a/src/test/java/com/o19s/es/ltr/action/BaseIntegrationTest.java
+++ b/src/test/java/com/o19s/es/ltr/action/BaseIntegrationTest.java
@@ -156,7 +156,10 @@ public abstract class BaseIntegrationTest extends ESSingleNodeTestCase {
                                 new SearchScript.LeafFactory() {
                                     final Map<String, Float> featureSupplier;
                                     final String dependentFeature;
+                                    double extraMultiplier = 0.0d;
+
                                     public static final String DEPDENDENT_FEATURE = "dependent_feature";
+                                    public static final String EXTRA_SCRIPT_PARAM = "extra_multiplier";
 
                                     {
                                         if (!p.containsKey(FEATURE_VECTOR)) {
@@ -164,6 +167,9 @@ public abstract class BaseIntegrationTest extends ESSingleNodeTestCase {
                                         }
                                         if (!p.containsKey(DEPDENDENT_FEATURE)) {
                                             throw new IllegalArgumentException("Missing parameter [depdendent_feature ]");
+                                        }
+                                        if (p.containsKey(EXTRA_SCRIPT_PARAM)) {
+                                            extraMultiplier = Double.valueOf(p.get(EXTRA_SCRIPT_PARAM).toString());
                                         }
                                         featureSupplier = (Map<String, Float>) p.get(FEATURE_VECTOR);
                                         dependentFeature = p.get(DEPDENDENT_FEATURE).toString();
@@ -174,7 +180,9 @@ public abstract class BaseIntegrationTest extends ESSingleNodeTestCase {
                                         return new SearchScript(p, lookup, ctx) {
                                             @Override
                                             public double runAsDouble() {
-                                                return featureSupplier.get(dependentFeature) * 10;
+                                                return extraMultiplier == 0.0d ?
+                                                        featureSupplier.get(dependentFeature) * 10 :
+                                                        featureSupplier.get(dependentFeature) * extraMultiplier;
                                             }
                                         };
                                     }


### PR DESCRIPTION
One thing that I overlooked while writing `ScriptFeature` was that it forces the query_parameter name in LTR script to be same as the source elasticsearch script. For example the painless elasticsearch script below uses `params.multiplier` so the ltr script also needs to use the same name i.e. `multiplier`. It cannot use a different name in params like `multiplier_ltr`.  This change allows us to decouple the naming in source scripts (painless or native) and LTR.

```
{
                  "name": "feature2",
                  "params": [
                    "multiplier_ltr"
                  ],
                  "template_language": "script_feature",
                  "template": {
                    "lang": "painless",
                    "source": "params.feature_vector.get('feature1') * (long)params.multiplier",
                    "params": {
                      "multiplier": "multiplier_ltr"
                    }
                  }
}
```