### PR TITLE
turn off caching for RankerQuery

### DIFF
--- a/src/main/java/com/o19s/es/ltr/query/RankerQuery.java
+++ b/src/main/java/com/o19s/es/ltr/query/RankerQuery.java
@@ -179,7 +179,7 @@ public class RankerQuery extends Query {
 
                 @Override
                 public boolean isCacheable(LeafReaderContext ctx) {
-                    return true;
+                    return false;
                 }
             };
         }
@@ -195,12 +195,7 @@ public class RankerQuery extends Query {
 
         @Override
         public boolean isCacheable(LeafReaderContext ctx) {
-            for (Weight w : weights) {
-                if (w.isCacheable(ctx) == false) {
-                    return false;
-                }
-            }
-            return true;
+            return false;
         }
 
         RankerWeight(List<Weight> weights) {


### PR DESCRIPTION
We were seeing `concurrent modifcation exceptions` on `RankerQuery` while stress testing ltr plugin with concurrent queries.  StackTrace: https://gist.github.com/umeshdangat/834e5d8b840d4c81c14921d58967ea93

@nomoa helped understand the underlying issue and it is documented here in the slack chat: 
https://gist.github.com/umeshdangat/b02e7333513b230d3c2e734e5954a42a

We deployed this fix in our stress test environment and the issue seems to be resolved.

Essentially caching `LtrScript`  in the current form uses FeatureSupplier in its `equals` method which can mutate (due to feature vector) and hence is not cacheable.