### PR TITLE
Sparse feature support for xgboost models

### DIFF
--- a/src/main/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTree.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTree.java
@@ -88,12 +88,14 @@ public class NaiveAdditiveDecisionTree extends DenseLtrRanker implements Account
         private static final long BASE_RAM_USED = RamUsageEstimator.shallowSizeOfInstance(Split.class);
         private final Node left;
         private final Node right;
+        private final Node onMissing;
         private final int feature;
         private final float threshold;
 
-        public Split(Node left, Node right, int feature, float threshold) {
+        public Split(Node left, Node right, Node onMissing, int feature, float threshold) {
             this.left = Objects.requireNonNull(left);
             this.right = Objects.requireNonNull(right);
+            this.onMissing = onMissing == null ? this.left : onMissing;
             this.feature = feature;
             this.threshold = threshold;
         }
@@ -109,7 +111,9 @@ public class NaiveAdditiveDecisionTree extends DenseLtrRanker implements Account
             while (!n.isLeaf()) {
                 assert n instanceof Split;
                 Split s = (Split) n;
-                if (s.threshold > scores[s.feature]) {
+                if (scores[s.feature] == Float.MAX_VALUE) {
+                    n = s.onMissing;
+                } else if (s.threshold > scores[s.feature]) {
                     n = s.left;
                 } else {
                     n = s.right;

--- a/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParser.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParser.java
@@ -82,7 +82,6 @@ public class XGBoostJsonParser implements LtrRankerParser {
         private Float threshold;
         private Integer rightNodeId;
         private Integer leftNodeId;
-        // Ignored
         private Integer missingNodeId;
         private Float leaf;
         private List<SplitParserState> children;
@@ -161,8 +160,10 @@ public class XGBoostJsonParser implements LtrRankerParser {
 
         Node toNode(FeatureSet set) {
             if (isSplit()) {
-                return new NaiveAdditiveDecisionTree.Split(children.get(0).toNode(set), children.get(1).toNode(set),
-                        set.featureOrdinal(split), threshold);
+                Node left = children.get(0).toNode(set);
+                Node right = children.get(1).toNode(set);
+                Node onMissing = this.missingNodeId.equals(this.rightNodeId) ? right : left;
+                return new NaiveAdditiveDecisionTree.Split(left, right, onMissing, set.featureOrdinal(split), threshold);
             } else {
                 return new NaiveAdditiveDecisionTree.Leaf(leaf);
             }

--- a/src/test/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParserTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParserTests.java
@@ -73,6 +73,8 @@ public class XGBoostJsonParserTests extends LuceneTestCase {
         assertEquals(0.5F, tree.score(v), Math.ulp(0.5F));
         v.setFeatureScore(0, 0.123F);
         assertEquals(0.2F, tree.score(v), Math.ulp(0.2F));
+        v.setFeatureScore(0, Float.MAX_VALUE);
+        assertEquals(0.2F, tree.score(v), Math.ulp(0.2F));
     }
 
     public void testMissingField() throws IOException {

--- a/src/test/resources/com/o19s/es/ltr/ranker/dectree/simple_tree.txt
+++ b/src/test/resources/com/o19s/es/ltr/ranker/dectree/simple_tree.txt
@@ -1,7 +1,7 @@
 # first line after split is right
 # data point: feature1:1, feature2:2, feature3:3
 - tree:3.4
-  - split:feature1:2.3
+  - split:feature1:false:2.3
     - output:3.2
 # right wins
     - split:feature2:2.2
@@ -11,7 +11,7 @@
 # left wins => output 1.2*3.4
       - output:1.2
 - tree:2.8
-  - split:feature1:0.1
+  - split:feature1:false:0.1
 # right wins
     - split:feature2:1.8
 # right wins


### PR DESCRIPTION
We still use a dense feature vector for model evaluation, but reserve `Float.MAX_VALUE` to represent "missing". We then use this value to take the proper node path during model evaluation.

`missingNodeId` was already present in the xgboost json parser but was being ignored. Modified the parser to actually make use of it and send it down to NaiveAdditiveDecisionTree.Split constructor.

The missing node Id has to be one of right or left nodes.

Modified the `simple_tree` format to allow specifying what node to take on missing features. Specified as a boolean—take left on true.