### PR TITLE
Update ES version to 6.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ repositories {
 }
 
 dependencies {
-  compile "org.apache.lucene:lucene-expressions:7.5.0"
+  compile "org.apache.lucene:lucene-expressions:7.6.0"
   compile 'org.antlr:antlr4-runtime:4.5.1-1'
   compile 'org.ow2.asm:asm:5.0.4'
   compile 'org.ow2.asm:asm-commons:5.0.4'

--- a/build.gradle
+++ b/build.gradle
@@ -6,12 +6,12 @@ buildscript {
   }
 
   dependencies {
-    classpath "org.elasticsearch.gradle:build-tools:6.5.4"
+    classpath "org.elasticsearch.gradle:build-tools:6.6.0"
   }
 }
 
 group = 'com.o19s'
-version = '1.1.0-es6.5.4'
+version = '1.1.0-es6.6.0'
 
 apply plugin: 'java'
 apply plugin: 'idea'
@@ -51,10 +51,10 @@ dependencies {
   compile 'org.ow2.asm:asm:5.0.4'
   compile 'org.ow2.asm:asm-commons:5.0.4'
   compile 'org.ow2.asm:asm-tree:5.0.4'
-  compile 'org.elasticsearch:elasticsearch:6.5.4'
+  compile 'org.elasticsearch:elasticsearch:6.6.0'
   compile 'com.o19s:RankyMcRankFace:0.1.1'
   compile "com.github.spullara.mustache.java:compiler:0.9.3"
-  testCompile 'org.elasticsearch.test:framework:6.5.4'
+  testCompile 'org.elasticsearch.test:framework:6.6.0'
 }
 
 dependencyLicenses {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2-bin.zip

--- a/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
+++ b/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
@@ -146,7 +146,7 @@ public class LtrQueryParserPlugin extends Plugin implements SearchPlugin, Script
 
     @Override
     public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
-        return new RankLibScriptEngine(settings, parserFactory);
+        return new RankLibScriptEngine(parserFactory);
     }
 
     @Override

--- a/src/main/java/com/o19s/es/ltr/ranker/ranklib/RankLibScriptEngine.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/ranklib/RankLibScriptEngine.java
@@ -19,7 +19,6 @@ package com.o19s.es.ltr.ranker.ranklib;
 import com.o19s.es.ltr.ranker.LtrRanker;
 import com.o19s.es.ltr.ranker.parser.LtrRankerParserFactory;
 import org.elasticsearch.common.component.AbstractComponent;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptEngine;
 
@@ -45,7 +44,7 @@ public class RankLibScriptEngine extends AbstractComponent implements ScriptEngi
             new ScriptContext<>("ranklib", RankLibModelContainer.Factory.class);
     private final LtrRankerParserFactory factory;
 
-    public RankLibScriptEngine(Settings settings, LtrRankerParserFactory factory) {
+    public RankLibScriptEngine(LtrRankerParserFactory factory) {
         super();
         this.factory = Objects.requireNonNull(factory);
     }

--- a/src/main/java/com/o19s/es/ltr/ranker/ranklib/RankLibScriptEngine.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/ranklib/RankLibScriptEngine.java
@@ -46,7 +46,7 @@ public class RankLibScriptEngine extends AbstractComponent implements ScriptEngi
     private final LtrRankerParserFactory factory;
 
     public RankLibScriptEngine(Settings settings, LtrRankerParserFactory factory) {
-        super(settings);
+        super();
         this.factory = Objects.requireNonNull(factory);
     }
 

--- a/src/test/java/com/o19s/es/ltr/query/ValidatingLtrQueryBuilderTests.java
+++ b/src/test/java/com/o19s/es/ltr/query/ValidatingLtrQueryBuilderTests.java
@@ -108,7 +108,13 @@ public class ValidatingLtrQueryBuilderTests extends AbstractQueryTestCase<Valida
         return false;
     }
 
-    protected boolean supportsBoostAndQueryName() {
+    @Override
+    protected boolean supportsBoost() {
+        return false;
+    }
+
+    @Override
+    protected boolean supportsQueryName() {
         return false;
     }
 

--- a/src/test/java/com/o19s/es/ltr/query/ValidatingLtrQueryBuilderTests.java
+++ b/src/test/java/com/o19s/es/ltr/query/ValidatingLtrQueryBuilderTests.java
@@ -108,7 +108,6 @@ public class ValidatingLtrQueryBuilderTests extends AbstractQueryTestCase<Valida
         return false;
     }
 
