### PR TITLE
Custom rescore context

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,7 @@ Contents
    logging-features
    training-models
    searching-with-your-model
+   ltr-rescoring
    x-pack
    advanced-functionality
    :caption: Contents:

--- a/docs/ltr-rescoring.rst
+++ b/docs/ltr-rescoring.rst
@@ -1,0 +1,185 @@
+Rescoring using the LTR rescorer
+********************************
+
+=====
+Usage
+=====
+
+The :code:`ltr_rescore` is a custom rescorer very similar to the :code:`query_rescorer` provided by elasticsearch.
+Its main advantage is to provide a `replace` mode but also enables bulk scoring capabilities. ::
+
+    {
+        "window_size": 100,
+        "ltr_rescore": {
+            "query_weight": 1.0,
+            "rescore_query_weight": 1.0,
+            "query_normalizer": "noop",
+            "rescore_query_normalizer": "noop",
+            "score_mode": "replace",
+            "scoring_batch_size": -1,
+            "ltr_query": {
+                "sltr" : {
+                    "model": "my_model",
+                    "params": {
+                        "query_string" : "query test"
+                    }
+                }
+            }
+        }
+    }
+
+
+query_weight
+    weight applied to the query score after normalization. Defaults to 1.
+rescore_query_weight
+    weight applied to the rescore query score after normalization. Defaults to 1.
+query_normalizer
+    type of normalization applied to the query score. Default to :code:`noop`.
+rescore_query_normalizer
+    type of normalization applied to the rescore query score. Default to :code:`noop`.
+score_mode
+    method to combine the query score and rescore query score. Possible values: :code:`avg`, :code:`multiply`, :code:`max`, :code:`min`, :code:`total` and :code:`replace`. Defaults to :code:`total`.
+scoring_batch_size
+    size of the batch when bulk scoring is supported by the ranker. Set to 1 to disable bulk scoring, -1 to use ranker preferred defaults. Defaults to -1.
+ltr_query:
+    the query to use for rescoring, bulk scoring is only supported with :code:`sltr` and :code:`ltr` queries.
+
+===========
+Normalizers
+===========
+
+minmax
+------
+
+:math:`\frac{ score - min }{ max - min }`
+
+Usage ::
+
+    {
+        "minmax": { "min": 0, "max": "12" }
+    }
+
+
+Normalizes the input score in the unit interval [0,1] assuming all input values are in the [0,12] interval.
+
+**NOTE**: input values outside the interval are set to the closest bound.
+
+saturation
+----------
+
+:math:`\frac{ score^a }{ score^a + k^a }`
+
+Usage ::
+
+    {
+        "saturation": { "k": 0.5, "a": "1" }
+    }
+
+
+Normalizes any positive values in the unit interval [0,1].
+
+**NOTE**: Negative input values are set to 0.
+
+logistic
+--------
+
+:math:`\frac{ 1 }{ 1 + e^{-k(score-x_0)} }`
+
+Usage ::
+
+    {
+        "logistic": { "k": 0.5, "x0": "1" }
+    }
+
+
+Normalizes any input value in the unit interval [0,1].
+
+interval
+--------
+
+Usage ::
+
+    {
+        "interval" : {
+            "from": 1,
+            "to": 2,
+            "inclusive": false,
+            "normalizer": {
+                "minmax": { "min": 0, "max": 100 }
+            }
+        }
+    }
+
+Normalizes any input value in [from, to] interval using the given normalizer to first normalize within the unit interval.
+
+from
+    lower bound
+to
+    upper bound
+inclusive
+    whether or not the upper bound is a possible output value. Defaults to false.
+normalizer:
+    input normalizer to use.
+
+noop
+----
+
+Usage ::
+
+    {
+        "noop" : {}
+    }
+
+
+Does nothing and return the input score.
+
+============
+Replace mode
+============
+
+A classic way to use this rescorer for replacing the main query score using you LTR model is to use the replace mode.
+
+Example ::
+
+    {
+        "query": { "match" : { "field" : "user query" } } }
+        "rescore" : [
+            {
+                "window_size": 100,
+                "ltr_rescore": {
+                    "query_normalizer" : {
+                        "interval" : {
+                            "from": 0,
+                            "to" : 1,
+                            "normalizer": { "saturation": { "k": 1, "a": 1 } }
+                        }
+                    },
+                    "rescore_query_normalizer" : {
+                        "interval" : {
+                            "from": 1,
+                            "to" : 2,
+                            "normalizer": { "minmax": { "min": 0, "max": 1 } }
+                        }
+                    },
+                    "score_mode" : "replace",
+                    "ltr_query" : {
+                        "sltr": {
+                            "model": "mymodel/v1"
+                            "params": {
+                                "query_string": "user query"
+                            }
+                        }
+                }
+            }
+        ]
+    }
+
+This will rescore the top-100 documents per shard returned by the retrieval query
+:code:`{ "match" : { "field" : "user query" } }`.
+
+The top-100 docs of every shards will have their scores normalized in the [1,2] interval, remaining documents (which are
+not rescored using your LTR model) will see their scores normalized in the [0,1] interval ensuring that that documents
+outside the top-100 are not ranked above rescored documents.
+
+If had to *hack* your classic query rescorer using insane boost values or simply you had to forbid your application to paginate
+over the :code:`window_size` result this `replace` mode is for you.

--- a/src/main/java/com/o19s/es/ltr/query/FeatureMatrixCollector.java
+++ b/src/main/java/com/o19s/es/ltr/query/FeatureMatrixCollector.java
@@ -1,0 +1,114 @@
+package com.o19s.es.ltr.query;
+
+import com.o19s.es.ltr.ranker.FeatureMatrix;
+import com.o19s.es.ltr.ranker.LtrRanker;
+import com.o19s.es.ltr.utils.Suppliers;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.ReaderUtil;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.Scorer;
+import org.elasticsearch.common.CheckedFunction;
+
+import java.io.IOException;
+import java.util.List;
+
+public class FeatureMatrixCollector {
+    private final ScoreDoc[] docs;
+    private final IndexReader reader;
+    private final int windowSize;
+    private List<Scorer> scorers;
+    // Number of docs in the initial ScoreDoc[] that belongs to the current segment
+    private int docsInSegment;
+    // Number of docs in the initial ScoreDoc[] that we already scored in this segment
+    private int docsReadInSegment;
+    private int current;
+    private LeafReaderContext currentLeaf;
+    private int readerMaxDoc;
+    private CheckedFunction<LeafReaderContext, List<Scorer>, IOException> weight;
+    private Suppliers.MutableSupplier<LtrRanker.FeatureVector> mutableSupplier;
+
+    public FeatureMatrixCollector(RankerQuery.RankerWeight weight,
+                                  IndexReader reader, ScoreDoc[] allDocs, int windowSize) {
+        this.weight = weight;
+        this.docs = allDocs;
+        assert assertOrdered();
+        this.reader = reader;
+        assert windowSize <= docs.length;
+        this.windowSize = windowSize;
+        this.mutableSupplier = weight.getFeatureVectorSupplier();
+    }
+
+    private boolean assertOrdered() {
+        int last = -1;
+        for (int i = 0; i < windowSize; i++) {
+            if (last > this.docs[i].doc) {
+                return false;
+            }
+            last = this.docs[i].doc;
+        }
+        return true;
+    }
+
+    private void maybeNextSegment() throws IOException {
+        assert current < windowSize && current < docs.length;
+        int doc = docs[current].doc;
+        if (doc < readerMaxDoc) return;
+        currentLeaf = reader.leaves().get(ReaderUtil.subIndex(doc, reader.leaves()));
+        readerMaxDoc = currentLeaf.docBase + currentLeaf.reader().maxDoc();
+        scorers = weight.apply(currentLeaf);
+        int i = current;
+        for (; i < windowSize && docs[i].doc < readerMaxDoc; i++);
+        docsInSegment = i - current;
+        docsReadInSegment = 0;
+    }
+
+    public int collect(FeatureMatrix matrix) throws IOException {
+        int matrixBase = 0;
+        while (current < windowSize) {
+            maybeNextSegment();
+            int remainingDocsInSegment = docsInSegment - docsReadInSegment;
+            int matrixCap = matrix.docSize() - matrixBase;
+            int docsToRead = Math.min(matrixCap, remainingDocsInSegment);
+            int maxDocToScore = current + docsToRead;
+            for (int f = 0; f < scorers.size(); f++) {
+                collectCurrentSegment(f, matrix, matrixBase, maxDocToScore);
+            }
+            current += docsToRead;
+            docsReadInSegment += docsToRead;
+            matrixBase += docsToRead;
+            if (matrixCap == docsToRead) {
+                // Matrix full
+                break;
+            }
+        }
+        return matrixBase;
+    }
+
+    private void collectCurrentSegment(int fIdx, FeatureMatrix matrix, int matrixBase, int maxDoc) throws IOException {
+        Scorer scorer = scorers.get(fIdx);
+        if (scorer == null) {
+            return;
+        }
+        DocIdSetIterator iterator = scorer.iterator();
+        // Keep two indices that increment in parallel:
+        // i: the source in docs
+        // matrixDoc: the target in our feature matrix
+        for (int matrixDoc = matrixBase, i = current; i < maxDoc; i++, matrixDoc++) {
+            // TODO: It might interesing to detect and split features that are dependent on others
+            // so that we maintain the the featureVector only for them.
+            mutableSupplier.set(matrix.vector(matrixDoc));
+            int doc = docs[i].doc - currentLeaf.docBase;
+            int scorerDocId = iterator.docID();
+            if (doc > scorerDocId) {
+                scorerDocId = iterator.advance(doc);
+            }
+            if (doc == scorerDocId) {
+                matrix.setFeatureScoreForDoc(matrixDoc, fIdx, scorer.score());
+            } else if (scorerDocId == DocIdSetIterator.NO_MORE_DOCS) {
+                return;
+            }
+        }
+    }
+}

--- a/src/main/java/com/o19s/es/ltr/query/Normalizer.java
+++ b/src/main/java/com/o19s/es/ltr/query/Normalizer.java
@@ -1,0 +1,498 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.query;
+
+import org.apache.lucene.search.Explanation;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.io.stream.NamedWriteable;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+public interface Normalizer extends NamedWriteable, ToXContent {
+    NoopNormalizer NOOP = new NoopNormalizer();
+
+    double normalize(double score);
+    Explanation explain(double sourceScore, Explanation sourceExplanation);
+
+    @Override
+    default XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject().field(getWriteableName());
+        return doToXContent(builder, params).endObject();
+    }
+
+    XContentBuilder doToXContent(XContentBuilder builder, Params params) throws IOException;
+    static Normalizer parseBaseNormalizer(XContentParser parser, Void context) throws IOException {
+        return parseNormalizer(parser, Normalizer.class, context);
+    }
+
+    static UnitIntervalNormalizer parseUnitIntervalNormalizer(XContentParser parser, Void context) throws IOException {
+        return parseNormalizer(parser, UnitIntervalNormalizer.class, context);
+    }
+
+    static <E extends Normalizer> E parseNormalizer(XContentParser parser, Class<E> clazz, Void context) throws IOException {
+        if (parser.currentToken() != XContentParser.Token.START_OBJECT) {
+            if (parser.nextToken() != XContentParser.Token.START_OBJECT) {
+                throw new ParsingException(parser.getTokenLocation(), "[_na] normalizer malformed, must start with start_object");
+            }
+        }
+        if (parser.nextToken() == XContentParser.Token.END_OBJECT) {
+            // we encountered '{}' for a query clause, it used to be supported, deprecated in 5.0 and removed in 6.0
+            throw new IllegalArgumentException("normalizer malformed, empty clause found at [" + parser.getTokenLocation() +"]");
+        }
+        if (parser.currentToken() != XContentParser.Token.FIELD_NAME) {
+            throw new ParsingException(parser.getTokenLocation(), "[_na] normalizer malformed, no field after start_object");
+        }
+        String name = parser.currentName();
+        E normalizer = parser.namedObject(clazz, name, null);
+        if (parser.currentToken() != XContentParser.Token.END_OBJECT) {
+            throw new ParsingException(parser.getTokenLocation(),
+                    "[" + name + "] malformed normalizer, expected [END_OBJECT] but found [" + parser.currentToken() + "]");
+        }
+        if (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            throw new ParsingException(parser.getTokenLocation(),
+                    "[" + name + "] malformed normalizer, expected [END_OBJECT] but found [" + parser.currentToken() + "]");
+        }
+        return normalizer;
+    }
+
+    static List<NamedXContentRegistry.Entry> getNamedXContent() {
+        return Arrays.asList(
+            new NamedXContentRegistry.Entry(Normalizer.class, NoopNormalizer.NAME, NoopNormalizer::parse),
+            new NamedXContentRegistry.Entry(Normalizer.class, IntervalNormalizer.NAME, IntervalNormalizer::parse),
+            new NamedXContentRegistry.Entry(Normalizer.class, MinMax.NAME, MinMax::parse),
+            new NamedXContentRegistry.Entry(Normalizer.class, Saturation.NAME, Saturation::parse),
+            new NamedXContentRegistry.Entry(Normalizer.class, Logistic.NAME, Logistic::parse),
+            new NamedXContentRegistry.Entry(UnitIntervalNormalizer.class, MinMax.NAME, MinMax::parse),
+            new NamedXContentRegistry.Entry(UnitIntervalNormalizer.class, Saturation.NAME, Saturation::parse),
+            new NamedXContentRegistry.Entry(UnitIntervalNormalizer.class, Logistic.NAME, Logistic::parse)
+        );
+    }
+
+    static List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return Arrays.asList(
+                new NamedWriteableRegistry.Entry(Normalizer.class, NoopNormalizer.NAME.getPreferredName(), (s) -> NOOP),
+                new NamedWriteableRegistry.Entry(Normalizer.class, IntervalNormalizer.NAME.getPreferredName(), IntervalNormalizer::new),
+                new NamedWriteableRegistry.Entry(Normalizer.class, MinMax.NAME.getPreferredName(), MinMax::new),
+                new NamedWriteableRegistry.Entry(Normalizer.class, Saturation.NAME.getPreferredName(), Saturation::new),
+                new NamedWriteableRegistry.Entry(Normalizer.class, Logistic.NAME.getPreferredName(), Logistic::new),
+                new NamedWriteableRegistry.Entry(UnitIntervalNormalizer.class, MinMax.NAME.getPreferredName(), MinMax::new),
+                new NamedWriteableRegistry.Entry(UnitIntervalNormalizer.class, Saturation.NAME.getPreferredName(), Saturation::new),
+                new NamedWriteableRegistry.Entry(UnitIntervalNormalizer.class, Logistic.NAME.getPreferredName(), Logistic::new)
+        );
+    }
+
+    /**
+     * Marker class to identify normalizers that outputs
+     * their scores in the unit interval [0,1]
+     */
+    interface UnitIntervalNormalizer extends Normalizer {}
+
+    class IntervalNormalizer implements Normalizer {
+        private static final ParseField NAME = new ParseField("interval");
+        private static final ParseField FROM = new ParseField("from");
+        private static final ParseField TO = new ParseField("to");
+        private static final ParseField INCLUSIVE = new ParseField("inclusive");
+        private static final ParseField NORMALIZER = new ParseField("normalizer");
+
+        static final ConstructingObjectParser<IntervalNormalizer, Void> PARSER = new ConstructingObjectParser<>(NAME.getPreferredName(),
+                (o) -> new IntervalNormalizer((double) o[0], (double) o[1],
+                        o[3] != null ? (boolean) o[3] : false, (UnitIntervalNormalizer) o[2]));
+
+        static {
+            PARSER.declareDouble(ConstructingObjectParser.constructorArg(), FROM);
+            PARSER.declareDouble(ConstructingObjectParser.constructorArg(), TO);
+            PARSER.declareField(ConstructingObjectParser.constructorArg(),
+                    Normalizer::parseUnitIntervalNormalizer, NORMALIZER, ObjectParser.ValueType.OBJECT);
+            PARSER.declareBoolean(ConstructingObjectParser.optionalConstructorArg(), INCLUSIVE);
+        }
+        private final double from;
+        private final double to;
+        private final boolean inclusive;
+        private final double intervalSize;
+        private final UnitIntervalNormalizer normalizer;
+
+        public IntervalNormalizer(double from, double to, boolean inclusive, UnitIntervalNormalizer normalizer) {
+            this.from = from;
+            this.to = to;
+            this.inclusive = inclusive;
+            if (inclusive) {
+                this.intervalSize = to - from;
+            } else {
+                this.intervalSize = to - from - Math.ulp(Math.abs(to)+Math.abs(from));
+            }
+            if (this.intervalSize < 0) {
+                throw new IllegalArgumentException( "Invalid interval ["+from+","+to+"] given");
+            }
+
+            this.normalizer = Objects.requireNonNull(normalizer);
+        }
+
+        IntervalNormalizer(StreamInput in) throws IOException {
+            this(in.readDouble(), in.readDouble(), in.readBoolean(), in.readNamedWriteable(UnitIntervalNormalizer.class));
+        }
+
+        public double normalize(double score) {
+            return ((this.intervalSize * this.normalizer.normalize(score)) + from);
+        }
+
+        static Normalizer parse(XContentParser parser) throws IOException {
+            return PARSER.parse(parser, null);
+        }
+
+        @Override
+        public Explanation explain(double sourceScore, Explanation sourceExplanation) {
+            return Explanation.match((float) normalize(sourceScore),
+                    String.format(Locale.ROOT, "interval: [%f, %f" + (this.inclusive ? "]" : ")"), from, to),
+                    this.normalizer.explain(sourceScore, sourceExplanation));
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeDouble(this.from);
+            out.writeDouble(this.to);
+            out.writeBoolean(this.inclusive);
+            out.writeNamedWriteable(this.normalizer);
+        }
+
+        /**
+         * Returns the name of the writeable object
+         */
+        @Override
+        public String getWriteableName() {
+            return NAME.getPreferredName();
+        }
+
+        @Override
+        public XContentBuilder doToXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject()
+                    .field(FROM.getPreferredName(), from)
+                    .field(TO.getPreferredName(), to)
+                    .field(NORMALIZER.getPreferredName(), normalizer);
+            if (inclusive) {
+                builder.field(INCLUSIVE.getPreferredName(), inclusive);
+            }
+            return builder.endObject();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            IntervalNormalizer that = (IntervalNormalizer) o;
+            return Double.compare(that.from, from) == 0 &&
+                    Double.compare(that.to, to) == 0 &&
+                    inclusive == that.inclusive &&
+                    normalizer.equals(that.normalizer);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(from, to, inclusive, normalizer);
+        }
+    }
+
+    class MinMax implements UnitIntervalNormalizer {
+        private final double min, max;
+        private static final ParseField NAME = new ParseField("minmax");
+        private static final ParseField MIN = new ParseField("min");
+        private static final ParseField MAX = new ParseField("max");
+
+        static final ConstructingObjectParser<MinMax,Void> PARSER = new ConstructingObjectParser<>(NAME.getPreferredName(),
+                (o) -> new MinMax((double) o[0], (double) o[1]));
+        static {
+            PARSER.declareDouble(ConstructingObjectParser.constructorArg(), MIN);
+            PARSER.declareDouble(ConstructingObjectParser.constructorArg(), MAX);
+        }
+
+        public MinMax(double min, double max) {
+            if (min >= max) {
+                throw new IllegalArgumentException("min >= max");
+            }
+            this.min = min;
+            this.max = max;
+        }
+
+        MinMax(StreamInput in) throws IOException {
+            min = in.readDouble();
+            max = in.readDouble();
+        }
+
+        @Override
+        public double normalize(double score) {
+            return ((Math.min(Math.max(score, min), max)- min)/(max - min));
+        }
+
+        public Explanation explain(double sourceScore, Explanation sourceExplanation) {
+            return Explanation.match((float) normalize(sourceScore),
+                    String.format(Locale.ROOT, "minmax: [%f, %f]", min, max),
+                    sourceExplanation);
+        }
+
+        static MinMax parse(XContentParser parser) throws IOException {
+            return PARSER.parse(parser, null);
+        }
+
+        /**
+         * Returns the name of the writeable object
+         */
+        @Override
+        public String getWriteableName() {
+            return NAME.getPreferredName();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeDouble(min);
+            out.writeDouble(max);
+        }
+
+        @Override
+        public XContentBuilder doToXContent(XContentBuilder builder, Params params) throws IOException {
+            return builder.startObject()
+                    .field(MIN.getPreferredName(), min)
+                    .field(MAX.getPreferredName(), max)
+                    .endObject();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            MinMax minMax = (MinMax) o;
+            return Double.compare(minMax.min, min) == 0 &&
+                    Double.compare(minMax.max, max) == 0;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(min, max);
+        }
+    }
+
+    class Saturation implements UnitIntervalNormalizer {
+        private final double k, ka, a;
+        private static final ParseField NAME = new ParseField("saturation");
+        private static final ParseField K = new ParseField("k");
+        private static final ParseField A = new ParseField("a");
+
+        static final ConstructingObjectParser<Saturation,Void> PARSER = new ConstructingObjectParser<>(NAME.getPreferredName(),
+                (o) -> new Saturation((double) o[0], (double) o[1]));
+        static {
+            PARSER.declareDouble(ConstructingObjectParser.constructorArg(), K);
+            PARSER.declareDouble(ConstructingObjectParser.constructorArg(), A);
+        }
+
+        public Saturation(double k, double a) {
+            if (k <= 0) {
+                throw new IllegalArgumentException("k must be strictly positive");
+            }
+            if (a <= 0) {
+                throw new IllegalArgumentException("a must be strictly positive");
+            }
+            this.k = k;
+            this.ka = Math.pow(k, a);
+            this.a = a;
+        }
+
+        Saturation(StreamInput in) throws IOException {
+            this(in.readDouble(), in.readDouble());
+        }
+
+        @Override
+        public double normalize(double score) {
+            double sa = Math.pow(Math.max(score, 0), a);
+            return (sa / ( sa + ka ));
+        }
+
+        public Explanation explain(double sourceScore, Explanation sourceExplanation) {
+            return Explanation.match((float) normalize(sourceScore),
+                    String.format(Locale.ROOT, "saturation(k = %f, a = %f)", k, a),
+                    sourceExplanation);
+        }
+
+        static Saturation parse(XContentParser parser) throws IOException {
+            return PARSER.parse(parser, null);
+        }
+
+        /**
+         * Returns the name of the writeable object
+         */
+        @Override
+        public String getWriteableName() {
+            return NAME.getPreferredName();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeDouble(k);
+            out.writeDouble(a);
+        }
+
+        @Override
+        public XContentBuilder doToXContent(XContentBuilder builder, Params params) throws IOException {
+            return builder.startObject()
+                    .field(K.getPreferredName(), k)
+                    .field(A.getPreferredName(), a)
+                    .endObject();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Saturation that = (Saturation) o;
+            return Double.compare(that.k, k) == 0 &&
+                    Double.compare(that.a, a) == 0;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(k, a);
+        }
+    }
+
+    class Logistic implements UnitIntervalNormalizer {
+        private final double k, x0;
+        private static final ParseField NAME = new ParseField("logistic");
+        private static final ParseField K = new ParseField("k");
+        private static final ParseField X0 = new ParseField("x0");
+
+        static final ConstructingObjectParser<Logistic,Void> PARSER = new ConstructingObjectParser<>(NAME.getPreferredName(),
+                (o) -> new Logistic((double) o[0], (double) o[1]));
+
+        static {
+            PARSER.declareDouble(ConstructingObjectParser.constructorArg(), K);
+            PARSER.declareDouble(ConstructingObjectParser.constructorArg(), X0);
+        }
+
+        public Logistic(double k, double x0) {
+            this.k = k;
+            this.x0 = x0;
+        }
+
+        Logistic(StreamInput in) throws IOException {
+            this.k = in.readDouble();
+            this.x0 = in.readDouble();
+        }
+
+        @Override
+        public double normalize(double score) {
+            return (1D / (1D + Math.exp(-k * ((score - x0)))));
+        }
+
+        public Explanation explain(double sourceScore, Explanation sourceExplanation) {
+            return Explanation.match((float) normalize(sourceScore),
+                    String.format(Locale.ROOT, "logistic(k = %f, x0 = %f)", k, x0),
+                    sourceExplanation);
+        }
+
+        static Logistic parse(XContentParser parser) throws IOException {
+            return PARSER.parse(parser, null);
+        }
+
+        /**
+         * Returns the name of the writeable object
+         */
+        @Override
+        public String getWriteableName() {
+            return NAME.getPreferredName();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeDouble(k);
+            out.writeDouble(x0);
+        }
+
+        @Override
+        public XContentBuilder doToXContent(XContentBuilder builder, Params params) throws IOException {
+            return builder.startObject()
+                    .field(K.getPreferredName(), k)
+                    .field(X0.getPreferredName(), x0)
+                    .endObject();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Logistic logistic = (Logistic) o;
+            return Double.compare(logistic.k, k) == 0 &&
+                    Double.compare(logistic.x0, x0) == 0;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(k, x0);
+        }
+    }
+
+    class NoopNormalizer implements Normalizer {
+        static final ParseField NAME = new ParseField("noop");
+
+        @Override
+        public double normalize(double score) {
+            return score;
+        }
+
+        public Explanation explain(double sourceScore, Explanation sourceExplanation) {
+            return Explanation.match((float) normalize(sourceScore),"noop normalizer",
+                    sourceExplanation);
+        }
+
+        /**
+         * Returns the name of the writeable object
+         */
+        @Override
+        public String getWriteableName() {
+            return NAME.getPreferredName();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+        }
+
+        static NoopNormalizer parse(XContentParser parser) throws IOException {
+            if (parser.nextToken() != XContentParser.Token.START_OBJECT) {
+                throw new ParsingException(parser.getTokenLocation(), "Expected START_OBJECT");
+            }
+            if (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+                throw new ParsingException(parser.getTokenLocation(), "Expected END_OBJECT");
+            }
+            return NOOP;
+        }
+
+        @Override
+        public XContentBuilder doToXContent(XContentBuilder builder, Params params) throws IOException {
+            return builder.startObject().endObject();
+        }
+    }
+}

