### PR TITLE
WIP Fixes #224 - use custom openjdk12 container for circle

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -63,10 +63,7 @@ RUN set -eux; \
     rm -rf /var/cache/apk/*; \
     rm -rf /tmp/openjdk.tar.gz;
 
-RUN chmod a+rwx /opt/java/openjdk/bin/*
-
-#RUN apt-get update
-#RUN apt-get -y install git openjdk-12-jdk
+RUN chmod a+x /opt/java/openjdk/bin/*
 
 RUN apk add --no-cache git
 

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,5 +1,8 @@
 FROM alpine:3.10
 
+# Basics: Git, bash libc, etc
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
 RUN apk update \
 	&& apk add \
 	openssh-client \
@@ -72,9 +75,9 @@ ENV JAVA_HOME=/opt/java/openjdk \
 
 RUN java -version
 
-# Create a group and user
-#RUN addgroup -S elastic && adduser -S elastic -G elastic
-
+# Elasticsearch cant be run as root, 
+# this includes various integration and unit tests
+# Build as another user
 ENV USER=docker
 ENV UID=12345
 ENV GID=23456
@@ -83,18 +86,18 @@ RUN addgroup --gid "$GID" "$USER" \
     && adduser \
     --disabled-password \
     --gecos "" \
-    --home "/home/docker" \
+    --home "/home/$USER" \
     --ingroup "$USER" \
     --uid "$UID" \
     "$USER"
 
-USER docker
-WORKDIR /home/docker/
+USER $USER
+WORKDIR /home/$USER/
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"
 
-# Various tests
+# Various sanity checks 
 RUN mkdir project
 RUN which java
 RUN java -version

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,15 +1,102 @@
-FROM ubuntu:19.04
+FROM alpine:3.10
 
-RUN apt-get update
-RUN apt-get -y install git openjdk-12-jdk
+RUN apk update \
+	&& apk add \
+	openssh-client \
+	ca-certificates \
+	bash \
+	git;
 
-RUN useradd -ms /bin/bash elastic
-USER elastic
+RUN apk add --no-cache --virtual .build-deps curl binutils \
+    && GLIBC_VER="2.29-r0" \
+    && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.2.1%2B20180831-1-x86_64.pkg.tar.xz" \
+    && GCC_LIBS_SHA256=e4b39fb1f5957c5aab5c2ce0c46e03d30426f3b94b9992b009d417ff2d56af4d \
+    && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
+    && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
+    && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
+    && SGERRAND_RSA_SHA256="823b54589c93b02497f1ba4dc622eaef9c813e6b0f0ebbb2f771e32adf9f4ef2" \
+    && echo "${SGERRAND_RSA_SHA256} */etc/apk/keys/sgerrand.rsa.pub" | sha256sum -c - \
+    && curl -LfsS ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-${GLIBC_VER}.apk > /tmp/glibc-${GLIBC_VER}.apk \
+    && apk add /tmp/glibc-${GLIBC_VER}.apk \
+    && curl -LfsS ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk > /tmp/glibc-bin-${GLIBC_VER}.apk \
+    && apk add /tmp/glibc-bin-${GLIBC_VER}.apk \
+    && curl -Ls ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-i18n-${GLIBC_VER}.apk > /tmp/glibc-i18n-${GLIBC_VER}.apk \
+    && apk add /tmp/glibc-i18n-${GLIBC_VER}.apk \
+    && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
+    && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && mkdir /tmp/gcc \
+    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
+    && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
+    && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \
+    && echo "${ZLIB_SHA256} */tmp/libz.tar.xz" | sha256sum -c - \
+    && mkdir /tmp/libz \
+    && tar -xf /tmp/libz.tar.xz -C /tmp/libz \
+    && mv /tmp/libz/usr/lib/libz.so* /usr/glibc-compat/lib \
+    && apk del --purge .build-deps glibc-i18n \
+    && rm -rf /tmp/*.apk /tmp/gcc /tmp/gcc-libs.tar.xz /tmp/libz /tmp/libz.tar.xz /var/cache/apk/*
 
-ENV JAVA_HOME="/usr/lib/jvm/java-12-openjdk-amd64"
+#############################################################################
+# Set Java version and URL of AdoptOpenJDK12 (built on Open JDK 12)
+#############################################################################
+ENV JAVA_VERSION jdk12u
+ENV JAVA_SHA256 59868804a7fd478eca6a4b131338d67a6e0e7cf2fef364987c2821bd29e682e9
+ENV JAVA_URL https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk12u-2019-06-12-22-41/OpenJDK12U-jdk_x64_linux_hotspot_2019-06-12-22-41.tar.gz
+
+#############################################################################
+# # Download and extract AdoptOpenJDK12 (built on Open JDK 12)
+#############################################################################
+RUN set -eux; \
+    apk add --virtual .fetch-deps curl; \
+    curl -LfsSo /tmp/openjdk.tar.gz ${JAVA_URL}; \
+    echo "${JAVA_SHA256} */tmp/openjdk.tar.gz" | sha256sum -c -; \
+    mkdir -p /opt/java/openjdk; \
+    cd /opt/java/openjdk; \
+    tar -xf /tmp/openjdk.tar.gz --strip-components=1; \
+    apk del --purge .fetch-deps; \
+    rm -rf /var/cache/apk/*; \
+    rm -rf /tmp/openjdk.tar.gz;
+
+RUN chmod a+rwx /opt/java/openjdk/bin/*
+
+#RUN apt-get update
+#RUN apt-get -y install git openjdk-12-jdk
+
+RUN apk add --no-cache git
+
+ENV JAVA_HOME=/opt/java/openjdk \
+    PATH="/opt/java/openjdk/bin:$PATH"
 
 RUN java -version
+
+# Create a group and user
+#RUN addgroup -S elastic && adduser -S elastic -G elastic
+
+ENV USER=docker
+ENV UID=12345
+ENV GID=23456
+
+RUN addgroup --gid "$GID" "$USER" \
+    && adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/home/docker" \
+    --ingroup "$USER" \
+    --uid "$UID" \
+    "$USER"
+
+USER docker
+WORKDIR /home/docker/
+
+ENV JAVA_HOME=/opt/java/openjdk \
+    PATH="/opt/java/openjdk/bin:$PATH"
+
+# Various tests
+RUN mkdir project
 RUN which java
-RUN ls $JAVA_HOME
+RUN java -version
 
 CMD /bin/sh

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:19.04
+
+RUN apt-get update
+RUN apt-get -y install git openjdk-12-jdk
+
+RUN useradd -ms /bin/bash elastic
+USER elastic
+
+ENV JAVA_HOME="/usr/lib/jvm/java-12-openjdk-amd64"
+
+RUN java -version
+RUN which java
+RUN ls $JAVA_HOME
+
+CMD /bin/sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ jobs:
     build:
         docker:
             - image: quepid/es-plugin-test
+              environment:
+                MAX_HEAP_SIZE: 4096m
+                HEAP_NEWSIZE: 1024m
         steps:
             - checkout
             - run: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,11 @@
 version: 2
 jobs:
     build:
-        resource_class: large
         docker:
             - image: quepid/es-plugin-test
+              environment:
+                MAX_HEAP_SIZE: 4096m
+                HEAP_NEWSIZE: 1024m
         steps:
             - checkout
             - run: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,4 +5,4 @@ jobs:
             - image: quepid/es-plugin-test
         steps:
             - checkout
-            - run: ./gradlew clean check -Des.insecure.allow.root=true  -Dtests.jvms=1
+            - run: ./gradlew clean check --no-daemon -Dtests.jvms=1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 version: 2
 jobs:
+    resource_class: large
     build:
         docker:
             - image: quepid/es-plugin-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,5 +7,5 @@ jobs:
             - checkout
             - run: 
                 name: Full ES Plugin Build ('clean and check')
-                command: ./gradlew clean check -Dtests.jvms=1
+                command: ./gradlew clean check --no-daemon -Dtests.jvms=1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,4 @@ jobs:
             - checkout
             - run: 
                 name: Full ES Plugin Build ('clean and check')
-                environment: 
-                   GRADLE_OPTS: -Xmx2048m -Dorg.gradle.daemon=false
                 command: ./gradlew clean check --no-daemon -Dtests.jvms=1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,6 @@ jobs:
             - checkout
             - run: 
                 environment: 
-                   GRADLE_OPTS: -Xmx2048m  
+                   GRADLE_OPTS: -Xmx4096m  
                 name: Full ES Plugin Build ('clean and check')
                 command: ./gradlew clean check --no-daemon -Dtests.jvms=1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,8 @@
+version: 2
+jobs:
+    build:
+        docker:
+            - image: codeaches/openjdk:12-jdk
+        steps:
+            - checkout
+            - run: ./gradlew clean check -Des.insecure.allow.root=true  -Dtests.jvms=1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 jobs:
-    resource_class: large
     build:
+        resource_class: large
         docker:
             - image: quepid/es-plugin-test
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
     build:
         docker:
-            - image: codeaches/openjdk:12-jdk
+            - image: quepid/es-plugin-test
         steps:
             - checkout
             - run: ./gradlew clean check -Des.insecure.allow.root=true  -Dtests.jvms=1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,4 +5,9 @@ jobs:
             - image: quepid/es-plugin-test
         steps:
             - checkout
-            - run: ./gradlew clean check --no-daemon -Dtests.jvms=1
+            - run: 
+                name: Full ES Plugin Build ('clean and check')
+                environment: 
+                   GRADLE_OPTS: -Xmx2048m -Dorg.gradle.daemon=false
+                command: ./gradlew clean check --no-daemon -Dtests.jvms=1
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,9 @@ jobs:
     build:
         docker:
             - image: quepid/es-plugin-test
-              environment:
-                MAX_HEAP_SIZE: 4096m
-                HEAP_NEWSIZE: 1024m
         steps:
             - checkout
             - run: 
                 name: Full ES Plugin Build ('clean and check')
-                environment: 
-                   GRADLE_OPTS: -Xmx2048m -Dorg.gradle.daemon=false
-                command: ./gradlew clean check --no-daemon -Dtests.jvms=1
+                command: ./gradlew clean check -Dtests.jvms=1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,5 +7,6 @@ jobs:
             - checkout
             - run: 
                 name: Full ES Plugin Build ('clean and check')
+                environment: 
+                   GRADLE_OPTS: -Xmx2048m -Dorg.gradle.daemon=false
                 command: ./gradlew clean check --no-daemon -Dtests.jvms=1
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,6 @@ jobs:
             - checkout
             - run: 
                 environment: 
-                   GRADLE_OPTS: -Xmx2048m 
+                   GRADLE_OPTS: -Xmx2048m  
                 name: Full ES Plugin Build ('clean and check')
                 command: ./gradlew clean check --no-daemon -Dtests.jvms=1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,5 +9,7 @@ jobs:
         steps:
             - checkout
             - run: 
+                environment: 
+                   GRADLE_OPTS: -Xmx2048m 
                 name: Full ES Plugin Build ('clean and check')
                 command: ./gradlew clean check --no-daemon -Dtests.jvms=1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CircleCI](https://circleci.com/gh/o19s/elasticsearch-learning-to-rank.svg?style=svg)](https://circleci.com/gh/o19s/elasticsearch-learning-to-rank)
- 
+  
 The Elasticsearch Learning to Rank plugin uses machine learning to improve search relevance ranking. It's powering search at places like Wikimedia Foundation and Snagajob!
 
 # What this plugin does...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CircleCI](https://circleci.com/gh/o19s/elasticsearch-learning-to-rank.svg?style=svg)](https://circleci.com/gh/o19s/elasticsearch-learning-to-rank)
-
+ 
 The Elasticsearch Learning to Rank plugin uses machine learning to improve search relevance ranking. It's powering search at places like Wikimedia Foundation and Snagajob!
 
 # What this plugin does...

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
   dependencies {
     classpath "org.elasticsearch.gradle:build-tools:7.0.1"
   }
+
 }
 
 group = 'com.o19s'
@@ -63,6 +64,10 @@ dependencyLicenses {
   mapping from: /asm-.*/, to: 'asm'
   mapping from: /Ranky-.*/, to: 'lucene'
   mapping from: /compiler-.*/, to: 'lucene'
+}
+
+test { 
+  maxHeapSize = "512m" 
 }
 
 // Set to false to not use elasticsearch checkstyle rules

--- a/build.gradle
+++ b/build.gradle
@@ -66,10 +66,6 @@ dependencyLicenses {
   mapping from: /compiler-.*/, to: 'lucene'
 }
 
-test { 
-  maxHeapSize = "512m" 
-}
-
 // Set to false to not use elasticsearch checkstyle rules
 checkstyleMain.enabled = true
 checkstyleTest.enabled = true

--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,0 @@
-version: 2
-jobs:
-    build:
-        docker:
-          - image: circleci/openjdk:11.0.1-jdk-node-browsers
-        steps:
-            - checkout
-            - run: ./gradlew clean check -Dtests.jvms=1


### PR DESCRIPTION
Please see this branch which currently doesn't build to attempt to use the provided jdk12 container. Currently stuck as it runs the commands as root, and Elasticsearch gives the error for each test

```
com.o19s.es.explore.ExplorerQueryBuilderTests > classMethod FAILED
    java.lang.RuntimeException: can not run elasticsearch as root
```

To recreate install circle tools locally and run:

```
circleci local execute --job build
```