-    @Override
     protected boolean supportsBoostAndQueryName() {
         return false;
     }


### PR DESCRIPTION
This is a naive attempt at upgrading the plugin to ES version 6.6.0

The changes are minimal, but I'm curious what opinions are on the removal of an `@Override`, and the removal of settings in `super`. The latter seems especially suspicious of being wrong.

Is there anything obvious going wrong here?

It appears, too, that after running the tests I see:

```
> Task :compileTestJava
Note: /home/ubuntu/diffeo/images/elasticsearch/elasticsearch-learning-to-rank/src/test/java/com/o19s/es/explore/ExplorerQueryTests.java uses or overrides a deprecated API.
```

and occassionally

```
> Task :integTestRunner
==> Test Info: seed=3D974279FB1A303; jvm=1; suites=7

Exception thrown by subscriber method onHeartbeat(com.carrotsearch.ant.tasks.junit4.events.aggregated.HeartBeatEvent) on subscriber com.carrotsearch.gradle.junit4.TestProgressLogger@5d88a632 when dispatching event: com.carrots
earch.ant.tasks.junit4.events.aggregated.HeartBeatEvent@30bc1695
java.lang.NullPointerException: Cannot get property 'className' on null object
        at org.codehaus.groovy.runtime.NullObject.getProperty(NullObject.java:60)
        at org.codehaus.groovy.runtime.InvokerHelper.getProperty(InvokerHelper.java:190)
        at org.codehaus.groovy.runtime.callsite.NullCallSite.getProperty(NullCallSite.java:46)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callGetProperty(AbstractCallSite.java:299)
        at com.carrotsearch.gradle.junit4.TestProgressLogger.onHeartbeat(TestProgressLogger.groovy:161)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at com.carrotsearch.ant.tasks.junit4.dependencies.com.google.common.eventbus.Subscriber.invokeSubscriberMethod(Subscriber.java:87)
        at com.carrotsearch.ant.tasks.junit4.dependencies.com.google.common.eventbus.Subscriber$SynchronizedSubscriber.invokeSubscriberMethod(Subscriber.java:144)
        at com.carrotsearch.ant.tasks.junit4.dependencies.com.google.common.eventbus.Subscriber$1.run(Subscriber.java:72)
        at com.carrotsearch.ant.tasks.junit4.dependencies.com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:398)
        at com.carrotsearch.ant.tasks.junit4.dependencies.com.google.common.eventbus.Subscriber.dispatchEvent(Subscriber.java:67)
        at com.carrotsearch.ant.tasks.junit4.dependencies.com.google.common.eventbus.Dispatcher$PerThreadQueuedDispatcher.dispatch(Dispatcher.java:108)
        at com.carrotsearch.ant.tasks.junit4.dependencies.com.google.common.eventbus.EventBus.post(EventBus.java:212)
        at com.carrotsearch.ant.tasks.junit4.events.aggregated.AggregatingListener.slowHeartBeat(AggregatingListener.java:76)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at com.carrotsearch.ant.tasks.junit4.dependencies.com.google.common.eventbus.Subscriber.invokeSubscriberMethod(Subscriber.java:87)
        at com.carrotsearch.ant.tasks.junit4.dependencies.com.google.common.eventbus.Subscriber$SynchronizedSubscriber.invokeSubscriberMethod(Subscriber.java:144)
        at com.carrotsearch.ant.tasks.junit4.dependencies.com.google.common.eventbus.Subscriber$1.run(Subscriber.java:72)
        at com.carrotsearch.ant.tasks.junit4.dependencies.com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:398)
        at com.carrotsearch.ant.tasks.junit4.dependencies.com.google.common.eventbus.Subscriber.dispatchEvent(Subscriber.java:67)
        at com.carrotsearch.ant.tasks.junit4.dependencies.com.google.common.eventbus.Dispatcher$PerThreadQueuedDispatcher.dispatch(Dispatcher.java:108)
        at com.carrotsearch.ant.tasks.junit4.dependencies.com.google.common.eventbus.EventBus.post(EventBus.java:212)
        at com.carrotsearch.ant.tasks.junit4.LocalSlaveStreamHandler$3.run(LocalSlaveStreamHandler.java:149)
HEARTBEAT J0 PID((?)): 2019-02-13T14:24:11, stalled for 10.0s at: <unknown>
```