--- a/src/main/java/com/o19s/es/ltr/query/StoredLtrQueryBuilder.java
+++ b/src/main/java/com/o19s/es/ltr/query/StoredLtrQueryBuilder.java
@@ -135,7 +135,7 @@ public class StoredLtrQueryBuilder extends AbstractQueryBuilder<StoredLtrQueryBu
         if (storeName != null) {
             builder.field(STORE_NAME.getPreferredName(), storeName);
         }
-        if (this.params != null && !this.params.isEmpty()) {
+        if (this.params != null) {
             builder.field(PARAMS.getPreferredName(), this.params);
         }
         if (this.activeFeatures != null && !this.activeFeatures.isEmpty()) {

--- a/src/main/java/com/o19s/es/ltr/ranker/BulkLtrRanker.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/BulkLtrRanker.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.ranker;
+
+/**
+ * A ranker that is able to rank multiple docs at once
+ */
+public interface BulkLtrRanker {
+    /**
+     * A new feature matrix that can hold nfeature*nDocs floats
+     * @param reuse a reusable matrix
+     * @param nDocs number of docs in the matrix
+     * @return the matrix
+     */
+    FeatureMatrix newMatrix(FeatureMatrix reuse, int nDocs);
+
+    /**
+     * Compute the scores using the values stored in the matrix
+     *
+     * @param matrix the input matrix with feature values populated
+     * @param from score from this base
+     * @param to score up to this doc
+     * @param consumer callback to receive scores
+     */
+    void bulkScore(FeatureMatrix matrix, int from, int to, BulkScoreConsumer consumer);
+
+    /**
+     * Tell the elastic engine how many docs are to be scored at once
+     * (it will be the value used to create the matrix using {@link #newMatrix(FeatureMatrix, int)})
+     *
+     * @param windowSize the number of document to be rescored
+     * @return prefered number of docs to score in a single batch
+     */
+    default int getPreferedBatchSize(int windowSize) {
+        return windowSize;
+    }
+
+    /**
+     * Call
+     */
+    interface BulkScoreConsumer {
+        void consume(int matrixIndex, float score);
+    }
+}

--- a/src/main/java/com/o19s/es/ltr/ranker/DenseFeatureMatrix.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/DenseFeatureMatrix.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.ranker;
+
+import java.util.Arrays;
+
+public class DenseFeatureMatrix implements FeatureMatrix {
+    public final float[][] scores;
+    private final FeatureVectorView view = new FeatureVectorView();
+
+    public DenseFeatureMatrix(int docs, int features) {
+        this.scores = new float[docs][features];
+    }
+
+    /**
+     * Set the feature score.
+     */
+    @Override
+    public void setFeatureScoreForDoc(int doc, int featureId, float score) {
+        this.scores[doc][featureId] = score;
+    }
+
+    /**
+     * Get the feature score
+     */
+    @Override
+    public float getFeatureScoreForDoc(int doc, int featureId) {
+        return this.scores[doc][featureId];
+    }
+
+    /**
+     * @return number of docs in this matrix
+     */
+    @Override
+    public int docSize() {
+        return this.scores.length;
+    }
+
+    public void reset() {
+        for (float[] score : scores) {
+            Arrays.fill(score, 0F);
+        }
+    }
+
+    @Override
+    public LtrRanker.FeatureVector vector(int doc) {
+        view.scores = scores[doc];
+        return view;
+    }
+
+    static class FeatureVectorView implements LtrRanker.FeatureVector {
+        private float[] scores;
+
+        @Override
+        public void setFeatureScore(int featureId, float score) {
+            throw new UnsupportedOperationException("read-only view");
+        }
+
+        @Override
+        public float getFeatureScore(int featureId) {
+            return scores[featureId];
+        }
+    }
+}

--- a/src/main/java/com/o19s/es/ltr/ranker/FeatureMatrix.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/FeatureMatrix.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.ranker;
+
+public interface FeatureMatrix {
+    /**
+     * Set the feature score.
+     */
+    void setFeatureScoreForDoc(int doc, int featureId, float score);
+
+    /**
+     * Get the feature score
+     */
+    float getFeatureScoreForDoc(int doc, int featureId);
+
+    /**
+     * A view of the matrix pointing at this specific doc.
+     */
+    default LtrRanker.FeatureVector vector(int doc) {
+        return new LtrRanker.FeatureVector() {
+            @Override
+            public void setFeatureScore(int featureId, float score) {
+                throw new UnsupportedOperationException("Read only vector");
+            }
+
+            @Override
+            public float getFeatureScore(int featureId) {
+                return getFeatureScoreForDoc(doc, featureId);
+            }
+        };
+    }
+
+    /**
+     * @return number of docs in this matrix
+     */
+    int docSize();
+}

--- a/src/main/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTree.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTree.java
@@ -16,8 +16,11 @@
 
 package com.o19s.es.ltr.ranker.dectree;
 
+import com.o19s.es.ltr.ranker.BulkLtrRanker;
+import com.o19s.es.ltr.ranker.DenseFeatureMatrix;
 import com.o19s.es.ltr.ranker.DenseFeatureVector;
 import com.o19s.es.ltr.ranker.DenseLtrRanker;
+import com.o19s.es.ltr.ranker.FeatureMatrix;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
 
@@ -27,7 +30,7 @@ import java.util.Objects;
  * Naive implementation of additive decision tree.
  * May be slow when the number of trees and tree complexity if high comparatively to the number of features.
  */
-public class NaiveAdditiveDecisionTree extends DenseLtrRanker implements Accountable {
+public class NaiveAdditiveDecisionTree extends DenseLtrRanker implements Accountable, BulkLtrRanker {
     private static final long BASE_RAM_USED = RamUsageEstimator.shallowSizeOfInstance(Split.class);
 
     private final Node[] trees;
@@ -57,10 +60,13 @@ public class NaiveAdditiveDecisionTree extends DenseLtrRanker implements Account
 
     @Override
     protected float score(DenseFeatureVector vector) {
+        return this.score(vector.scores);
+    }
+
+    private float score(float[] scores) {
         float sum = 0;
-        float[] scores = vector.scores;
         for (int i = 0; i < trees.length; i++) {
-            sum += weights[i]*trees[i].eval(scores);
+            sum += weights[i] * trees[i].eval(scores);
         }
         return sum;
     }
@@ -77,6 +83,43 @@ public class NaiveAdditiveDecisionTree extends DenseLtrRanker implements Account
     public long ramBytesUsed() {
         return BASE_RAM_USED + RamUsageEstimator.sizeOf(weights)
                 + RamUsageEstimator.sizeOf(trees);
+    }
+
+    /**
+     * A new feature matrix that can hold nfeature*nDocs floats
+     *
+     * @param reuse a reusable matrix
+     * @param nDocs number of docs in the matrix
+     * @return the matrix
+     */
+    @Override
+    public DenseFeatureMatrix newMatrix(FeatureMatrix reuse, int nDocs) {
+        if (reuse == null) {
+            return new DenseFeatureMatrix(nDocs, size());
+        }
+        assert reuse instanceof DenseFeatureMatrix;
+        DenseFeatureMatrix dmatrix = (DenseFeatureMatrix) reuse;
+        dmatrix.reset();
+        return dmatrix;
+    }
+
+    float[] scores = null;
+
+    /**
+     * Compute the scores using the values stored in the matrix
+     *
+     * @param matrix   the input matrix with feature values populated
+     * @param from     score from this base
+     * @param to       score up to this doc
+     * @param consumer callback to receive scores
+     */
+    @Override
+    public void bulkScore(FeatureMatrix matrix, int from, int to, BulkScoreConsumer consumer) {
+        assert matrix instanceof DenseFeatureMatrix;
+        DenseFeatureMatrix dmatrix = (DenseFeatureMatrix) matrix;
+        for (int i = from;  i < to; i++) {
+            consumer.consume(i, score(dmatrix.scores[i]));
+        }
     }
 
     public interface Node extends Accountable {

--- a/src/main/java/com/o19s/es/ltr/rescore/LtrRescoreBuilder.java
+++ b/src/main/java/com/o19s/es/ltr/rescore/LtrRescoreBuilder.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.rescore;
+
+import com.o19s.es.ltr.query.LtrQueryBuilder;
+import com.o19s.es.ltr.query.Normalizer;
+import com.o19s.es.ltr.query.RankerQuery;
+import com.o19s.es.ltr.query.StoredLtrQueryBuilder;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.AbstractQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryRewriteContext;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.search.rescore.RescoreContext;
+import org.elasticsearch.search.rescore.RescorerBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class LtrRescoreBuilder extends RescorerBuilder<LtrRescoreBuilder> {
+    public static final ParseField NAME = new ParseField("ltr_rescore");
+    static ObjectParser<LtrRescoreBuilder, Void> PARSER = new ObjectParser<>(NAME.getPreferredName(), LtrRescoreBuilder::new);
+    private static final ParseField QUERY_NORMALIZER = new ParseField("query_normalizer");
+    private static final ParseField RESCORE_QUERY_NORMALIZER = new ParseField("rescore_query_normalizer");
+    private static final ParseField QUERY_WEIGHT = new ParseField("query_weight");
+    private static final ParseField RESCORE_QUERY_WEIGHT = new ParseField("rescore_query_weight");
+    private static final ParseField RESCORE_QUERY = new ParseField("ltr_query");
+    private static final ParseField SCORE_MODE = new ParseField("score_mode");
+    private static final ParseField SCORING_BATCH_SIZE = new ParseField("scoring_batch_size");
+    private static final LtrRescorer RESCORER = new LtrRescorer();
+
+    private Normalizer queryNormalizer = Normalizer.NOOP;
+    private Normalizer rescoreQueryNormalizer = Normalizer.NOOP;
+    private double queryWeight = 1F;
+    private double rescoreQueryWeight = 1F;
+    private LtrRescorer.LtrRescoreMode scoreMode = LtrRescorer.LtrRescoreMode.Total;
+    private QueryBuilder query;
+    private int scoringBatchSize = -1;
+
+    static {
+        PARSER.declareObject(LtrRescoreBuilder::setQueryNormalizer, Normalizer::parseBaseNormalizer, QUERY_NORMALIZER);
+        PARSER.declareObject(LtrRescoreBuilder::setRescoreQueryNormalizer, Normalizer::parseBaseNormalizer, RESCORE_QUERY_NORMALIZER);
+        PARSER.declareDouble(LtrRescoreBuilder::setQueryWeight, QUERY_WEIGHT);
+        PARSER.declareDouble(LtrRescoreBuilder::setRescoreQueryWeight, RESCORE_QUERY_WEIGHT);
+        PARSER.declareObject(LtrRescoreBuilder::setQuery, (p,c) -> AbstractQueryBuilder.parseInnerQueryBuilder(p), RESCORE_QUERY);
+        PARSER.declareString((ltr, scoremode) -> ltr.scoreMode = LtrRescorer.LtrRescoreMode.fromString(scoremode), SCORE_MODE);
+        PARSER.declareInt(LtrRescoreBuilder::setScoringBatchSize, SCORING_BATCH_SIZE);
+    }
+
+    public LtrRescoreBuilder() {
+    }
+
+    public LtrRescoreBuilder(StreamInput in) throws IOException {
+        super(in);
+        queryNormalizer = in.readNamedWriteable(Normalizer.class);
+        rescoreQueryNormalizer = in.readNamedWriteable(Normalizer.class);
+        queryWeight = in.readDouble();
+        rescoreQueryWeight = in.readDouble();
+        scoreMode = LtrRescorer.LtrRescoreMode.readFromStream(in);
+        query = in.readNamedWriteable(QueryBuilder.class);
+        assert query instanceof LtrQueryBuilder || query instanceof StoredLtrQueryBuilder;
+        scoringBatchSize = in.readInt();
+    }
+
+    public static LtrRescoreBuilder parse(XContentParser parser) throws IOException {
+        try {
+            return PARSER.parse(parser, null);
+        } catch(IllegalArgumentException iae) {
+            throw new ParsingException(parser.getTokenLocation(), iae.getMessage(), iae);
+        }
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeNamedWriteable(queryNormalizer);
+        out.writeNamedWriteable(rescoreQueryNormalizer);
+        out.writeDouble(queryWeight);
+        out.writeDouble(rescoreQueryWeight);
+        scoreMode.writeTo(out);
+        out.writeNamedWriteable(query);
+        out.writeInt(scoringBatchSize);
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(NAME.getPreferredName());
+        if (queryNormalizer != Normalizer.NOOP) {
+            builder.field(QUERY_NORMALIZER.getPreferredName(), queryNormalizer);
+        }
+        if (rescoreQueryNormalizer != Normalizer.NOOP) {
+            builder.field(RESCORE_QUERY_NORMALIZER.getPreferredName(), rescoreQueryNormalizer);
+        }
+        if (queryWeight != 1F) {
+            builder.field(QUERY_WEIGHT.getPreferredName(), queryWeight);
+        }
+        if (rescoreQueryWeight != 1F) {
+            builder.field(RESCORE_QUERY_WEIGHT.getPreferredName(), rescoreQueryWeight);
+        }
+        builder.field(RESCORE_QUERY.getPreferredName(), query);
+        if (scoringBatchSize != -1) {
+            builder.field(SCORING_BATCH_SIZE.getPreferredName(), scoringBatchSize);
+        }
+        if (scoreMode != LtrRescorer.LtrRescoreMode.Total) {
+            builder.field(SCORE_MODE.getPreferredName(), scoreMode.toString());
+        }
+        builder.endObject();
+    }
+
+    @Override
+    protected RescoreContext innerBuildContext(int windowSize, QueryShardContext context) throws IOException {
+        LtrRescorer.LtrRescoreContext ctx = new LtrRescorer.LtrRescoreContext(windowSize, RESCORER);
+        ctx.setBatchSize(this.scoringBatchSize);
+        ctx.setQueryWeight(this.queryWeight);
+        ctx.setRescoreQueryWeight(this.rescoreQueryWeight);
+        ctx.setQueryNormalizer(this.queryNormalizer);
+        ctx.setRescoreQueryNormalizer(this.rescoreQueryNormalizer);
+        ctx.setQuery((RankerQuery) this.query.toQuery(context));
+        ctx.setScoreMode(this.scoreMode);
+        return ctx;
+    }
+
+    /**
+     * Returns the name of the writeable object
+     */
+    @Override
+    public String getWriteableName() {
+        return null;
+    }
+
+    @Override
+    public RescorerBuilder<LtrRescoreBuilder> rewrite(QueryRewriteContext ctx) throws IOException {
+        QueryBuilder rewrite = query.rewrite(ctx);
+        if (rewrite == query) {
+            return this;
+        }
+        LtrRescoreBuilder ltrRescoreBuilder = new LtrRescoreBuilder();
+        ltrRescoreBuilder.query = rewrite;
+        ltrRescoreBuilder.queryNormalizer = queryNormalizer;
+        ltrRescoreBuilder.rescoreQueryNormalizer = rescoreQueryNormalizer;
+        ltrRescoreBuilder.queryWeight = queryWeight;
+        ltrRescoreBuilder.rescoreQueryWeight = rescoreQueryWeight;
+        ltrRescoreBuilder.scoringBatchSize = scoringBatchSize;
+        ltrRescoreBuilder.scoreMode = scoreMode;
+        ltrRescoreBuilder.windowSize = windowSize;
+        return ltrRescoreBuilder;
+
+    }
+
+    public LtrRescoreBuilder setQuery(QueryBuilder query) {
+        this.query = query;
+        return this;
+    }
+
+    public Normalizer getQueryNormalizer() {
+        return queryNormalizer;
+    }
+
+    public LtrRescoreBuilder setQueryNormalizer(Normalizer queryNormalizer) {
+        this.queryNormalizer = Objects.requireNonNull(queryNormalizer);
+        return this;
+    }
+
+    public Normalizer getRescoreQueryNormalizer() {
+        return rescoreQueryNormalizer;
+    }
+
+    public LtrRescoreBuilder setRescoreQueryNormalizer(Normalizer rescoreQueryNormalizer) {
+        this.rescoreQueryNormalizer = Objects.requireNonNull(rescoreQueryNormalizer);
+        return this;
+    }
+
+    public double getQueryWeight() {
+        return queryWeight;
+    }
+
+    public LtrRescoreBuilder setQueryWeight(double queryWeight) {
+        this.queryWeight = queryWeight;
+        return this;
+    }
+
+    public double getRescoreQueryWeight() {
+        return rescoreQueryWeight;
+    }
+
+    public LtrRescoreBuilder setRescoreQueryWeight(double rescoreQueryWeight) {
+        this.rescoreQueryWeight = rescoreQueryWeight;
+        return this;
+    }
+
+    public LtrRescorer.LtrRescoreMode getScoreMode() {
+        return scoreMode;
+    }
+
+    public LtrRescoreBuilder setScoreMode(LtrRescorer.LtrRescoreMode scoreMode) {
+        this.scoreMode = Objects.requireNonNull(scoreMode);
+        return this;
+    }
+
+    public QueryBuilder getQuery() {
+        return query;
+    }
+
+    public int getScoringBatchSize() {
+        return scoringBatchSize;
+    }
+
+    public LtrRescoreBuilder setScoringBatchSize(int scoringBatchSize) {
+        this.scoringBatchSize = scoringBatchSize;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        LtrRescoreBuilder builder = (LtrRescoreBuilder) o;
+        return Double.compare(builder.queryWeight, queryWeight) == 0 &&
+                Double.compare(builder.rescoreQueryWeight, rescoreQueryWeight) == 0 &&
+                scoringBatchSize == builder.scoringBatchSize &&
+                Objects.equals(queryNormalizer, builder.queryNormalizer) &&
+                Objects.equals(rescoreQueryNormalizer, builder.rescoreQueryNormalizer) &&
+                scoreMode == builder.scoreMode &&
+                Objects.equals(query, builder.query);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), queryNormalizer, rescoreQueryNormalizer, queryWeight,
+                rescoreQueryWeight, scoreMode, query, scoringBatchSize);
+    }
+}

--- a/src/main/java/com/o19s/es/ltr/rescore/LtrRescorer.java
+++ b/src/main/java/com/o19s/es/ltr/rescore/LtrRescorer.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.rescore;
+
+import com.o19s.es.ltr.query.FeatureMatrixCollector;
+import com.o19s.es.ltr.query.Normalizer;
+import com.o19s.es.ltr.query.RankerQuery;
+import com.o19s.es.ltr.ranker.BulkLtrRanker;
+import com.o19s.es.ltr.ranker.FeatureMatrix;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryRescorer;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.search.rescore.RescoreContext;
+import org.elasticsearch.search.rescore.Rescorer;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Locale;
+import java.util.Set;
+
+public class LtrRescorer implements Rescorer {
+    public static final String NAME = "ltr";
+    public static final Comparator<ScoreDoc> SCORE_DOC_COMPARATOR = (o1, o2) -> {
+        int cmp = Float.compare(o2.score, o1.score);
+        return cmp == 0 ? Integer.compare(o1.doc, o2.doc) : cmp;
+    };
+
+    @Override
+    public TopDocs rescore(TopDocs topDocs, IndexSearcher searcher, RescoreContext rescoreContext) throws IOException {
+        LtrRescoreContext ctx = (LtrRescoreContext) rescoreContext;
+
+        if (ctx.query instanceof RankerQuery &&  ((RankerQuery) ctx.query).getRanker() instanceof BulkLtrRanker && ctx.batchSize != 1) {
+            return bulkRescore(topDocs, searcher, ctx);
+        } else {
+            return classicRescore(topDocs, searcher, ctx);
+        }
+    }
+
+    TopDocs bulkRescore(TopDocs topDocs, IndexSearcher searcher, LtrRescoreContext ctx) throws IOException {
+        ScoreDoc[] docs = topDocs.scoreDocs;
+        if (docs.length == 0) {
+            return topDocs;
+        }
+        FeatureMatrix matrix = null;
+
+        Query query = searcher.rewrite(ctx.query);
+        assert query instanceof RankerQuery;
+        RankerQuery rquery = (RankerQuery) query;
+
+        RankerQuery.ElasticProfilerWeightWrapper wrapper = RankerQuery.ElasticProfilerWeightWrapper.wrap(rquery);
+        searcher.createWeight(wrapper, true, 1F);
+        RankerQuery.RankerWeight weight = wrapper.getWeight();
+        assert weight != null;
+        BulkLtrRanker ranker = (BulkLtrRanker) rquery.getRanker();
+
+        int wSize = Math.min(ctx.getWindowSize(), docs.length);
+        FeatureMatrixCollector collector = new FeatureMatrixCollector(weight, searcher.getIndexReader(), docs, wSize);
+        // We want to scan the index in doc order, reorder only the docs
+        Arrays.sort(docs, 0, wSize, Comparator.comparingInt((s) -> s.doc));
+        int batchSize = ctx.batchSize > 0 ? ctx.batchSize : ranker.getPreferedBatchSize(wSize);
+        batchSize = Math.min(batchSize, wSize);
+
+        for (int i = 0; i < wSize;) {
+            final int base = i;
+            matrix = ranker.newMatrix(matrix, batchSize);
+            int docsToScore = collector.collect(matrix);
+            ranker.bulkScore(matrix, 0, docsToScore, (matrixIndex, s) -> {
+                int idx = matrixIndex+base;
+                ScoreDoc original = docs[idx];
+                original.score = this.combine(original.score, s, ctx);
+            });
+            i+=docsToScore;
+        }
+
+        // Normalize remaining docs
+        for (int i = wSize; i < docs.length; i++) {
+            ScoreDoc original = docs[i];
+            original.score = (float) ctx.normalizedQueryScore(original.score);
+        }
+
+        Arrays.sort(docs, SCORE_DOC_COMPARATOR);
+        topDocs.setMaxScore(docs[0].score);
+        return topDocs;
+    }
+
+    TopDocs classicRescore(TopDocs topDocs, IndexSearcher searcher, LtrRescoreContext ctx) throws IOException {
+        if (topDocs.scoreDocs.length == 0) {
+            return topDocs;
+        }
+
+        QueryRescorer rescorer = new QueryRescorer(ctx.query) {
+            @Override
+            protected float combine(float firstPassScore, boolean secondPassMatches, float secondPassScore) {
+                if (secondPassMatches) {
+                    return LtrRescorer.this.combine(firstPassScore, secondPassScore, ctx);
+                }
+                // should not happen, the ranker query always match
+                return (float) ctx.normalizedQueryScore(firstPassScore);
+            }
+        };
+        TopDocs topDocsRescored = topDocs;
+        if (ctx.getWindowSize() < topDocs.scoreDocs.length) {
+            ScoreDoc[] rescored = Arrays.copyOfRange(topDocs.scoreDocs, 0, ctx.getWindowSize());
+            topDocsRescored = new TopDocs(topDocs.totalHits, rescored, rescored[0].score);
+        }
+
+        topDocsRescored = rescorer.rescore(searcher, topDocsRescored, topDocsRescored.scoreDocs.length);
+        System.arraycopy(topDocsRescored.scoreDocs, 0, topDocs.scoreDocs, 0, topDocsRescored.scoreDocs.length);
+        for (int i = topDocsRescored.scoreDocs.length; i < topDocs.scoreDocs.length; i++) {
+            ScoreDoc doc = topDocs.scoreDocs[i];
+            doc.score = (float) (ctx.queryNormalizer.normalize(doc.score)*ctx.queryWeight);
+        }
+        Arrays.sort(topDocs.scoreDocs, SCORE_DOC_COMPARATOR);
+        topDocs.setMaxScore(topDocs.scoreDocs[0].score);
+        return topDocs;
+    }
+
+    float combine(float queryScore, float rescoreQueryScore, LtrRescoreContext ctx) {
+        double weightedRescoreScore = ctx.rescoreQueryNormalizer.normalize(rescoreQueryScore)*ctx.rescoreQueryWeight;
+        if (ctx.scoreMode == LtrRescoreMode.Replace) {
+            return (float) weightedRescoreScore;
+        }
+        double weightedQueryScore = ctx.queryNormalizer.normalize(queryScore)*ctx.queryWeight;
+        return (float) ctx.scoreMode.combine(weightedQueryScore, weightedRescoreScore);
+    }
+
+    private Explanation explainCombine(Explanation queryExplanation, Explanation rescoreQueryExplanation, LtrRescoreContext ctx) {
+        Explanation queryExplain = ctx.queryNormalizer.explain(queryExplanation.getValue(), queryExplanation);
+        queryExplain = Explanation.match((float) (queryExplain.getValue() * ctx.queryWeight), "product of:",
+                queryExplain, Explanation.match((float) ctx.rescoreQueryWeight, "primaryWeight"));
+        Explanation explain = queryExplain;
+
+        if (rescoreQueryExplanation.isMatch()) {
+            Explanation rescoreExplain = ctx.rescoreQueryNormalizer.explain(rescoreQueryExplanation.getValue(), rescoreQueryExplanation);
+            rescoreExplain = Explanation.match((float) (rescoreExplain.getValue() * ctx.rescoreQueryWeight), "product of:",
+                    rescoreExplain, Explanation.match((float) ctx.rescoreQueryWeight, "secondaryWeight"));
+
+            float finalScore = combine(queryExplanation.getValue(), rescoreQueryExplanation.getValue(), ctx);
+            explain = Explanation.match(finalScore, ctx.scoreMode.toString(), queryExplain, rescoreExplain);
+        }
+        return explain;
+    }
+
+    @Override
+    public Explanation explain(int topLevelDocId, IndexSearcher searcher, RescoreContext rescoreContext,
+                               Explanation sourceExplanation) throws IOException {
+        Explanation rescoreQueryExplanation = searcher.explain(((LtrRescoreContext) rescoreContext).getQuery(), topLevelDocId);
+        return explainCombine(sourceExplanation, rescoreQueryExplanation, (LtrRescoreContext) rescoreContext);
+    }
+
+    @Override
+    public void extractTerms(IndexSearcher searcher, RescoreContext rescoreContext, Set<Term> termsSet) throws IOException {
+        searcher.createWeight(searcher.rewrite(((LtrRescoreContext) rescoreContext).query), true, 1F).extractTerms(termsSet);
+    }
+
+    public static class LtrRescoreContext extends RescoreContext {
+        private Query query;
+        private int batchSize = -1;
+
+        private Normalizer queryNormalizer = Normalizer.NOOP;
+        private Normalizer rescoreQueryNormalizer = Normalizer.NOOP;
+
+        private double queryWeight = 1.0f;
+        private double rescoreQueryWeight = 1.0f;
+
+        private LtrRescoreMode scoreMode = LtrRescoreMode.Replace;
+
+        public LtrRescoreContext(int windowSize, LtrRescorer rescorer) {
+            super(windowSize, rescorer);
+        }
+
+        public double normalizedQueryScore(float score) {
+            return queryNormalizer.normalize(score)* queryWeight;
+        }
+
+        public double normalizedRescoreQueryScore(float score) {
+            return rescoreQueryNormalizer.normalize(score)*rescoreQueryWeight;
+        }
+
+        public Query getQuery() {
+            return query;
+        }
+
+        public LtrRescoreContext setQuery(Query query) {
+            this.query = query;
+            return this;
+        }
+
+        public int getBatchSize() {
+            return batchSize;
+        }
+
+        public LtrRescoreContext setBatchSize(int batchSize) {
+            this.batchSize = batchSize;
+            return this;
+        }
+
+        public Normalizer getQueryNormalizer() {
+            return queryNormalizer;
+        }
+
+        public LtrRescoreContext setQueryNormalizer(Normalizer queryNormalizer) {
+            this.queryNormalizer = queryNormalizer;
+            return this;
+        }
+
+        public Normalizer getRescoreQueryNormalizer() {
+            return rescoreQueryNormalizer;
+        }
+
+        public LtrRescoreContext setRescoreQueryNormalizer(Normalizer rescoreQueryNormalizer) {
+            this.rescoreQueryNormalizer = rescoreQueryNormalizer;
+            return this;
+        }
+
+        public double getQueryWeight() {
+            return queryWeight;
+        }
+
+        public LtrRescoreContext setQueryWeight(double queryWeight) {
+            this.queryWeight = queryWeight;
+            return this;
+        }
+
+        public double getRescoreQueryWeight() {
+            return rescoreQueryWeight;
+        }
+
+        public LtrRescoreContext setRescoreQueryWeight(double rescoreQueryWeight) {
+            this.rescoreQueryWeight = rescoreQueryWeight;
+            return this;
+        }
+
+        public LtrRescoreMode getScoreMode() {
+            return scoreMode;
+        }
+
+        public LtrRescoreContext setScoreMode(LtrRescoreMode scoreMode) {
+            this.scoreMode = scoreMode;
+            return this;
+        }
+    }
+
+    public enum LtrRescoreMode implements Writeable {
+        Replace {
+            @Override
+            public double combine(double primary, double secondary) {
+                return secondary;
+            }
+
+            @Override
+            public String toString() {
+                return "replace";
+            }
+        },
+        Avg {
+            @Override
+            public double combine(double primary, double secondary) {
+                return (primary + secondary) / 2;
+            }
+
+            @Override
+            public String toString() {
+                return "avg";
+            }
+        },
+        Max {
+            @Override
+            public double combine(double primary, double secondary) {
+                return Math.max(primary, secondary);
+            }
+
+            @Override
+            public String toString() {
+                return "max";
+            }
+        },
+        Min {
+            @Override
+            public double combine(double primary, double secondary) {
+                return Math.min(primary, secondary);
+            }
+
+            @Override
+            public String toString() {
+                return "min";
+            }
+        },
+        Total {
+            @Override
+            public double combine(double primary, double secondary) {
+                return primary + secondary;
+            }
+
+            @Override
+            public String toString() {
+                return "total";
+            }
+        },
+        Multiply {
+            @Override
+            public double combine(double primary, double secondary) {
+                return primary * secondary;
+            }
+
+            @Override
+            public String toString() {
+                return "multiply";
+            }
+        };
+
+        public abstract double combine(double primary, double secondary);
+
+        public static LtrRescoreMode readFromStream(StreamInput in) throws IOException {
+            return in.readEnum(LtrRescoreMode.class);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeEnum(this);
+        }
+
+        public static LtrRescoreMode fromString(String scoreMode) {
+            String lscoreMode = scoreMode.toLowerCase(Locale.ROOT);
+            for (LtrRescoreMode mode : values()) {
+                if (lscoreMode.equals(mode.toString())) {
+                    return mode;
+                }
+            }
+            throw new IllegalArgumentException("illegal score_mode [" + scoreMode + "]");
+        }
+    }
+}

--- a/src/test/java/com/o19s/es/ltr/query/FeatureMatrixCollectorTests.java
+++ b/src/test/java/com/o19s/es/ltr/query/FeatureMatrixCollectorTests.java
@@ -1,0 +1,193 @@
+package com.o19s.es.ltr.query;
+
+import com.o19s.es.ltr.feature.PrebuiltFeature;
+import com.o19s.es.ltr.feature.PrebuiltFeatureSet;
+import com.o19s.es.ltr.feature.PrebuiltLtrModel;
+import com.o19s.es.ltr.ranker.DenseFeatureMatrix;
+import com.o19s.es.ltr.ranker.FeatureMatrix;
+import com.o19s.es.ltr.ranker.linear.LinearRanker;
+import org.apache.commons.codec.Charsets;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.RandomIndexWriter;
+import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.SimpleCollector;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.LuceneTestCase;
+import org.apache.lucene.util.QueryBuilder;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public class FeatureMatrixCollectorTests extends LuceneTestCase {
+
+    private IndexSearcher searcher;
+    private RandomIndexWriter writer;
+    private IndexReader reader;
+    private Directory directory;
+    private List<String> queries;
+
+    @Before
+    public void init() throws IOException {
+        directory = new ByteBuffersDirectory();
+        writer = new RandomIndexWriter(random(), directory);
+        queries = new ArrayList<>();
+        Function<String, Document> docBuilder = (data) -> {
+            Document doc = new Document();
+            doc.add(newTextField("txt", data, Field.Store.NO));
+            if (random().nextInt(4) == 2) {
+                String query = Arrays.stream(data.split(" +", 300))
+                        .filter((s) -> random().nextInt(4) == 2)
+                        .limit(10)
+                        .collect(Collectors.joining(" "));
+                if (!query.isEmpty()) {
+                    queries.add(query);
+                }
+            }
+            return doc;
+        };
+
+        try (InputStream res = this.getClass().getResourceAsStream("LouiseMichel.txt")) {
+            List<Document> docs = new BufferedReader(new InputStreamReader(res, Charsets.UTF_8)).lines().map(docBuilder)
+                    .collect(Collectors.toList());
+            writer.addDocuments(docs);
+        }
+        writer.commit();
+        writer.forceMerge(random().nextInt(10) + 1);
+
+        reader = writer.getReader();
+        searcher = newSearcher(reader);
+
+    }
+
+    public void testEmptyInitial() throws IOException {
+        ScoreDoc[] docs = new ScoreDoc[0];
+        TopDocs tdocs = new TopDocs(0, docs, 0F);
+        RankerQuery query = RankerQuery.build(new PrebuiltLtrModel("name", new LinearRanker(new float[0]),
+                new PrebuiltFeatureSet("set", Collections.emptyList())));
+        FeatureMatrixCollector collector = new FeatureMatrixCollector((RankerQuery.RankerWeight) query.createWeight(searcher, true, 1F),
+                searcher.getIndexReader(), tdocs.scoreDocs, 0);
+        FeatureMatrix matrix = new DenseFeatureMatrix(10,0);
+        assertEquals(0, collector.collect(matrix));
+    }
+
+    public void testRandom() throws IOException {
+        int nFeat = random().nextInt(500) + 100;
+        List<Query> features = new ArrayList<>(nFeat);
+        QueryBuilder qb = new QueryBuilder(new StandardAnalyzer());
+        Supplier<Query> randomQuery = () -> {
+            Query q = qb.createBooleanQuery("txt", this.queries.get(random().nextInt(this.queries.size())));
+            return q != null ? q : new BoostQuery(new ConstantScoreQuery(new MatchAllDocsQuery()), random().nextFloat());
+        };
+        for (int i = 0; i < nFeat; i++) {
+            features.add(randomQuery.get());
+        }
+        List<PrebuiltFeature> pfeatures = new ArrayList<>();
+        for (int i = 0; i < features.size(); i++) {
+            pfeatures.add(new PrebuiltFeature("feature"+i, features.get(i)));
+        }
+        PrebuiltLtrModel model = new PrebuiltLtrModel("test",
+                new LinearRanker(new float[features.size()]), new PrebuiltFeatureSet("set", pfeatures));
+
+        Query mainQuery = randomQuery.get();
+        TopDocs docs = searcher.search(mainQuery, random().nextInt(1000) + 1);
+        int windowSize = Math.min(docs.scoreDocs.length, random().nextInt(500) + 1);
+
+        Arrays.sort(docs.scoreDocs, Comparator.comparingInt(a -> a.doc));
+        RankerQuery.RankerWeight weight = (RankerQuery.RankerWeight) RankerQuery.build(model).createWeight(searcher, true, 1F);
+        FeatureMatrixCollector collector = new FeatureMatrixCollector(weight, searcher.getIndexReader(), docs.scoreDocs, windowSize);
+        Map<Integer, float[]> rawMatrix = new HashMap<>();
+
+
+        int chunkSize = random().nextInt(150) + 1;
+        DenseFeatureMatrix matrix = new DenseFeatureMatrix(chunkSize, nFeat);;
+        for (int i = 0; i < windowSize; ) {
+            matrix.reset();
+            int collected = collector.collect(matrix);
+            for (int j = 0; j < collected; j++) {
+                float[] vector = new float[nFeat];
+                for (int jj = 0; jj < nFeat; jj++) {
+                    vector[jj] = matrix.getFeatureScoreForDoc(j, jj);
+                }
+                if ( docs.scoreDocs[i + j].doc == 197 ) {
+                    //System.out.println("Copying");
+                }
+                rawMatrix.put(docs.scoreDocs[i + j].doc, vector);
+            }
+            i += collected;
+        }
+
+        for (int f = 0; f < nFeat; f++) {
+            Query q = features.get(f);
+            Set<Integer> seen = new HashSet<>();
+            int featureIdx = f;
+            searcher.search(q, new SimpleCollector() {
+                int base;
+                Scorer scorer;
+
+                @Override
+                public void collect(int doc) throws IOException {
+                    int globDoc = doc+base;
+                    if (rawMatrix.containsKey(globDoc)) {
+                        float score = this.scorer.score();
+                        assertEquals(score, rawMatrix.get(globDoc)[featureIdx], Math.ulp(score));
+                    }
+                    seen.add(globDoc);
+                }
+
+                @Override
+                protected void doSetNextReader(LeafReaderContext context) throws IOException {
+                    base = context.docBase;
+                }
+
+                @Override
+                public void setScorer(Scorer scorer) throws IOException {
+                    this.scorer = scorer;
+                }
+
+                @Override
+                public boolean needsScores() {
+                    return true;
+                }
+            });
+            Arrays.stream(docs.scoreDocs).limit(windowSize).filter((sd) -> !seen.contains(sd.doc)).forEach((sd) -> {
+                Assert.assertEquals(0.0F, rawMatrix.get(sd.doc)[featureIdx], Math.ulp(0F));
+            });
+        }
+    }
+
+    @After
+    public void closeStuff() throws IOException {
+        reader.close();
+        writer.close();
+        directory.close();
+    }
+}

--- a/src/test/java/com/o19s/es/ltr/query/LtrQueryTests.java
+++ b/src/test/java/com/o19s/es/ltr/query/LtrQueryTests.java
@@ -158,7 +158,9 @@ public class LtrQueryTests extends LuceneTestCase {
 
 
         indexReaderUnderTest = indexWriterUnderTest.getReader();
-        searcherUnderTest = newSearcher(indexReaderUnderTest);
+        // don't use newSearcher it may use an executor service and do not
+        // support parallel collector
+        searcherUnderTest = new IndexSearcher(indexReaderUnderTest);
         searcherUnderTest.setSimilarity(similarity);
     }
 

--- a/src/test/java/com/o19s/es/ltr/query/LtrRescorerIT.java
+++ b/src/test/java/com/o19s/es/ltr/query/LtrRescorerIT.java
@@ -1,0 +1,146 @@
+package com.o19s.es.ltr.query;
+
+import com.o19s.es.ltr.LtrTestUtils;
+import com.o19s.es.ltr.action.BaseIntegrationTest;
+import com.o19s.es.ltr.feature.store.StoredFeature;
+import com.o19s.es.ltr.feature.store.StoredFeatureSet;
+import com.o19s.es.ltr.feature.store.StoredLtrModel;
+import com.o19s.es.ltr.logging.LoggingSearchExtBuilder;
+import com.o19s.es.ltr.ranker.parser.LinearRankerParser;
+import com.o19s.es.ltr.rescore.LtrRescoreBuilder;
+import com.o19s.es.ltr.rescore.LtrRescorer;
+import org.elasticsearch.action.search.SearchRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.WrapperQueryBuilder;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFirstHit;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.hasId;
+
+public class LtrRescorerIT extends BaseIntegrationTest {
+    private static final String SIMPLE_MODEL = "{" +
+            "\"feature1\": 0.1," +
+            "\"feature2\": 0.2," +
+            "\"feature3\": 0.3" +
+            "}";
+
+
+    public void testSimple() throws ExecutionException, InterruptedException {
+        buildIndex();
+        addModel();
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("query", "paris");
+        SearchRequestBuilder sb = client().prepareSearch("test_index")
+                .setQuery(QueryBuilders.matchQuery("field1", "hello"))
+                .setRescorer(new LtrRescoreBuilder().setQuery(new WrapperQueryBuilder(new StoredLtrQueryBuilder(LtrTestUtils.nullLoader())
+                        .modelName("my_model").params(params).toString()))
+                        .setScoreMode(LtrRescorer.LtrRescoreMode.Replace)
+                        .windowSize(2)
+                        .setQueryNormalizer(new Normalizer.IntervalNormalizer(0,1, false, new Normalizer.MinMax(0, 10)))
+                        .setRescoreQueryNormalizer(new Normalizer.IntervalNormalizer(1,2, false, new Normalizer.Saturation(1, 1)))
+                        .setQueryWeight(1F)
+                        .setRescoreQueryWeight(1F));
+        SearchResponse sr = sb.get();
+        assertEquals(4, sr.getHits().getTotalHits());
+        assertFirstHit(sr, hasId("paris"));
+        for (SearchHit hit : Arrays.copyOfRange(sr.getHits().getHits(), 0, 2)) {
+            assertTrue(hit.getScore() >= 1F);
+            assertTrue(hit.getScore() < 2F);
+        }
+        for (SearchHit hit : Arrays.copyOfRange(sr.getHits().getHits(), 2, 4)) {
+            assertTrue(hit.getScore() < 1F);
+            assertTrue(hit.getScore() >= 0F);
+        }
+    }
+
+    public void testLogging() throws ExecutionException, InterruptedException {
+        buildIndex();
+        addModel();
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("query", "paris");
+        SearchSourceBuilder builder = new SearchSourceBuilder();
+        SearchRequestBuilder sb = client().prepareSearch("test_index")
+                .setSource(builder)
+                .setQuery(QueryBuilders.matchQuery("field1", "hello"))
+                .setRescorer(new LtrRescoreBuilder().setQuery(new WrapperQueryBuilder(new StoredLtrQueryBuilder(LtrTestUtils.nullLoader())
+                        .modelName("my_model").params(params).toString()))
+                        .setScoreMode(LtrRescorer.LtrRescoreMode.Replace)
+                        .windowSize(2)
+                        .setQueryNormalizer(new Normalizer.IntervalNormalizer(0,1, false, new Normalizer.MinMax(0, 10)))
+                        .setRescoreQueryNormalizer(new Normalizer.IntervalNormalizer(1,2, false, new Normalizer.Saturation(1, 1)))
+                        .setQueryWeight(1F)
+                        .setRescoreQueryWeight(1F));
+        builder.ext(Collections.singletonList(new LoggingSearchExtBuilder().addRescoreLogging("test", 0, true)));
+        SearchResponse sr = sb.get();
+        for (SearchHit hit : sr.getHits().getHits()) {
+            Map<String, List<Map<String, Object>>> logs = hit.getFields().get("_ltrlog").getValue();
+            assertTrue(logs.containsKey("test"));
+            List<Map<String, Object>> log = logs.get("test");
+            assertEquals("feature3", log.get(2).get("name"));
+            assertEquals((float) log.get(0).get("value") * (float) log.get(1).get("value"), (float) log.get(2).get("value"), Math.ulp(1F));
+        }
+    }
+
+    public void testProfiling() throws ExecutionException, InterruptedException {
+        buildIndex();
+        addModel();
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("query", "paris");
+        SearchRequestBuilder sb = client().prepareSearch("test_index")
+                .setQuery(QueryBuilders.matchQuery("field1", "hello"))
+                .setRescorer(new LtrRescoreBuilder().setQuery(new WrapperQueryBuilder(new StoredLtrQueryBuilder(LtrTestUtils.nullLoader())
+                        .modelName("my_model").params(params).toString()))
+                        .setScoreMode(LtrRescorer.LtrRescoreMode.Replace)
+                        .windowSize(2)
+                        .setQueryNormalizer(new Normalizer.IntervalNormalizer(0,1, false, new Normalizer.MinMax(0, 10)))
+                        .setRescoreQueryNormalizer(new Normalizer.IntervalNormalizer(1,2, false, new Normalizer.Saturation(1, 1)))
+                        .setQueryWeight(1F)
+                        .setRescoreQueryWeight(1F))
+                .setProfile(true);
+        SearchResponse sr = sb.get();
+        assertFalse(sr.getProfileResults().isEmpty());
+        assertEquals(4, sr.getHits().getTotalHits());
+    }
+
+    public void buildIndex() {
+        Settings settings = Settings.builder().put(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1).build();
+        client().admin().indices().prepareCreate("test_index").setSettings(settings).get();
+        for (String w : Arrays.asList("world", "paris", "madrid", "roma")) {
+            client().prepareIndex("test_index", "test", w)
+                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                    .setSource("field1", "hello " + w, "field2", "bonjour " + w)
+                    .get();
+        }
+    }
+
+    public void addModel() throws ExecutionException, InterruptedException {
+        List<StoredFeature> features = Arrays.asList(
+            new StoredFeature("feature1", Collections.singletonList("query"), "mustache",
+                QueryBuilders.matchQuery("field1", "{{query}}").toString()),
+            new StoredFeature("feature2", Collections.singletonList("query"), "mustache",
+                QueryBuilders.matchQuery("field1", "{{query}}").toString()),
+            new StoredFeature("feature3", Collections.emptyList(), "derived_expression",
+                "feature1 * feature2")
+
+        );
+
+        StoredFeatureSet set = new StoredFeatureSet("set", features);
+        addElement(new StoredLtrModel("my_model", set,
+                new StoredLtrModel.LtrModelDefinition(LinearRankerParser.TYPE, SIMPLE_MODEL, false)));
+    }
+}

--- a/src/test/java/com/o19s/es/ltr/query/NormalizerTests.java
+++ b/src/test/java/com/o19s/es/ltr/query/NormalizerTests.java
@@ -1,0 +1,168 @@
+package com.o19s.es.ltr.query;
+
+import com.o19s.es.ltr.rescore.LtrRescorer;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.util.LuceneTestCase;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.hamcrest.Matcher;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+public class NormalizerTests extends LuceneTestCase {
+    static NamedWriteableRegistry B_REGISTRY = new NamedWriteableRegistry(Normalizer.getNamedWriteables());
+    static NamedXContentRegistry X_REGISTRY = new NamedXContentRegistry(Normalizer.getNamedXContent());
+
+    public void testNoop() {
+        double v = random().nextDouble();
+        assertEquals(v, Normalizer.NOOP.normalize(v), Math.ulp(v));
+        assertSer(Normalizer.NOOP);
+        assertRankOrder(Normalizer.NOOP, -random().nextInt(10), random().nextInt(1000)+1);
+        assertExplanation(Normalizer.NOOP, random().nextDouble());
+        assertSame(Normalizer.NOOP, writeAndReadStream(Normalizer.NOOP));
+        assertSame(Normalizer.NOOP, writeAndReadXContent(Normalizer.NOOP));
+    }
+
+    public void testMinMax() {
+        int min = -random().nextInt(100);
+        int max = random().nextInt(100);
+        Normalizer minMax = new Normalizer.MinMax(min, max);
+        assertEquals(1D, minMax.normalize(max), Math.ulp(1D));
+        assertEquals(0D, minMax.normalize(min), Math.ulp(0D));
+        assertThat(minMax.normalize(random().nextDouble()), allOf(greaterThanOrEqualTo(0D), lessThanOrEqualTo(1D)));
+        assertRankOrder(minMax, min, max);
+        assertExplanation(minMax, random().nextDouble());
+        assertSer(minMax);
+    }
+
+    public void testSaturation() {
+        double k = random().nextDouble();
+        double a = random().nextDouble();
+        Normalizer satu = new Normalizer.Saturation(k, a);
+        assertEquals(0D, satu.normalize(0D), Math.ulp(0D));
+        assertEquals(0.5D, satu.normalize(k), Math.ulp(0.5D));
+        assertThat(satu.normalize(random().nextDouble()), allOf(greaterThanOrEqualTo(0D), lessThanOrEqualTo(1D)));
+        assertThat(satu.normalize(random().nextDouble()*random().nextInt()), allOf(greaterThanOrEqualTo(0D), lessThanOrEqualTo(1D)));
+        assertRankOrder(satu, 0, random().nextInt(1000)+1); // non respected on negative values
+        assertExplanation(satu, random().nextDouble());
+        assertSer(satu);
+    }
+
+    public void testLogistic() {
+        double k = random().nextDouble();
+        double x0 = random().nextDouble();
+        Normalizer logistic = new Normalizer.Logistic(k, x0);
+        assertEquals(0.5D, logistic.normalize(x0), Math.ulp(0.5D));
+        assertThat(logistic.normalize(random().nextDouble()), allOf(greaterThanOrEqualTo(0D), lessThanOrEqualTo(1D)));
+        assertThat(logistic.normalize(random().nextDouble()*random().nextInt()), allOf(greaterThanOrEqualTo(0D), lessThanOrEqualTo(1D)));
+        assertRankOrder(logistic, -random().nextInt(100), random().nextInt(100));
+        assertExplanation(logistic, random().nextDouble());
+        assertSer(logistic);
+    }
+
+    public void testIntervalNormalizer() {
+        double minInput = random().nextDouble();
+        double maxInput = minInput + random().nextDouble() + Math.ulp(minInput);
+        Normalizer.UnitIntervalNormalizer minMax = new Normalizer.MinMax(minInput, maxInput);
+
+        double min = -random().nextInt(100);
+        double max = random().nextInt(100);
+
+        boolean inclusive = random().nextBoolean();
+        Matcher<Double> maxBound = inclusive ? lessThanOrEqualTo(max) : lessThan(max);
+        Normalizer interval = new Normalizer.IntervalNormalizer(min, max, inclusive, minMax);
+        assertEquals(min + ((max-min)/2), interval.normalize(minInput+((maxInput-minInput)/2)), 10*Math.ulp(max));
+        assertThat(interval.normalize(random().nextDouble()), allOf(greaterThanOrEqualTo(min), maxBound));
+        assertThat(interval.normalize(random().nextDouble()*random().nextInt()), allOf(greaterThanOrEqualTo(min), maxBound));
+        assertRankOrder(interval, -random().nextInt(100), random().nextInt(100));
+
+        double source = random().nextDouble();
+        Explanation sourceExp = Explanation.match((float) source, "input");
+        Explanation logisticExp = minMax.explain(source, sourceExp);
+        Explanation intervalExp = interval.explain(source, sourceExp);
+        assertEquals((float) interval.normalize(source), intervalExp.getValue(), Math.ulp((float) interval.normalize(source)));
+        assertThat(Arrays.asList(intervalExp.getDetails()), contains(logisticExp));
+        assertSer(interval);
+    }
+
+    private void assertExplanation(Normalizer n, double input) {
+        assertExplanation(n, input, Explanation.match((float) input, "input"));
+    }
+
+    private void assertExplanation(Normalizer n, double input, Explanation source) {
+        double output = n.normalize(input);
+        Explanation normExp = n.explain(input, source);
+        assertEquals((float) output, normExp.getValue(), Math.ulp((float)output));
+        assertThat(Arrays.asList(normExp.getDetails()), contains(equalTo(source)));
+    }
+
+    private void assertRankOrder(Normalizer n, int from, int to) {
+        assert from < to;
+        ScoreDoc[] docs = IntStream.range(1, random().nextInt(1000))
+                .mapToObj((i) -> new ScoreDoc(i, (float) (to + random().nextDouble() * (to - from))))
+                .sorted(LtrRescorer.SCORE_DOC_COMPARATOR)
+                .toArray(ScoreDoc[]::new);
+        for(int i = 0; i < docs.length; i++) {
+            docs[i].doc = i+1;
+            docs[i].score = (float) n.normalize(docs[i].score);
+        }
+
+        Arrays.sort(docs, LtrRescorer.SCORE_DOC_COMPARATOR);
+        int last = 0;
+        for (ScoreDoc d : docs) {
+            assertEquals(d.doc, last+1);
+            last = d.doc;
+        }
+    }
+
+    private void assertSer(Normalizer norm) {
+        assertEquals(norm, writeAndReadStream(norm));
+        assertEquals(norm, writeAndReadXContent(norm));
+    }
+
+    private Normalizer writeAndReadStream(Normalizer normalizer) {
+        BytesStreamOutput out = new BytesStreamOutput();
+        try {
+            out.writeNamedWriteable(normalizer);
+            StreamInput in = new NamedWriteableAwareStreamInput(out.bytes().streamInput(), B_REGISTRY);
+            return in.readNamedWriteable(Normalizer.class);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Normalizer writeAndReadXContent(Normalizer normalizer) {
+        try {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            XContentBuilder builder = new XContentBuilder(JsonXContent.jsonXContent, bos);
+            normalizer.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            builder.close();
+            XContentParser parser = JsonXContent.jsonXContent.createParser(X_REGISTRY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                    new ByteArrayInputStream(bos.toByteArray()));
+
+            return Normalizer.parseBaseNormalizer(parser, null);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/o19s/es/ltr/ranker/DenseFeatureMatrixTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/DenseFeatureMatrixTests.java
@@ -1,0 +1,43 @@
+package com.o19s.es.ltr.ranker;
+
+import org.apache.lucene.util.LuceneTestCase;
+
+public class DenseFeatureMatrixTests extends LuceneTestCase {
+    public void testGetSetFeatureScoreForDoc() {
+        int nDocs = random().nextInt(20) + 1;
+        int nFeat = random().nextInt(20) + 1;
+        DenseFeatureMatrix matrix = new DenseFeatureMatrix(nDocs, nFeat);
+        float featValue = random().nextFloat();
+
+        int doc = random().nextInt(nDocs);
+        int feat = random().nextInt(nFeat);
+
+        matrix.setFeatureScoreForDoc(doc, feat, featValue);
+        assertEquals(featValue, matrix.getFeatureScoreForDoc(doc, feat), Math.ulp(featValue));
+        assertEquals(featValue, matrix.scores[doc][feat], Math.ulp(featValue));
+    }
+
+    public void testDocSize() {
+        int nDocs = random().nextInt(20) + 1;
+        int nFeat = random().nextInt(20) + 1;
+        DenseFeatureMatrix matrix = new DenseFeatureMatrix(nDocs, nFeat);
+        assertEquals(nDocs, matrix.docSize());
+        assertEquals(nDocs, matrix.scores.length);
+        assertEquals(nFeat, matrix.scores[0].length);
+    }
+
+    public void testReset() {
+        int nDocs = random().nextInt(20) + 1;
+        int nFeat = random().nextInt(20) + 1;
+        DenseFeatureMatrix matrix = new DenseFeatureMatrix(nDocs, nFeat);
+
+        float featValue = random().nextFloat() + 1F;
+        int doc = random().nextInt(nDocs);
+        int feat = random().nextInt(nFeat);
+
+        matrix.setFeatureScoreForDoc(doc, feat, featValue);
+        assertNotEquals(matrix.getFeatureScoreForDoc(doc, feat), 0F);
+        matrix.reset();
+        assertEquals(matrix.getFeatureScoreForDoc(doc, feat), 0F, Math.ulp(0F));
+    }
+}

--- a/src/test/java/com/o19s/es/ltr/rescore/LtrRescoreBuilderTests.java
+++ b/src/test/java/com/o19s/es/ltr/rescore/LtrRescoreBuilderTests.java
@@ -1,0 +1,226 @@
+package com.o19s.es.ltr.rescore;
+
+import com.o19s.es.ltr.LtrQueryParserPlugin;
+import com.o19s.es.ltr.feature.PrebuiltFeatureSet;
+import com.o19s.es.ltr.feature.store.CompiledLtrModel;
+import com.o19s.es.ltr.feature.store.MemStore;
+import com.o19s.es.ltr.query.Normalizer;
+import com.o19s.es.ltr.query.RankerQuery;
+import com.o19s.es.ltr.query.StoredLtrQueryBuilder;
+import com.o19s.es.ltr.ranker.linear.LinearRanker;
+import com.o19s.es.ltr.utils.FeatureStoreLoader;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.WrapperQueryBuilder;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.search.rescore.RescorerBuilder;
+import org.elasticsearch.test.AbstractBuilderTestCase;
+import org.hamcrest.CoreMatchers;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static com.o19s.es.ltr.LtrTestUtils.wrapMemStore;
+
+public class LtrRescoreBuilderTests extends AbstractBuilderTestCase {
+    private static final MemStore STORE = new MemStore("mem");
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return Collections.singleton(TestPlugin.class);
+    }
+
+    @BeforeClass
+    public static void init() {
+        STORE.add(new CompiledLtrModel("foo", new PrebuiltFeatureSet("set", new ArrayList<>()), new LinearRanker(new float[0])));
+    }
+
+    @Override
+    protected NamedXContentRegistry xContentRegistry() {
+        List<NamedXContentRegistry.Entry> entries = new ArrayList<>(Normalizer.getNamedXContent());
+        entries.add(new NamedXContentRegistry.Entry(QueryBuilder.class, new ParseField(StoredLtrQueryBuilder.NAME),
+                (p) -> StoredLtrQueryBuilder.fromXContent(wrapMemStore(STORE), p)));
+        entries.add(new NamedXContentRegistry.Entry(RescorerBuilder.class,
+                LtrRescoreBuilder.NAME, LtrRescoreBuilder::parse));
+        return new NamedXContentRegistry(entries);
+    }
+
+    @Override
+    protected NamedWriteableRegistry namedWriteableRegistry() {
+        List<NamedWriteableRegistry.Entry> entries = new ArrayList<>(Normalizer.getNamedWriteables());
+        entries.add(new NamedWriteableRegistry.Entry(QueryBuilder.class, StoredLtrQueryBuilder.NAME,
+                (sr) -> new StoredLtrQueryBuilder(wrapMemStore(STORE), sr)));
+        entries.add(new NamedWriteableRegistry.Entry(RescorerBuilder.class,
+                LtrRescoreBuilder.NAME.getPreferredName(), LtrRescoreBuilder::new));
+        return new NamedWriteableRegistry(entries);
+    }
+
+    public void testToContext() throws IOException {
+        Supplier<LtrRescoreBuilder> supplier = () -> new LtrRescoreBuilder()
+                .setQuery(new StoredLtrQueryBuilder(wrapMemStore(STORE)).modelName("foo").params(new HashMap<>()))
+                .setQueryNormalizer(Normalizer.NOOP)
+                .setRescoreQueryNormalizer(new Normalizer.Logistic(1D, 2D))
+                .setQueryWeight(0.3D)
+                .setRescoreQueryWeight(0.4D)
+                .setScoreMode(LtrRescorer.LtrRescoreMode.Avg)
+                .setScoringBatchSize(4)
+                .windowSize(25);
+        LtrRescorer.LtrRescoreContext context = (LtrRescorer.LtrRescoreContext) supplier.get().buildContext(createShardContext());
+        assertEquals(Normalizer.NOOP, context.getQueryNormalizer());
+        assertEquals(new Normalizer.Logistic(1D, 2D), context.getRescoreQueryNormalizer());
+        assertEquals(0.3D, context.getQueryWeight(), Math.ulp(0.3D));
+        assertEquals(0.4D, context.getRescoreQueryWeight(), Math.ulp(0.4D));
+        assertEquals(LtrRescorer.LtrRescoreMode.Avg, context.getScoreMode());
+        assertEquals(4, context.getBatchSize());
+        assertEquals(25, context.getWindowSize());
+        assertThat(context.getQuery(), CoreMatchers.instanceOf(RankerQuery.class));
+        assertEquals("linear", ((RankerQuery) context.getQuery()).getRanker().name());
+    }
+
+    public void testSerialization() throws IOException {
+        Supplier<LtrRescoreBuilder> supplier = () -> new LtrRescoreBuilder()
+                .setQuery(new StoredLtrQueryBuilder(wrapMemStore(STORE)).modelName("foo").params(new HashMap<>()))
+                .setQueryNormalizer(Normalizer.NOOP)
+                .setRescoreQueryNormalizer(Normalizer.NOOP)
+                .setQueryWeight(0.3D)
+                .setRescoreQueryWeight(0.4D)
+                .setScoreMode(LtrRescorer.LtrRescoreMode.Avg)
+                .setScoringBatchSize(4)
+                .windowSize(25);
+        BytesStreamOutput output = new BytesStreamOutput();
+        LtrRescoreBuilder original = supplier.get();
+        original.writeTo(output);
+        LtrRescoreBuilder builder = new LtrRescoreBuilder(new NamedWriteableAwareStreamInput(output.bytes().streamInput(),
+                namedWriteableRegistry()));
+        assertEquals(original, builder);
+    }
+
+
+    public void testDefaults() throws IOException {
+        String json = "{" +
+                "\"ltr_rescore\":{" +
+                "   \"ltr_query\": {\"sltr\": {\"model\":\"foo\", \"params\": {}}}" +
+                "}}";
+        LtrRescoreBuilder builder = parse(json);
+        assertEquals(Normalizer.NOOP, builder.getQueryNormalizer());
+        assertEquals(Normalizer.NOOP, builder.getRescoreQueryNormalizer());
+        assertNull(builder.windowSize());
+        assertEquals(1D, builder.getQueryWeight(), Math.ulp(1D));
+        assertEquals(1D, builder.getRescoreQueryWeight(), Math.ulp(1D));
+        assertEquals(-1, builder.getScoringBatchSize());
+        assertEquals(LtrRescorer.LtrRescoreMode.Total, builder.getScoreMode());
+        assertEquals(new StoredLtrQueryBuilder(wrapMemStore(STORE)).modelName("foo").params(new HashMap<>()),
+                builder.getQuery());
+        assertNull(builder.windowSize());
+    }
+
+    public void testParse() throws IOException {
+        String json = "{" +
+                "\"window_size\":2," +
+                "\"ltr_rescore\":{" +
+                "\"query_normalizer\": {\"minmax\":{\"min\": -0.5, \"max\":0.5}}," +
+                "\"rescore_query_normalizer\": {\"saturation\":{\"k\": 2.3, \"a\":0.8}}," +
+                "\"query_weight\": 2.3," +
+                "\"rescore_query_weight\": 2.5," +
+                "\"ltr_query\": {\"sltr\": {\"model\":\"foo\", \"params\": {}}}," +
+                "\"scoring_batch_size\": 23," +
+                "\"score_mode\": \"avg\"" +
+                "}}";
+        LtrRescoreBuilder builder = parse(json);
+        assertEquals(new Normalizer.MinMax(-0.5D, 0.5D), builder.getQueryNormalizer());
+        assertEquals(new Normalizer.Saturation(2.3D, 0.8D), builder.getRescoreQueryNormalizer());
+        assertEquals(2.3D, builder.getQueryWeight(), Math.ulp(2.3D));
+        assertEquals(2.5D, builder.getRescoreQueryWeight(), Math.ulp(2.5D));
+        assertEquals(23, builder.getScoringBatchSize());
+        assertEquals(LtrRescorer.LtrRescoreMode.Avg, builder.getScoreMode());
+        assertEquals(new StoredLtrQueryBuilder(wrapMemStore(STORE)).modelName("foo").params(new HashMap<>()),
+                builder.getQuery());
+        assertEquals(Integer.valueOf(2), builder.windowSize());
+        LtrRescoreBuilder reparsed = parse(Strings.toString(builder));
+        assertEquals(builder, reparsed);
+    }
+
+    public void testEquals() {
+        Supplier<LtrRescoreBuilder> supplier = () -> new LtrRescoreBuilder()
+                .setQuery(new StoredLtrQueryBuilder(wrapMemStore(STORE)).modelName("foo").params(new HashMap<>()))
+                .setQueryNormalizer(Normalizer.NOOP)
+                .setRescoreQueryNormalizer(Normalizer.NOOP)
+                .setQueryWeight(0.3D)
+                .setRescoreQueryWeight(0.4D)
+                .setScoreMode(LtrRescorer.LtrRescoreMode.Avg)
+                .setScoringBatchSize(4)
+                .windowSize(12);
+
+        assertEquals(supplier.get(), supplier.get());
+        assertEquals(supplier.get().hashCode(), supplier.get().hashCode());
+
+        assertNotEquals(supplier.get()
+                .setQuery(new StoredLtrQueryBuilder(wrapMemStore(STORE))
+                        .modelName("moo").params(new HashMap<>())), supplier.get());
+        assertNotEquals(supplier.get().setQueryNormalizer(new Normalizer.Saturation(1D, 2D)), supplier.get());
+        assertNotEquals(supplier.get().setRescoreQueryNormalizer(new Normalizer.Saturation(1D, 2D)), supplier.get());
+        assertNotEquals(supplier.get().setQueryWeight(1D), supplier.get());
+        assertNotEquals(supplier.get().setRescoreQueryWeight(1D), supplier.get());
+        assertNotEquals(supplier.get().setScoreMode(LtrRescorer.LtrRescoreMode.Total), supplier.get());
+        assertNotEquals(supplier.get().setScoringBatchSize(1), supplier.get());
+        assertNotEquals(supplier.get().windowSize(21), supplier.get());
+    }
+
+    public void testRewrite() throws IOException {
+        Supplier<LtrRescoreBuilder> supplier = () -> new LtrRescoreBuilder()
+                .setQuery(new WrapperQueryBuilder(new StoredLtrQueryBuilder(wrapMemStore(STORE))
+                        .modelName("foo").params(new HashMap<>()).toString()))
+                .setQueryNormalizer(new Normalizer.Saturation(randomDouble()+Double.MIN_VALUE, randomDouble()+Double.MIN_VALUE))
+                .setRescoreQueryNormalizer(new Normalizer.Logistic(randomDouble()+Double.MIN_VALUE, randomDouble()))
+                .setQueryWeight(randomDouble())
+                .setRescoreQueryWeight(randomDouble())
+                .setScoreMode(randomFrom(LtrRescorer.LtrRescoreMode.values()))
+                .setScoringBatchSize(randomInt(100))
+                .windowSize(randomInt(100));
+        LtrRescoreBuilder original = supplier.get();
+        LtrRescoreBuilder rewritten = (LtrRescoreBuilder) original.rewrite(createShardContext());
+        assertNotSame(original, rewritten);
+        assertNotSame(original.getQuery(), rewritten.getQuery());
+        assertSame(original.getQueryNormalizer(), rewritten.getQueryNormalizer());
+        assertSame(original.getRescoreQueryNormalizer(), rewritten.getRescoreQueryNormalizer());
+        assertSame(original.getScoreMode(), rewritten.getScoreMode());
+        assertEquals(original.getScoringBatchSize(), rewritten.getScoringBatchSize());
+        assertEquals(original.windowSize(), rewritten.windowSize());
+        assertEquals(original.getQueryWeight(), rewritten.getQueryWeight(), Math.ulp(original.getQueryWeight()));
+        assertEquals(original.getRescoreQueryWeight(), rewritten.getRescoreQueryWeight(), Math.ulp(original.getRescoreQueryWeight()));
+    }
+
+    private LtrRescoreBuilder parse(String json) throws IOException {
+        XContentParser parser = JsonXContent.jsonXContent
+                .createParser(xContentRegistry(), DeprecationHandler.THROW_UNSUPPORTED_OPERATION, json);
+        // Consume the first START_OBJECT...
+        assertSame(parser.nextToken(), XContentParser.Token.START_OBJECT);
+        return (LtrRescoreBuilder) RescorerBuilder.parseFromXContent(parser);
+    }
+
+    public static class TestPlugin extends LtrQueryParserPlugin {
+        public TestPlugin(Settings settings) {
+            super(settings);
+        }
+
+        @Override
+        protected FeatureStoreLoader getFeatureStoreLoader() {
+            return wrapMemStore(STORE);
+        }
+    }
+}

--- a/src/test/java/com/o19s/es/ltr/rescore/LtrRescorerTests.java
+++ b/src/test/java/com/o19s/es/ltr/rescore/LtrRescorerTests.java
@@ -1,0 +1,329 @@
+package com.o19s.es.ltr.rescore;
+
+import com.o19s.es.ltr.feature.PrebuiltFeature;
+import com.o19s.es.ltr.feature.PrebuiltFeatureSet;
+import com.o19s.es.ltr.feature.PrebuiltLtrModel;
+import com.o19s.es.ltr.query.Normalizer;
+import com.o19s.es.ltr.query.RankerQuery;
+import com.o19s.es.ltr.ranker.LtrRanker;
+import com.o19s.es.ltr.ranker.linear.LinearRanker;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FloatDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.MultiReader;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queries.function.FunctionQuery;
+import org.apache.lucene.queries.function.valuesource.FloatFieldSource;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.LuceneTestCase;
+import org.elasticsearch.common.CheckedFunction;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class LtrRescorerTests extends LuceneTestCase {
+    private IndexSearcher searcher;
+    private IndexReader reader;
+    private List<Directory> directories;
+
+    static final int[] SEGMENTS = new int[]{1, 10, 25, 50, 100, 200, 500, 1000};
+
+    @Before
+    public void init() throws IOException {
+        directories = new ArrayList<>(SEGMENTS.length);
+        int docId = 0;
+        for(int s = 0; s < SEGMENTS.length; s++) {
+            Directory directory = new ByteBuffersDirectory();
+            directories.add(directory);
+            IndexWriter writer = new IndexWriter(directory, newIndexWriterConfig());
+            for (; docId < SEGMENTS[s]; docId++) {
+                writer.addDocument(buildDoc(s, docId));
+            }
+            writer.commit();
+            writer.forceMerge(1);
+            writer.close();
+        }
+
+        reader = new MultiReader(directories.stream().map((d) -> {
+            try {
+                return DirectoryReader.open(d);
+            } catch (IOException e) {
+                throw new AssertionError(e);
+            }
+        }).toArray(IndexReader[]::new));
+        searcher = new IndexSearcher(reader);
+    }
+
+    private Query newMainQuery(int[] segmentFilter, int[] docIdFilter) {
+        Query scoreQuery = new FunctionQuery(new FloatFieldSource("main"));
+
+        BooleanQuery.Builder seg = new BooleanQuery.Builder();
+        Arrays.stream(segmentFilter)
+                .mapToObj((s) -> new Term("segment", String.valueOf(s)))
+                .map(TermQuery::new)
+                .map((q) -> new BooleanClause(q, BooleanClause.Occur.SHOULD))
+                .forEach(seg::add);
+
+        BooleanQuery.Builder ids = new BooleanQuery.Builder();
+        Arrays.stream(docIdFilter)
+                .mapToObj((s) -> new Term("docId", String.valueOf(s)))
+                .map(TermQuery::new)
+                .map((q) -> new BooleanClause(q, BooleanClause.Occur.SHOULD))
+                .forEach(ids::add);
+
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        builder.add(new BooleanClause(scoreQuery, BooleanClause.Occur.MUST));
+        if (segmentFilter.length > 0) builder.add(new BooleanClause(seg.build(), BooleanClause.Occur.FILTER));
+        if (docIdFilter.length > 0) builder.add(new BooleanClause(ids.build(), BooleanClause.Occur.FILTER));
+
+        return builder.build();
+    }
+
+    private PrebuiltFeatureSet newFeatureSet() {
+        return new PrebuiltFeatureSet("set", Arrays.asList(
+                new PrebuiltFeature("feature1", new FunctionQuery(new FloatFieldSource("feat1"))),
+                new PrebuiltFeature("feature2", new FunctionQuery(new FloatFieldSource("feat2")))
+        ));
+    }
+
+    private RankerQuery newRankerQuery() {
+        return RankerQuery.build(new PrebuiltLtrModel("mymodel", newRanker(), newFeatureSet()));
+    }
+
+    private LtrRanker newRanker() {
+        return new LinearRanker(new float[]{0.5F, 0.5F});
+    }
+
+    private Document buildDoc(int seg, int docId) {
+        Document doc = new Document();
+        doc.add(newTextField("docId", String.valueOf(docId), Field.Store.YES));
+        doc.add(newTextField("segment", String.valueOf(seg), Field.Store.YES));
+        doc.add(new FloatDocValuesField("feat1", random().nextFloat()));
+        doc.add(new FloatDocValuesField("feat2", random().nextFloat()));
+        doc.add(new FloatDocValuesField("main", random().nextFloat()));
+        return doc;
+    }
+
+    private LtrRescorer.LtrRescoreContext prepareLtrContext(int wSize) {
+        LtrRescorer.LtrRescoreContext context = new LtrRescorer.LtrRescoreContext(wSize, new LtrRescorer());
+        context.setQueryNormalizer(new Normalizer.IntervalNormalizer(0D, 1D, false, new Normalizer.Saturation(0.5D, 1D)));
+        context.setRescoreQueryNormalizer(new Normalizer.IntervalNormalizer(1D, 2D, false, new Normalizer.Saturation(0.5D, 1D)));
+        context.setScoreMode(LtrRescorer.LtrRescoreMode.Replace);
+        context.setQuery(newRankerQuery());
+        return context;
+    }
+
+    public void testNoDocs() throws IOException {
+        LtrRescorer.LtrRescoreContext ctx = prepareLtrContext(1);
+        TopDocs docs = searcher.search(newMainQuery(new int[0], new int[]{-1}), 10);
+        assertEquals(0, docs.totalHits);
+        TopDocs rescored = ctx.rescorer().rescore(docs, searcher, ctx);
+        assertEquals(0, docs.totalHits);
+        assertEquals(0, docs.scoreDocs.length);
+    }
+
+    public void testClassicSingleDocSingleSeg() throws IOException {
+        LtrRescorer.LtrRescoreContext ctx = prepareLtrContext(1);
+        TopDocs docs = searcher.search(newMainQuery(new int[0], new int[]{0}), 10);
+        assertEquals(1, docs.totalHits);
+        TopDocs rescored = ctx.rescorer().rescore(docs, searcher, ctx);
+        assertEquals(rescored.scoreDocs[0].score, ctx.normalizedRescoreQueryScore(modelScore(0)), Math.ulp(rescored.scoreDocs[0].score));
+    }
+
+    public void testTwoDocsSameWindow() throws IOException {
+        LtrRescorer.LtrRescoreContext ctx = prepareLtrContext(2);
+        TopDocs docs = searcher.search(newMainQuery(new int[0], new int[]{0,1}), 10);
+        assertEquals(2, docs.totalHits);
+        TopDocs rescored = ((LtrRescorer) ctx.rescorer()).bulkRescore(docs, searcher, ctx);
+        for (ScoreDoc sd : rescored.scoreDocs) {
+            assertEquals(sd.score, ctx.normalizedRescoreQueryScore(modelScore(sd)), Math.ulp(sd.score));
+        }
+
+        rescored = ((LtrRescorer) ctx.rescorer()).classicRescore(docs, searcher, ctx);
+        for (ScoreDoc sd : rescored.scoreDocs) {
+            assertEquals(sd.score, ctx.normalizedRescoreQueryScore(modelScore(sd)), Math.ulp(sd.score));
+        }
+    }
+
+    public void testTwoDocsThreeInWindow() throws IOException {
+        LtrRescorer.LtrRescoreContext ctx = prepareLtrContext(2);
+        List<CheckedFunction<TopDocs, TopDocs, IOException>> recorers = new ArrayList<>();
+        recorers.add((docs) -> ((LtrRescorer) ctx.rescorer()).bulkRescore(docs, searcher, ctx));
+        recorers.add((docs) -> ((LtrRescorer) ctx.rescorer()).classicRescore(docs, searcher, ctx));
+        for (CheckedFunction<TopDocs, TopDocs, IOException> sup : recorers) {
+            TopDocs docs = searcher.search(newMainQuery(new int[0], new int[]{0,1,2}), 10);
+            assertEquals(3, docs.totalHits);
+            TopDocs rescored = sup.apply(docs);
+            assertEquals(3, rescored.totalHits);
+
+            for (ScoreDoc sd : Arrays.copyOf(rescored.scoreDocs, 2)) {
+                assertEquals(sd.score, ctx.normalizedRescoreQueryScore(modelScore(sd)), Math.ulp(sd.score));
+            }
+
+            for (ScoreDoc sd : Arrays.copyOfRange(rescored.scoreDocs, 2, 3)) {
+                assertEquals(sd.score, ctx.normalizedQueryScore(mainQueryScore(sd)), Math.ulp(sd.score));
+            }
+        }
+    }
+
+    public void testLargeWindowCustomBulkSize() throws IOException {
+        LtrRescorer.LtrRescoreContext ctx = prepareLtrContext(700);
+        ctx.setBatchSize(20);
+        List<CheckedFunction<TopDocs, TopDocs, IOException>> recorers = new ArrayList<>();
+        recorers.add((docs) -> ((LtrRescorer) ctx.rescorer()).bulkRescore(docs, searcher, ctx));
+        recorers.add((docs) -> ((LtrRescorer) ctx.rescorer()).classicRescore(docs, searcher, ctx));
+        Query mainQuery = newMainQuery(new int[0], new int[0]);
+        for (CheckedFunction<TopDocs, TopDocs, IOException> sup : recorers) {
+            TopDocs docs = searcher.search(mainQuery, 1000);
+            assertEquals(1000, docs.totalHits);
+            TopDocs rescored = sup.apply(docs);
+            assertEquals(1000, rescored.totalHits);
+
+            for (ScoreDoc sd : Arrays.copyOf(rescored.scoreDocs, 700)) {
+                assertEquals(sd.score, ctx.normalizedRescoreQueryScore(modelScore(sd)), Math.ulp(sd.score));
+                Explanation explanation = ctx.rescorer().explain(sd.doc, searcher, ctx, searcher.explain(mainQuery, sd.doc));
+                assertEquals(sd.score, explanation.getValue(), Math.ulp(sd.score));
+                assertEquals(ctx.getScoreMode().toString(), explanation.getDescription());
+                assertEquals("product of:", explanation.getDetails()[0].getDescription());
+                assertEquals("primaryWeight", explanation.getDetails()[0].getDetails()[1].getDescription());
+                assertEquals(ctx.getQueryWeight(), explanation.getDetails()[0].getDetails()[1].getValue(),
+                        Math.ulp(ctx.getQueryWeight()));
+                assertEquals("product of:", explanation.getDetails()[1].getDescription());
+                assertEquals("secondaryWeight", explanation.getDetails()[1].getDetails()[1].getDescription());
+                assertEquals(ctx.getQueryWeight(), explanation.getDetails()[1].getDetails()[1].getValue(),
+                        Math.ulp(ctx.getRescoreQueryWeight()));
+            }
+
+            for (ScoreDoc sd : Arrays.copyOfRange(rescored.scoreDocs, 700, rescored.scoreDocs.length)) {
+                assertEquals(sd.score, ctx.normalizedQueryScore(mainQueryScore(sd)), Math.ulp(sd.score));
+            }
+        }
+    }
+
+    public void testNormalization() {
+        float qscore = random().nextFloat();
+        float rscore = random().nextFloat();
+        float qweight = random().nextFloat();
+        float rweight = random().nextFloat();
+        LtrRescorer.LtrRescoreContext ctx = new LtrRescorer.LtrRescoreContext(1, new LtrRescorer());
+        ctx.setQueryNormalizer(Normalizer.NOOP);
+        ctx.setRescoreQueryNormalizer(Normalizer.NOOP);
+        ctx.setQueryWeight(qweight);
+        ctx.setRescoreQueryWeight(rweight);
+        assertEquals(qscore*qweight, ctx.normalizedQueryScore(qscore), Math.ulp(qscore));
+        assertEquals(rscore*rweight, ctx.normalizedRescoreQueryScore(rscore), Math.ulp(rscore));
+
+        Normalizer qnorm = new Normalizer.Logistic(random().nextFloat(), random().nextFloat());
+        Normalizer rnorm = new Normalizer.Logistic(random().nextFloat(), random().nextFloat());
+        ctx.setQueryNormalizer(qnorm);
+        ctx.setRescoreQueryNormalizer(rnorm);
+        assertEquals(qnorm.normalize(qscore)*qweight, ctx.normalizedQueryScore(qscore), Math.ulp(qscore));
+        assertEquals(rnorm.normalize(rscore)*rweight, ctx.normalizedRescoreQueryScore(rscore), Math.ulp(rscore));
+    }
+
+    public void testCombine() {
+        float qscore = random().nextFloat();
+        float rscore = random().nextFloat();
+        double qweight = random().nextDouble();
+        double rweight = random().nextDouble();
+        LtrRescorer.LtrRescoreContext ctx = new LtrRescorer.LtrRescoreContext(1, new LtrRescorer());
+        ctx.setQueryWeight(qweight);
+        ctx.setRescoreQueryWeight(rweight);
+        Normalizer qnorm = new Normalizer.Logistic(random().nextDouble(), random().nextDouble());
+        Normalizer rnorm = new Normalizer.Logistic(random().nextDouble(), random().nextDouble());
+        ctx.setQueryNormalizer(qnorm);
+        ctx.setRescoreQueryNormalizer(rnorm);
+        for (LtrRescorer.LtrRescoreMode mode : LtrRescorer.LtrRescoreMode.values()) {
+            ctx.setScoreMode(mode);
+            float expected = (float) mode.combine(ctx.normalizedQueryScore(qscore), ctx.normalizedRescoreQueryScore(rscore));
+            assertEquals(expected, ((LtrRescorer)ctx.rescorer()).combine(qscore, rscore, ctx), Math.ulp(expected));
+        }
+    }
+
+    public void testWindowLarger() throws IOException {
+        LtrRescorer.LtrRescoreContext ctx = prepareLtrContext(4);
+        List<CheckedFunction<TopDocs, TopDocs, IOException>> recorers = new ArrayList<>();
+        recorers.add((docs) -> ((LtrRescorer) ctx.rescorer()).bulkRescore(docs, searcher, ctx));
+        recorers.add((docs) -> ((LtrRescorer) ctx.rescorer()).classicRescore(docs, searcher, ctx));
+        for (CheckedFunction<TopDocs, TopDocs, IOException> sup : recorers) {
+            TopDocs docs = searcher.search(newMainQuery(new int[0], new int[]{0,1,2}), 10);
+            assertEquals(3, docs.totalHits);
+            TopDocs rescored = sup.apply(docs);
+            assertEquals(3, rescored.totalHits);
+
+            for (ScoreDoc sd : rescored.scoreDocs) {
+                assertEquals(sd.score, ctx.normalizedRescoreQueryScore(modelScore(sd)), Math.ulp(sd.score));
+            }
+        }
+    }
+
+    public float modelScore(ScoreDoc doc) throws IOException {
+        return modelScore(Integer.parseInt(searcher.doc(doc.doc).get("docId")));
+    }
+
+    public float modelScore(int doc) throws IOException {
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        builder.add(new BooleanClause(new TermQuery(new Term("docId", String.valueOf(doc))), BooleanClause.Occur.FILTER));
+        builder.add(new BooleanClause(newRankerQuery(), BooleanClause.Occur.MUST));
+        return searcher.search(builder.build(), 1).scoreDocs[0].score;
+    }
+
+    public float mainQueryScore(ScoreDoc sd) throws IOException {
+        int doc = Integer.parseInt(searcher.doc(sd.doc).get("docId"));
+        return searcher.search(newMainQuery(new int[0], new int[]{doc}), 1).scoreDocs[0].score;
+    }
+
+    public void testScoreMode() {
+        double q = random().nextDouble();
+        double r = random().nextDouble();
+        assertEquals((q+r)/2, LtrRescorer.LtrRescoreMode.Avg.combine(q, r), Math.ulp(q));
+        assertEquals(q > r ? q : r, LtrRescorer.LtrRescoreMode.Max.combine(q, r), Math.ulp(q));
+        assertEquals(q > r ? r : q, LtrRescorer.LtrRescoreMode.Min.combine(q, r), Math.ulp(q));
+        assertEquals(q*r, LtrRescorer.LtrRescoreMode.Multiply.combine(q, r), Math.ulp(q));
+        assertEquals(q+r, LtrRescorer.LtrRescoreMode.Total.combine(q, r), Math.ulp(q));
+        assertEquals(r, LtrRescorer.LtrRescoreMode.Replace.combine(q, r), Math.ulp(q));
+
+        assertEquals( "avg", LtrRescorer.LtrRescoreMode.Avg.toString());
+        assertEquals( LtrRescorer.LtrRescoreMode.Avg, LtrRescorer.LtrRescoreMode.fromString("avg"));
+
+        assertEquals( "min", LtrRescorer.LtrRescoreMode.Min.toString());
+        assertEquals( LtrRescorer.LtrRescoreMode.Min, LtrRescorer.LtrRescoreMode.fromString("min"));
+
+        assertEquals( "max", LtrRescorer.LtrRescoreMode.Max.toString());
+        assertEquals( LtrRescorer.LtrRescoreMode.Max, LtrRescorer.LtrRescoreMode.fromString("max"));
+
+        assertEquals( "total", LtrRescorer.LtrRescoreMode.Total.toString());
+        assertEquals( LtrRescorer.LtrRescoreMode.Total, LtrRescorer.LtrRescoreMode.fromString("total"));
+
+        assertEquals( "multiply", LtrRescorer.LtrRescoreMode.Multiply.toString());
+        assertEquals( LtrRescorer.LtrRescoreMode.Multiply, LtrRescorer.LtrRescoreMode.fromString("multiply"));
+
+        assertEquals( "replace", LtrRescorer.LtrRescoreMode.Replace.toString());
+        assertEquals( LtrRescorer.LtrRescoreMode.Replace, LtrRescorer.LtrRescoreMode.fromString("replace"));
+    }
+
+
+    @After
+    public void closeStuff() throws IOException {
+        reader.close();
+        for (Directory directory : directories) {
+            directory.close();
+        }
+    }
+}

--- a/src/test/resources/com/o19s/es/ltr/query/LouiseMichel.txt
+++ b/src/test/resources/com/o19s/es/ltr/query/LouiseMichel.txt
@@ -1,0 +1,589 @@
+Louise Michel (French pronunciation: [lwiz miʃɛl] (listen); 29 May 1830– 9 January 1905) was a teacher and important figure in the Paris Commune.
+Following her penal transportation she embraced anarchism.
+When returning to France she emerged as important French anarchist and went on speaking tours across Europe.
+The journalist Brian Doherty has called her the "French grande dame of anarchy." Louise Michel was born on 29 May 1830 as the illegitimate daughter of a serving-maid, Marianne Michel.
+She was raised by her grandparents, Charlotte and Charles-Étienne Demahis, in north-eastern France.
+She spent her childhood in the Château à Vroncourt la Cote and was provided with a libertarian education.
+When her grandparents died, she completed the teacher training and worked in villages.
+In 1865 Michel opened a school in Paris which became known for its modern and progressive methods.
+Michel corresponded with the prominent French romanticist Victor Hugo and began publishing poetry.
+She became involved in the radical politics of Paris and among her associates were Auguste Blanqui, Jules Vallès and Théophile Ferré.
+In 1869 the feminist group Société pour la Revendication du Droits Civils de la Femme (Society for the Demand of Civil Rights for Women) was announced by André Léo.
+Among the members of the group were Michel, Paule Minck, Eliska Vincent, Élie Reclus and his wife Néomie, Mme Jules Simon, Caroline de Barrau and Maria Deraismes.
+Because of the broad range of opinions, the group decided to focus on the subject of improving girls' education.
+Commonly known as the Revendication des Droits de la Femme (Demand for Women's Rights), the group had close ties with the Société Cooperative des Ouriers et Ouvrierés (Cooperative Society of Men and Women Workers).
+The July 1869 manifesto of the Revendication des Droits de la Femme was thus signed by the wives of militant cooperative members.
+The manifesto was also supported by Sophie Doctrinal, signing with Citroyenne Poirier, who would later become a close associate of Michel in the Paris Commune.
+In January 1870 Michel and Léo attended the funeral of Victor Noir.
+Michel expressed disappointment that the death of Noir had not been used to overthrow the Empire.
+At the start of the Siege of Paris, in November 1870, Léo in a lecture declared "It is not a question of our practicing politics, we are human, that is all.
+During the siege, Michel became part of the National Guard.
+When the Paris Commune was declared she was elected head of the Montmartre Women's Vigilance Committee.
+Michel thus occupied a leading role in the revolutionary government of the Paris Commune.
+In April 1871 she threw herself into the armed struggle against the French government.
+She closely aligned with Ferré and Raoul Rigault, two of the most violent members of the Paris Commune.
+However, Ferré and Rigault persuaded her to not carry out her plan to assassinate Adolphe Thiers, the chief executive of the French national government.
+Instead Michel fought with the 61st Battalion of Montmartre and organised ambulance stations.
+In her memoirs she later wrote "oh, I'm a savage all right, I like the smell of gunpowder, grapeshot flying through the air, but above all, I'm devoted to the Revolution." Women played a key role in the Paris Commune.
+They not only chaired committees, but also built barricades and participated in the armed violence.
+Michel ideologically justified a militant revolution, proclaiming: "I descended the Butte, my rifle under my coat, shouting: Treason! .
+.
+.
+Our deaths would free Paris".
+Michel would be among the few militants who survived the Paris Commune and reflected: "It is true, perhaps, that women like rebellions.
+We are no better than men in respect to power, but power has not yet corrupted us." In her memoirs Michel confessed that the realities of the revolutionary government strengthened her resolve to end the discrimination against women.
+On the attitude of her male comrades, she wrote "How many times, during the Commune, did I go, with a national guardsman or a soldier, to some place where they hardly expected to have to contend with a woman?".
+She challenged her comrades to "play a part in the struggle for women's rights, after men and women have won the rights of all humanity?" In December 1871, Michel was brought before the 6th council of war, charged with offences including trying to overthrow the government, encouraging citizens to arm themselves, and herself using weapons and wearing a military uniform.
+Defiantly, she dared the judges to sentence her to death.
+Michel was sentenced to penal transportation.
+It is estimated that 20,000 defenders of the Paris Commune had been summarily executed.
+Michel was among the 10,000 supporters of the Commune that were sentenced to deportation.
+After twenty months in prison Michel was loaded onto the ship Virginie on 8 August 1873, to be deported to New Caledonia, where she arrived four months later.
+Whilst on board, she became acquainted with Henri Rochefort, a famous polemicist, who became her friend until her death.
+She also met Nathalie Lemel, another figure active in the commune.
+It was this latter contact that led Louise to become an anarchist.
+She remained in New Caledonia for seven years and befriended the local kanak people.
+She taught them French and took their side in the 1878 Kanak revolt.
+The following year, she received authorisation to become a teacher in Nouméa for the children of the deported—among them many Algerian Kabyles ("Kabyles du Pacifique") from Cheikh Mokrani's rebellion (1871).
+In 1880, amnesty was granted to those who had participated in Paris Commune.
+Michel returned to Paris, her revolutionary passion undiminished.
+She gave a public address on the 21st of November, 1880 and continued her revolutionary activity in Europe, attending the anarchist congress in London in 1881, where she led demonstrations and spoke to huge crowds.
+While in London, she also attended meetings at the Russell Square home of the Pankhursts where she made a particular impression on a young Sylvia Pankhurst.
+In France she successfully campaigned, together with Charles Malato and Victor Henri Rochefort, for an amnesty to be also granted to Algerian deportees in New Caledonia.
+In March 1883 Michel and Émile Pouget led a demonstration by unemployed workers.
+In a subsequent riot three bakeries were pillaged.
+Reputably, Michel led this demonstration with a black flag, which has since become a symbol of anarchism.
+Michel was tried for her actions in the riot and used the court to publicly defend her anarchist principles.
+She was sentenced to six years of solitary confinement for inciting the looting.
+Michel was defiant, for her the future of the human race was at stake, "one without exploiters and without exploited." Michel was released in 1886, at the same time as Kropotkin and other prominent anarchists.
+In 1890 she was arrested again.
+After an attempt to commit her to a mental asylum she moved to London.
+Michel lived in London for five years.
+She opened a school and moved among the European anarchist exile circles.
+Her International Anarchist School for the children of political refugees opened in 1890 on Fitzroy Square.
+The teachings were influenced by the libertarian educationist Paul Robin and put into practice Mikhail Bakunin's educational principles, emphasising scientific and rational methods.
+Michel's aim was to develop among the children the principles of humanity and justice.
+Among the teachers were exiled anarchists, such as Victorine Rouchy-Brocher, but also pioneering educationalists such as Rachel McMillan and Agnes Henry.
+In 1892 the school was closed, when explosives were found in the basement.
+(see Walsall Anarchists) Michel contributed to many English speaking publications.
+Some of Michel's writings were translated into English by the poet Louisa Sarah Bevington.
+Michel's published works were also translated into Spanish by the anarchist Soledad Gustavo.
+The Spanish anarchist and workers rights activist Teresa Claramunt became known as the "Spanish Louise Michel".
+By that time Michel had become a legendary speaker, touring Europe repeatedly to speak in front of thousands of people.
+In 1895 Sebastien Faure and Michel founded the French anarchist periodical Le Monde Libertaire (Libertarian World).
+In the same year Michel met Emma Goldman at an anarchist conference in London, at which both were speaking.
+The young Goldman was hugely impressed by Michel, considering her to have a "social instinct developed to the extreme".
+In reference to the harsh conditions of Michel's life, Goldman asserted "Anarchists insist that conditions must be radically wrong if human instincts develop to such extremes at the expense of each other." Michel returned to France in 1895, and was not active in the agitation provoked by the Dreyfus affair in 1898.
+In a 1896 article, entitled "Why I am an Anarchist", Michel argued that "Anarchy will not begin the eternal miseries anew.
+Humanity in its fight of despair will cling to it in order to emerge from the abyss." In 1904 Michel went on a conference tour through French Algeria.
+Michel was scheduled to meet the anti-colonial campaigner Isabelle Eberhardt, but Eberhardt died shortly before Michel arrived in Algeria.
+Michel died in Marseille of pneumonia on the 10 January 1905.
+Her funeral in Paris was attended by more than 100,000 people.
+Michel's grave is in the cemetery of Levallois-Perret, in one of the suburbs of Paris.
+The grave is maintained by the community.
+This cemetery is also the last resting place of her friend and fellow communard Théophile Ferré.
+Michel once joked, "We love to have agents provocateurs in the party, because they always propose the most revolutionary motions." Michel's political ideas evolved throughout her life.
+Once a teacher with progressive ideals, her activism saw her embrace revolutionary socialism, but the experience of a failed revolution turned her into a radical anarchist.
+Her political theory progressed from peaceful reform to violent revolution, because she came to believe that contemporary society had to be completely destroyed for a new egalitarian era to emerge.
+The many years she spent in prison and in the French penal colony New Caledonia were central to her change of heart.
+Michel's political theory had its roots in the aftermath of the French Revolution, which was followed by a series of monarchies.
+Two prevailing theories emerged.
+There were those who believed that the Reign of Terror that followed the revolution was proof that democracy was flawed.
+The ruling elites of the post-revolutionary monarchies believed that for the economy to succeed, it was necessary to control the labour market, wages and working conditions.
+Thus few labour reforms were enacted.
+On the other hand, French romanticism reinterpreted the French Revolution as the tangible spirit of the French people.
+In the 1840s romanticism in France became politicised, because it became accepted that individual happiness could not be achieved in isolation.
+Romantics became preoccupied with social progress and reform.
+Writers embarked on a quest to realistically portray the lives of the working poor.
+Victor Hugo and Emile Zola emerged as key writers and political activists.
+Shortly after Michel was born in 1830 a short-lived revolt resulted in a constitutional monarchy being established.
+Louis Philippe I encouraged commercial interests and the enrichment of the upper-middle class through colonization and penal transportation, but at the same time practiced laissez-faire when the socio-economic plight of the working class was concerned.
+Michel first made a name for herself by publicly defending the poor and working class women.
+In the 1860s she was noted as political activist for vehemently opposing the policies of Emperor Napoleon III.
+Napoleon III curtailed the civil and political rights of the French citizens and enacted a series of economic policies that disadvantaged waged labourers.
+Michel signed a number of her published political writings with Enjolras, the name of the revolutionary in Hugo's Les Misérables.
+In 1865 she provocatively wrote a new Marseillaise, the call to arms during the French Revolution.
+In her Marseillaise, Michel called for a mass uprising of the people to defend the republic, arguing that martyrdom was preferable to defeat.
+This sentiment would be echoed in her subsequently published poetry, plays and novels.
+But unlike her contemporaries, Michel repeatedly lamented the violent treatment of children and the gory abuse of animals.
+Michel's political characters fought for justice, while the children and animals in her fictional works were too weak, sick and starved to resist or survive.
+When Emperor Napoleon III and his army were captured by the Prussians in 1870, the French Third Republic was proclaimed in Paris.
+But the provisional government continued the war against the Prussians and a four-month siege of Paris resulted in bleak hardship.
+Parisians starved and froze to death.
+Some managed to save themselves by eating cats, dogs and rats.
+The government surrendered, but Michel and other Parisians had taken up arms and organised themselves as a National Guard.
+When the Paris Commune was proclaimed Michel was named head of the Women's Vigilance Committee and played a key role in initiating economic and social reforms.
+Michel pushed through the separation of church and state, initiated educational reforms and codified rights for workers.
+When the Paris Commune was crushed in May 1871 Michel witnessed unrelenting bloodshed and the summary execution of thousands.
+When Michel was trialled, she demanded to be killed by firing squad and proclaimed "If you let me live, I shall never stop crying for vengeance, and I shall avenge my brothers by denouncing the murderers".
+The military court refused to make her a martyr.
+Michel was imprisoned for two years before she was deported.
+While in prison she demanded to be treated just like the other prisoners and rejected efforts by her friends Hugo and Georges Clemenceau to have her sentence commuted.
+She considered preferential treatment a dishonour.
+On the four months journey to New Caledonia Michel re-examined her believe in revolutionary socialism.
+She embraced anarchism and for the rest of her life rejected all forms of government.
+In 1896 she wrote about her change of mind: "I considered the things, events and people of the past.
+I thought about the behaviour of our friends of the Commune: they were scrupulous, so afraid of exceeding their authority, that they never threw their full energies into anything but the loss of their own lives.
+I quickly came to the conclusion that good men in power are incompetent, just as bad men are evil, and therefore it is impossible for liberty ever to be associated with any form of power whatsoever." Michel was introduced to the tenets of anarchism by a fellow prisoner Nathalie Lemel, with whom she was imprisoned in a large cage for several months.
+Michel became known for her selfless generosity and devotion to others.
+In the penal colony she lived in voluntary poverty, giving away her books, clothes and any money she acquired.
+Michel took up teaching again.
+She spent time with the indigenous Canaques, teaching them French so that they could challenge the French authorities.
+Michel supported them in their revolt against the colonial power.
+In 1875 the monarchist dominated National Assembly passed a constitution that established a republican government with an upper and lower house of parliament.
+This democracy was a compromise, as the National Assembly could not agree on who should be king.
+The brutal crackdown on the Paris Commune would influence French politics for years to come.
+Conservatives and moderates in the new government avoided anything that could trigger another uprising.
+This fear delayed the amnesty for those who had participated in the Paris Commune for years.
+Eventually an amnesty was granted and when Michel returned to Paris in November 1880 she was greeted by Henri Rochefort, Clemenceau, a crowd of 20,000 and the police.
+But she had no patience for Clemenceau's "illustration..
+that he should wait for parliamentarianism to bring progress".
+Michel soon began her career as a public speaker and found an audience all over Europe.
+In 1882 she staged her first anarchist play Nadine.
+As a public speaker Michel became skilled in advancing pragmatic arguments to attack capitalism and the authoritarian state, while holding open the possibility of a positive outcome.
+When she was put on trial in 1883 for leading a group of unemployed workers, she attacked shortcomings in the implementation of the French republican constitution, saying: "They keep talking to us about liberty: There is the liberty of speech with five years of prison at the end.
+In England, the meeting would have taken place; in France, they have not even made a legal admonition in order to let the crowd retreat, which would have left without resistance.
+People are dying from hunger, and they do not even have the right to say that they are dying from hunger." Michel frequently spoke on women's rights from an anarchist perspective.
+She not only advocated education for women, but also that marriage should be free and that men should hold no property rights over women.
+In the late 1880s she authored several works in which she revisited the themes of her earlier works, but also portrayed the demise of the old order and its replacement with a society of equals.
+Michel embarked on a journey towards a new political philosophy.
+The revolutionary characters in The Strike expected to die, but instead they gave life to a new age and Michel discussed the rights and responsibilities of the people who lived in the aftermath of a revolution.
+She staged her plays in accordance with Jean Grave's theory on audience participation.
+The audience was integrated through a political and artistic program of lectures, poems and songs.
+The audience was encouraged to react and re-enact the conflicts of the plays.
+In her plays The Human Microbes (1886), Crimes of the Times (1888) and The Bordello (1890) an agricultural utopia emerges from a devastated Europe.
+Michel's political ideals owed much to the French romanticism of Hugo and are described at length in The New Era, Last Thought, Memories of Caledonia (1887): "It is indeed time that this old world die since no one is safe any longer...
+We can no longer live like our Stone Age ancestors, nor as in the past century, since the series of inventions, since the discoveries of science have brought the certainty that all production will increase a hundredfold when these innovations will be used for the general good, instead of letting just a handful of vultures help themselves in order to starve the rest." Michel lived at a time when hunger was widespread among the working poor of Europe.
+She believed that technological progress would replace physical labour with machines.
+In combination with anarchist politics, she argued, this could lead to equal distribution of wealth.
+In 1890 she reasoned that "the attractive power of progress will demonstrate itself all the more as daily bread will be assured, and a few hours of work which will have become attractive and voluntary will be enough to produce more than what is necessary for consumption." Like other anarchists of her time she did not believe that history was a record of constant improvement, but that it could become so.
+However, constant economic growth was not an improvement in itself.
+Michel argued instead, that progress came through intellectual development, social evolution and liberation.
+Her vision of the future was shaped by a supreme confidence.
+"Science will bring forth harvests in the desert; the energy of the tempests and whirlpools will carve paths through the mountains.
+Undersea boats will discover lost continents.
+Electricity will carry ships of the air above the icy poles.
+The ideas of Liberty, Equality and Justice will finally burst into flame.
+Each individual will live his integral part within humankind as a whole.
+Progress being infinite, transformations will be perpetual." Michel did not only bemoan the poverty in which people across Europe lived, she also advanced a detailed critique of 19th century capitalism.
+She lamented the deficiencies of the capitalist banking system and predicted that the concentration of capital would result in the ruin of small enterprises and the middle class.
+In her memoirs Michael said that the Anarchist Manifesto of Lyon (1883) precisely expressed her views.
+The Manifesto had been signed by Peter Kropotkin, Émile Gautier, Joseph Bernard, Pierre Martin [fr] and Toussaint Bordat.
+Kropotkin, like Jules Guesde and Émile Pouget would become close friends and associates of her.
+Instead of focusing on violent revolution, as she had done in her earlier works, Michel in her later works emphasised the spontaneous uprising of the people.
+She came to reject terror as a means of bringing about a new era.
+She wrote "Tyrannicide is practical only when tyranny has a single head, or at most a small number of heads.
+When it is a hydra, only the Revolution can kill it".
+She took the view that it is best, if the leaders of such a revolution would perish, so that the people would not be burdened with surviving general staff.
+Michel thought that "power is evil" and in her mind history was the story of free people being enslaved.
+In a 1882 speech she said "All revolutions have been insufficient because they have been political".
+Organisation was, in her mind, not necessary.
+Because the poor and exploited would rise up and through their sheer numbers would force the old order to shrivel up.
+Michel was among the most influential French political figures in the second half of the 19th century.
+She was also one of the most powerful women political theorists of her day.
+Her publications on social justice for the poor and the cause of the working classes were read in France and all over Europe.
+When she died in 1905 she was mourned by thousands.
+Memorial services were held all over France and in London.
+Although her writings are today forgotten, her name is remembered in the names of French streets, schools and parks.
+Michel became a national heroine in France and was revered as the "great citizen".
+A cultish image of Michel emerged.
+Shortly before her death, when returning from her exile in London, Michel had been dubbed "the angel of petrol", "the virago of the rabble" and "queen of the scum" by the conservative French press.
+In turn, Charles Ferdinand Gambon compared her to Jeanne d'Arc in reference to her role in the Paris Commune.
+This imagery was further propagandized by Edmond Lepelletier in 1911.
+The image of Michel as vierge rouge (red virgin) came to be used by conservative and liberal historians alike when recounting the story of the Paris Commune.
+Michel is regarded as a founder of anarcho-feminism.
+Despite the anti-authoritarian rhetoric, early anarchist thinkers maintained cultural orthodoxy when it came to the division of domestic labour and their personal relationships with women.
+The founder of French anarchism, Pierre-Joseph Proudhon was notorious for his sexist views.
+Michel, Teresa Claramunt, Lucy Parsons, Voltairine de Cleyre and Emma Goldman became prominent figures in the late 19th century pan-European and American anarchist movement.
+With the formation of the First International anarchist sections in various European countries under the leadership of Mikhail Bakunin, anarchism got noted for not only encouraging female participation in the political movement, but also for espousing to the ideal of female emancipation.
+Michel was rediscovered by French feminists in the 1970s through the works of Xavière Gauthier.
+Academic interest in Michel's life and political writings was prompted in the 1970s by Édith Thomas's comprehensively researched biography.
+Louise Michel station on the Paris Metro, located in Levallois-Perret, is named for her.
+À travers la vie, poetry, Paris, 1894.
+Le Bâtard impérial, by L.
+Michel and J.
+Winter, Paris, 1883.
+Le claque-dents, Paris.
+La Commune, Paris, 1898.
+Contes et légendes, Paris, 1884.
+Les Crimes de l'époque, nouvelles inédites, Paris, 1888.
+Défense de Louise Michel, Bordeaux, 1883.
+L'Ère nouvelle, pensée dernière, souvenirs de Calédonie (prisoners' songs), Paris, 1887 La Fille du peuple par L.
+Michel et A.
+Grippa, Paris (1883) Fleurs et ronces, poetry, Paris, Le Gars Yvon, légende bretonne, Paris, 1882.
+Lectures encyclopédiques par cycles attractifs, Paris, 1888.
+Ligue internationale des femmes révolutionnaires, Appel à une réunion.
+Signed "Louise Michel", Paris, 1882.
+Le livre du jour de l'an : historiettes, contes et légendes pour les enfants, Paris, 1872.
+Lueurs dans l'ombre.
+Plus d'idiots, plus de fous.
+L'âme intelligente.
+L'idée libre.
+L'esprit lucide de la terre à Dieu...
+Paris, 1861.
+Manifeste et proclamation de Louise Michel aux citoyennes de Paris, Signed "Louise Maboul", Paris, 1883.
+Mémoires, Paris, 1886, t.
+1.
+Les Méprises, grand roman de mœurs parisiennes, par Louise Michel et Jean Guêtré, Paris, 1882.
+Les Microbes humains, Paris, 1886.
+(translated by Brian Stableford as The Human Microbes, ISBN 978-1-61227-116-3) La Misère by Louise Michel, 2nd part, and Jean Guêtré 1st part, Paris, 1882.
+Le Monde nouveau, Paris, 1888 (translated by Brian Stableford as The New World, ISBN 978-1-61227-117-0) Louise Michel à Victor Hugo, lettres de prison et du bagne (1871–1879) "Nous reviendrons foule sans ombre", lettres de prison et du bagne (1871–1879), adaptation de Virginie Berling, coll.
+Scènes intempestives à Grignan, ed.
+TriArtis, Paris 2016, ISBN 978-2-916724-78-2.
+Posthumous Vol.
+I.
+Avant la Commune.
+Preface by Laurent Tailhade, Alfortville, 1905.
+Les Paysans by Louise Michel et Émile Gautier, Paris, Incomplete.
+Prise de possession, Saint-Denis, 1890.
+Le Rêve (in a work by Constant Martin), Paris, 1898.
+Légendes et chants de gestes canaques.
+Présentation.
+Gérard Oberlé.
+Edition 1900.
+1988.
+Je vous écris de ma nuit, correspondance générale, 1850-1904, edition established by Xavière Gauthier, Édition de Paris-Max Chaleil, 1999.
+Michel was often discussed in the French press during her lifetime, as well as the English-language press in Britain and the United States.
+These are a sample of press caricatures of Michel: Anarchism in France Louise Michel Battalions – Spanish Civil War Doherty, Brian (2010-12-17) The First War on Terror, Reason Cornelia Ilie & Giuliana Garzone, eds.
+(2017).
+Argumentation across Communities of Practice: Multi-disciplinary perspectives.
+John Benjamins Publishing Company.
+p.
+105.
+ISBN 9789027265173.CS1 maint: Uses editors parameter (link) Christine Fauré (2003).
+Political and Historical Encyclopedia of Women.
+Routledge.
+p.
+359.
+ISBN 9781135456917.
+McMillan 2002, p.
+130.
+Gay L.
+Gullickson (1996).
+Unruly Women of Paris: Images of the Commune.
+Cornell University Press.
+p.
+149.
+ISBN 9780801483189.
+Gay L.
+Gullickson (1996).
+Unruly Women of Paris: Images of the Commune.
+Cornell University Press.
+p.
+150.
+ISBN 9780801483189.
+Adam Gopnik (December 22, 2014).
+"The Fires of Paris: Why do people still fight about the Paris Commune?".
+The New Yorker.
+Raylene L.
+Ramsay (2003).
+French Women in Politics: Writing Power, Paternal Legitimization, and Maternal Legacies.
+Berghahn Books.
+p.
+31.
+ISBN 9781571810816.
+Gay L.
+Gullickson (1996).
+Unruly Women of Paris: Images of the Commune.
+Cornell University Press.
+p.
+152.
+ISBN 9780801483189.
+Louise Michel, a French anarchist women who fought in the Paris commune Archived 2009-07-10 at the Wayback Machine.
+Jackson J.
+Spielvogel (2013).
+Western Civilization: A Brief History, Volume II: Since 1500.
+Cengage Learning.
+p.
+530.
+ISBN 9781133607939.
+"Deportation to New Caledonia – Introduction".
+www.iisg.nl.
+Retrieved 2016-08-21.
+https://books.google.com/books?id=Vd-OAQAAQBAJ&pg=PA2 Francis McCollum Feeley, ed.
+(2010).
+Comparative Patriarchy and American Institutions: The Language, Culture, and Politics of Liberalism.
+Cambridge Scholars Publishing.
+p.
+145.
+ISBN 9781443820141.
+Cornelia Ilie & Giuliana Garzone, eds.
+(2017).
+Argumentation across Communities of Practice: Multi-disciplinary perspectives.
+John Benjamins Publishing Company.
+p.
+106.
+ISBN 9789027265173.CS1 maint: Uses editors parameter (link) Mary McAuliffe (2011).
+Dawn of the Belle Epoque: The Paris of Monet, Zola, Bernhardt, Eiffel, Debussy, Clemenceau, and Their Friends.
+Rowman & Littlefield Publishers.
+p.
+143.
+ISBN 9781442209299.
+https://books.google.com/books?id=gLIjAQAAMAAJ&pg=RA6-PA12 https://books.google.com/books?id=JN1EAQAAMAAJ&pg=PA390 Constance Bantman (2013).
+The French Anarchists in London, 1880-1914: Exile and Transnationalism in the First Globalisation.
+Oxford University Press.
+pp.
+90–91.
+ISBN 9781781386583.
+Constance Bantman (2013).
+The French Anarchists in London, 1880-1914: Exile and Transnationalism in the First Globalisation.
+Oxford University Press.
+p.
+89.
+ISBN 9781781386583.
+Emma Goldman (1996).
+Vision on Fire: Emma Goldman on the Spanish Revolution.
+AK Press.
+p.
+37.
+ISBN 9781904859574.
+Pietro Di Paola (2013).
+The Knights Errant of Anarchy: London and the Italian Anarchist Diaspora (1880-1917).
+Oxford University Press.
+p.
+22.
+ISBN 9781846319693.
+Chaz Bufe (2014).
+Provocations: Don't Call Them Libertarians, AA Lies, and Other Incitements.
+See Sharp Press.
+p.
+45.
+ISBN 9781937276744.
+Francis McCollum Feeley, ed.
+(2010).
+Comparative Patriarchy and American Institutions: The Language, Culture, and Politics of Liberalism.
+Cambridge Scholars Publishing.
+p.
+175.
+ISBN 9781443820141.
+https://books.google.com/books?id=3uQMzo8yyD8C&pg=PA200 Cornelia Ilie & Giuliana Garzone, eds.
+(2017).
+Argumentation across Communities of Practice: Multi-disciplinary perspectives.
+John Benjamins Publishing Company.
+pp.
+114–115.
+ISBN 9789027265173.CS1 maint: Uses editors parameter (link) Francis McCollum Feeley, ed.
+(2010).
+Comparative Patriarchy and American Institutions: The Language, Culture, and Politics of Liberalism.
+Cambridge Scholars Publishing.
+p.
+150.
+ISBN 9781443820141.
+Philip Edward Phillips, ed.
+(2014).
+Prison Narratives from Boethius to Zana.
+Springer.
+p.
+119.
+ISBN 9781137428684.
+Philip Edward Phillips, ed.
+(2014).
+Prison Narratives from Boethius to Zana.
+Springer.
+p.
+120.
+ISBN 9781137428684.
+Philip Edward Phillips, ed.
+(2014).
+Prison Narratives from Boethius to Zana.
+Springer.
+p.
+123.
+ISBN 9781137428684.
+Philip Edward Phillips, ed.
+(2014).
+Prison Narratives from Boethius to Zana.
+Springer.
+p.
+128.
+ISBN 9781137428684.
+Philip Edward Phillips, ed.
+(2014).
+Prison Narratives from Boethius to Zana.
+Springer.
+p.
+124.
+ISBN 9781137428684.
+Philip Edward Phillips, ed.
+(2014).
+Prison Narratives from Boethius to Zana.
+Springer.
+p.
+125.
+ISBN 9781137428684.
+Cecilia Beach (2005).
+Staging Politics and Gender: French Women’s Drama, 1880–1923.
+Springer.
+p.
+32.
+ISBN 9781403978745.
+Jackson J.
+Spielvogel (2013).
+Western Civilization: A Brief History, Volume II: Since 1500.
+Cengage Learning.
+p.
+530.
+ISBN 9781133607939.
+Mary McAuliffe (2011).
+Dawn of the Belle Epoque: The Paris of Monet, Zola, Bernhardt, Eiffel, Debussy, Clemenceau, and Their Friends.
+Rowman & Littlefield Publishers.
+p.
+146.
+ISBN 9781442209299.
+Cecilia Beach (2005).
+Staging Politics and Gender: French Women’s Drama, 1880–1923.
+Springer.
+p.
+32.
+ISBN 9781403978745.
+Mary McAuliffe (2011).
+Dawn of the Belle Epoque: The Paris of Monet, Zola, Bernhardt, Eiffel, Debussy, Clemenceau, and Their Friends.
+Rowman & Littlefield Publishers.
+p.
+147.
+ISBN 9781442209299.
+Cecilia Beach (2005).
+Staging Politics and Gender: French Women’s Drama, 1880–1923.
+Springer.
+p.
+32.
+ISBN 9781403978745.
+Cecilia Beach (2005).
+Staging Politics and Gender: French Women’s Drama, 1880–1923.
+Springer.
+p.
+33.
+ISBN 9781403978745.
+Cornelia Ilie & Giuliana Garzone, eds.
+(2017).
+Argumentation across Communities of Practice: Multi-disciplinary perspectives.
+John Benjamins Publishing Company.
+p.
+113.
+ISBN 9789027265173.CS1 maint: Uses editors parameter (link) Cornelia Ilie & Giuliana Garzone, eds.
+(2017).
+Argumentation across Communities of Practice: Multi-disciplinary perspectives.
+John Benjamins Publishing Company.
+p.
+114.
+ISBN 9789027265173.CS1 maint: Uses editors parameter (link) Cheris Kramarae & Dale Spender (2004).
+Routledge International Encyclopedia of Women: Global Women's Issues and Knowledge.
+Routledge.
+p.
+47.
+ISBN 9781135963156.CS1 maint: Uses authors parameter (link) Cecilia Beach (2005).
+Staging Politics and Gender: French Women’s Drama, 1880–1923.
+Springer.
+p.
+33.
+ISBN 9781403978745.
+Cornelia Ilie & Giuliana Garzone, eds.
+(2017).
+Argumentation across Communities of Practice: Multi-disciplinary perspectives.
+John Benjamins Publishing Company.
+p.
+115.
+ISBN 9789027265173.CS1 maint: Uses editors parameter (link) Peter Ryley (2013).
+Making Another World Possible: Anarchism, Anti-capitalism and Ecology in Late 19th and Early 20th Century Britain.
+Bloomsbury Publishing USA.
+p.
+3.
+ISBN 9781441153777.
+Cornelia Ilie & Giuliana Garzone, eds.
+(2017).
+Argumentation across Communities of Practice: Multi-disciplinary perspectives.
+John Benjamins Publishing Company.
+p.
+121.
+ISBN 9789027265173.CS1 maint: Uses editors parameter (link) Louise Michel (1981).
+Red Virgin: Memoirs Of Louise Michel.
+University of Alabama Press.
+pp.
+ix.
+ISBN 9780817300630.
+"Manifesto of the Anarchists: Lyon 1883".
+Robert Graham's Anarchism Weblog.
+Louise Michel (1981).
+Red Virgin: Memoirs Of Louise Michel.
+University of Alabama Press.
+pp.
+xi.
+ISBN 9780817300630.
+Louise Michel (1981).
+Red Virgin: Memoirs Of Louise Michel.
+University of Alabama Press.
+pp.
+x.
+ISBN 9780817300630.
+Francis McCollum Feeley, ed.
+(2010).
+Comparative Patriarchy and American Institutions: The Language, Culture, and Politics of Liberalism.
+Cambridge Scholars Publishing.
+p.
+156.
+ISBN 9781443820141.
+Gay L.
+Gullickson (1996).
+Unruly Women of Paris: Images of the Commune.
+Cornell University Press.
+p.
+154.
+ISBN 9780801483189.
+Emma Goldman (1996).
+Vision on Fire: Emma Goldman on the Spanish Revolution.
+AK Press.
+p.
+251.
+ISBN 9781904859574.
+Martine Hennard Dutheil de la Rochère (2013).
+Reading, Translating, Rewriting: Angela Carter's Translational Poetics.
+Wayne State University Press.
+p.
+303.
+ISBN 9780814336359.
+ This article incorporates text from a publication now in the public domain: Chisholm, Hugh, ed.
+(1911).
+"Michel, Clémence Louise".
+Encyclopædia Britannica (11th ed.).
+Cambridge University Press.
+Beach, Cecilia (2005).
+"Staging the Revolution: Louise Michel".
+Staging Politics and Gender: French Women’s Drama, 1880–1923.
+New York: Palgrave Macmillan.
+pp.
+26–48.
+ISBN 978-1-349-52917-9.
+OCLC 951524695.
+Mason, Paul (4 May 2007).
+Live working or die fighting: how the working class went global.
+Harvill Secker.
+ISBN 978-0-436-20615-3.
+Retrieved 15 October 2010.
+Thomas, Edith (1980).
+Louise Michel.
+Black Rose Books.
+Retrieved 15 October 2010.
+Thomas, Edith (2007).
+The Women Incendiaries.
+Translated by Atkinson, James; Atkinson, Starr.
+Haymarket Books.
+ISBN 978-1-931859-46-2.
+Maclellan, Nic (2004).
+Louise Michel.
+Ocean Press.
+ISBN 978-1-876175-76-4.
+Michel, Louise (January 1981).
+The Red Virgin: memoirs of Louise Michel.
+University of Alabama Press.
+ISBN 978-0-8173-0062-3.
+Retrieved 15 October 2010.
+The World That Never Was: A True Story of Dreamers, Schemers, Anarchists and Secret Police by Alex Butterworth (Pantheon Books, 2010) Bantman, Constance.
+"Louise Michel's London years: A political reassessment (1890–1905)." Women's History Review 26.6 (2017): 994-1012.
+Works by Louise Michel at LibriVox (public domain audiobooks) Works by Louise Michel at Open Library McMillan, James F.
+(2002-01-08).
+France and Women, 1789–1914: Gender, Society and Politics.
+Routledge.
+ISBN 978-1-134-58957-9.
+Retrieved 2014-10-23.
+Louise Michel archive at the Anarchy Archives Les Louise Mitchels - French D.I.Y.
+jazz-punk band influenced by the life and work of Louise Michel Paul Foot on Louise Michel Louise Michel at Find a Grave Archive of Louise Michel Papers at the International Institute of Social History

--- a/src/test/resources/rest-api-spec/test/fstore/90_ltr_rescore.yml
+++ b/src/test/resources/rest-api-spec/test/fstore/90_ltr_rescore.yml
@@ -1,0 +1,84 @@
+---
+setup:
+  - do:
+      ltr.create_store: {}
+
+  - do:
+      ltr.create_model:
+        name: my_model
+        body:
+          model:
+            feature_set:
+              name: my_set
+              features:
+                - name: feature1
+                  params: query_string
+                  template:
+                    match:
+                      field1: "{{query_string}}"
+                - name: feature2
+                  params: query_string
+                  template:
+                    match:
+                      field2: "{{query_string}}"
+            model:
+              type: model/linear
+              definition:
+                feature1: 1.2
+                feature2: 0.2
+
+  - do:
+      indices.create:
+          index:  test
+
+  - do:
+      index:
+        index:  test
+        type:   test
+        id:     1
+        body:   { "field1": "hello montpellier", "field2": "bonjour montpellier" }
+
+  - do:
+      index:
+        index:  test
+        type:   test
+        id:     2
+        body:   { "field1": "hello paris", "field2": "bonjour paris"  }
+
+  - do:
+      index:
+        index:  test
+        type:   test
+        id:     3
+        body:   { "field1": "hello toulouse", "field2": "bonjour toulouse" }
+
+  - do:
+      index:
+        index:  test
+        type:   test
+        id:     4
+        body:   { "field1": "hello marseille", "field2": "bonjour marseille" }
+
+  - do:
+      indices.refresh: {}
+
+---
+"use ltr rescore":
+  - do:
+      search:
+        index: test
+        body:
+          query: { match: { "field1": "hello" } }
+          rescore:
+            - window_size: 2
+              ltr_rescore:
+                 ltr_query: { sltr: { params: {"query_string": "montpellier"}, model: "my_model"  } }
+                 query_normalizer: { interval: { from: 0, to: 1, normalizer: { minmax: { min: 0, max: 10 } } } }
+                 rescore_query_normalizer: { interval: { from: 1, to: 2, normalizer: { saturation: { k: 0.5, a: 1 } } } }
+                 score_mode: "replace"
+                 query_weight: 1
+                 rescore_query_weight: 1
+                 scoring_batch_size: 10
+
+  - length:   { hits.hits: 4  }
+  - match:   { hits.hits.0._id: "1" }


### PR DESCRIPTION
Add a custom rescore component "ltr_rescore". Meant to enable bulk scoring
provided that the ranker implements BulkLtrRanker but also to provide a
more convenient way to "replace" the query score.

Bulk scoring works by collecting feature values on per feature/segment basis
into a FeatureMatrix. Batch size can be controlled by the ranker but also
overridden by the user providing "scoring_batch_size".

This rescore component provides the same functionalaties as the upstream
rescore but with a new score mode: replace.
Replacing query scores require normalizing the scores into coherent ranges
accross shards. Added the following normalizers:

- minmax: normalizes to [0,1] given a min, max range
- saturation: normalizes to [0,1] given k and a (only works for positive values)
- logistic: normalizes to [0,1] given k and x0
- interval: normalizes to a custom range

Strategy here is e.g. to force query scores to be in the [0,1] ranges and
rescored docs in the [1,2] range.