### PR TITLE
Remove declareStandardFields method from AbstractQueryBuilderUtils

### DIFF
--- a/src/main/java/com/o19s/es/explore/ExplorerQueryBuilder.java
+++ b/src/main/java/com/o19s/es/explore/ExplorerQueryBuilder.java
@@ -15,7 +15,6 @@
 
 package com.o19s.es.explore;
 
-import com.o19s.es.ltr.utils.AbstractQueryBuilderUtils;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
@@ -47,7 +46,7 @@ public class ExplorerQueryBuilder extends AbstractQueryBuilder<ExplorerQueryBuil
                 QUERY_NAME
         );
         PARSER.declareString(ExplorerQueryBuilder::statsType, TYPE_NAME);
-        AbstractQueryBuilderUtils.declareStandardFields(PARSER);
+        declareStandardFields(PARSER);
     }
 
     private QueryBuilder query;

--- a/src/main/java/com/o19s/es/ltr/query/LtrQueryBuilder.java
+++ b/src/main/java/com/o19s/es/ltr/query/LtrQueryBuilder.java
@@ -53,7 +53,7 @@ public class LtrQueryBuilder extends AbstractQueryBuilder<LtrQueryBuilder> {
 
     static {
         PARSER = new ObjectParser<>(NAME, LtrQueryBuilder::new);
-        AbstractQueryBuilderUtils.declareStandardFields(PARSER);
+        declareStandardFields(PARSER);
         PARSER.declareObjectArray(
                 LtrQueryBuilder::features,
                 (parser, context) -> parseInnerQueryBuilder(parser),

--- a/src/main/java/com/o19s/es/ltr/query/StoredLtrQueryBuilder.java
+++ b/src/main/java/com/o19s/es/ltr/query/StoredLtrQueryBuilder.java
@@ -22,7 +22,6 @@ import com.o19s.es.ltr.feature.store.CompiledLtrModel;
 import com.o19s.es.ltr.feature.store.FeatureStore;
 import com.o19s.es.ltr.feature.store.index.IndexFeatureStore;
 import com.o19s.es.ltr.ranker.linear.LinearRanker;
-import com.o19s.es.ltr.utils.AbstractQueryBuilderUtils;
 import com.o19s.es.ltr.utils.FeatureStoreLoader;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
@@ -63,7 +62,7 @@ public class StoredLtrQueryBuilder extends AbstractQueryBuilder<StoredLtrQueryBu
         PARSER.declareString(StoredLtrQueryBuilder::storeName, STORE_NAME);
         PARSER.declareField(StoredLtrQueryBuilder::params, XContentParser::map, PARAMS, ObjectParser.ValueType.OBJECT);
         PARSER.declareStringArray(StoredLtrQueryBuilder::activeFeatures, ACTIVE_FEATURES);
-        AbstractQueryBuilderUtils.declareStandardFields(PARSER);
+        declareStandardFields(PARSER);
     }
 
     /**

--- a/src/main/java/com/o19s/es/ltr/query/ValidatingLtrQueryBuilder.java
+++ b/src/main/java/com/o19s/es/ltr/query/ValidatingLtrQueryBuilder.java
@@ -28,7 +28,6 @@ import com.o19s.es.ltr.feature.store.StoredFeatureSet;
 import com.o19s.es.ltr.feature.store.StoredLtrModel;
 import com.o19s.es.ltr.ranker.linear.LinearRanker;
 import com.o19s.es.ltr.ranker.parser.LtrRankerParserFactory;
-import com.o19s.es.ltr.utils.AbstractQueryBuilderUtils;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.ParseField;
@@ -83,7 +82,7 @@ public class ValidatingLtrQueryBuilder extends AbstractQueryBuilder<ValidatingLt
         PARSER.declareObject((b, v) -> b.validation = v,
                 (p, c) -> FeatureValidation.PARSER.apply(p, null),
                 new ParseField("validation"));
-        AbstractQueryBuilderUtils.declareStandardFields(PARSER);
+        declareStandardFields(PARSER);
     }
 
     private final transient LtrRankerParserFactory factory;

--- a/src/main/java/com/o19s/es/ltr/utils/AbstractQueryBuilderUtils.java
+++ b/src/main/java/com/o19s/es/ltr/utils/AbstractQueryBuilderUtils.java
@@ -2,28 +2,20 @@ package com.o19s.es.ltr.utils;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.AbstractObjectParser;
-import org.elasticsearch.index.query.AbstractQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Contains a few methods copied from the AbstractQueryBuilder class. These methods are not accessible from sub classes
+ * that do not reside in the same package.
+ */
 public class AbstractQueryBuilderUtils {
 
-    /**
-     * Method copied from the {@link org.elasticsearch.index.query.AbstractQueryBuilder}. Scope was reduced to
-     * package private. But we use it in multiple subclasses.
-     *
-     * An issue is send to elastic to ask for a change to make it available again:
-     * https://github.com/elastic/elasticsearch/issues/27865
-     *
-     * @param parser Instance of a parser declare some default values for fields
-     */
-    public static void declareStandardFields(AbstractObjectParser<? extends QueryBuilder, ?> parser) {
-        parser.declareFloat(QueryBuilder::boost, AbstractQueryBuilder.BOOST_FIELD);
-        parser.declareString(QueryBuilder::queryName, AbstractQueryBuilder.NAME_FIELD);
+    private AbstractQueryBuilderUtils() {
+        // Utility class with static methods only
     }
 
     public static void writeQueries(StreamOutput out, List<? extends QueryBuilder> queries) throws IOException {


### PR DESCRIPTION
As the method is now open to subclasses based on the pull request
https://github.com/elastic/elasticsearch/issues/27865, we can now
use the method from the parent class.