### PR TITLE
Upgrade elasticsearch to 6.5.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,12 +6,12 @@ buildscript {
   }
 
   dependencies {
-    classpath "org.elasticsearch.gradle:build-tools:6.5.2"
+    classpath "org.elasticsearch.gradle:build-tools:6.5.4"
   }
 }
 
 group = 'com.o19s'
-version = '1.1.0-es6.5.2'
+version = '1.1.0-es6.5.4'
 
 apply plugin: 'java'
 apply plugin: 'idea'
@@ -51,10 +51,10 @@ dependencies {
   compile 'org.ow2.asm:asm:5.0.4'
   compile 'org.ow2.asm:asm-commons:5.0.4'
   compile 'org.ow2.asm:asm-tree:5.0.4'
-  compile 'org.elasticsearch:elasticsearch:6.5.2'
+  compile 'org.elasticsearch:elasticsearch:6.5.4'
   compile 'com.o19s:RankyMcRankFace:0.1.1'
   compile "com.github.spullara.mustache.java:compiler:0.9.3"
-  testCompile 'org.elasticsearch.test:framework:6.5.2'
+  testCompile 'org.elasticsearch.test:framework:6.5.4'
 }
 
 dependencyLicenses {


### PR DESCRIPTION
Similar commit to what it was done [here](https://github.com/o19s/elasticsearch-learning-to-rank/commit/3075d1cd015c2b5e9f4c24c069bca75674687879) for upgrading to 6.5.2

We are starting to use the plugin and planning to install it during the next upgrade of our production clusters.

Thank you for developing this plugin :)