### PR TITLE
Add new xgboost parameter to represent missing features in feature vector

### DIFF
--- a/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParser.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParser.java
@@ -57,7 +57,9 @@ public class XGBoostJsonParser implements LtrRankerParser {
         float[] weights = new float[trees.length];
         // Tree weights are already encoded in outputs
         Arrays.fill(weights, 1F);
-        return new NaiveAdditiveDecisionTree(trees, weights, set.size(), modelDefinition.normalizer);
+        return new NaiveAdditiveDecisionTree(trees, weights, set.size(),
+                modelDefinition.normalizer,
+                modelDefinition.useFloatMaxForMissing ? Float.MAX_VALUE : null);
     }
 
     private static class XGBoostDefinition {
@@ -256,11 +258,11 @@ public class XGBoostJsonParser implements LtrRankerParser {
             if (isSplit()) {
                 Node left = children.get(0).toNode(set, xgb);
                 Node right = children.get(1).toNode(set, xgb);
+                Node onMissing = this.missingNodeId.equals(this.rightNodeId) ? right : left;
                 if (xgb.useFloatMaxForMissing) {
-                    Node onMissing = this.missingNodeId.equals(this.rightNodeId) ? right : left;
-                    return new NaiveAdditiveDecisionTree.SplitWithMissing(left, right, onMissing, set.featureOrdinal(split), threshold);
+                    return new NaiveAdditiveDecisionTree.Split(left, right, onMissing, set.featureOrdinal(split), threshold);
                 } else {
-                    return new NaiveAdditiveDecisionTree.Split(left, right, set.featureOrdinal(split), threshold);
+                    return new NaiveAdditiveDecisionTree.Split(left, right, null, set.featureOrdinal(split), threshold);
                 }
             } else {
                 return new NaiveAdditiveDecisionTree.Leaf(leaf);

--- a/src/test/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTreeTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTreeTests.java
@@ -84,7 +84,8 @@ public class NaiveAdditiveDecisionTreeTests extends LuceneTestCase {
     }
 
     public void testScoreSparseFeatureSet() throws IOException {
-        NaiveAdditiveDecisionTree ranker = parseTreeModel("tree_with_missing_branches.txt", Normalizers.get(Normalizers.NOOP_NORMALIZER_NAME), Float.MAX_VALUE);
+        NaiveAdditiveDecisionTree ranker = parseTreeModel("tree_with_missing_branches.txt",
+                Normalizers.get(Normalizers.NOOP_NORMALIZER_NAME), Float.MAX_VALUE);
         LtrRanker.FeatureVector vector = ranker.newFeatureVector(null);
         vector.setFeatureScore(0, 1);
         vector.setFeatureScore(1, 2);
@@ -95,7 +96,8 @@ public class NaiveAdditiveDecisionTreeTests extends LuceneTestCase {
     }
 
     public void testScoreSparseFeatureSetWithMissingField() throws IOException {
-        NaiveAdditiveDecisionTree ranker = parseTreeModel("tree_with_missing_branches.txt", Normalizers.get(Normalizers.NOOP_NORMALIZER_NAME), Float.MAX_VALUE);
+        NaiveAdditiveDecisionTree ranker = parseTreeModel("tree_with_missing_branches.txt",
+                Normalizers.get(Normalizers.NOOP_NORMALIZER_NAME), Float.MAX_VALUE);
         LtrRanker.FeatureVector vector = ranker.newFeatureVector(null);
         vector.setFeatureScore(0, Float.MAX_VALUE);
         vector.setFeatureScore(1, 2);

--- a/src/test/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParserTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParserTests.java
@@ -128,6 +128,35 @@ public class XGBoostJsonParserTests extends LuceneTestCase {
         assertEquals(0.2F, tree.score(v), Math.ulp(0.2F));
     }
 
+    public void testReadSimpleSplitWithSupportForMissing() throws IOException {
+        String model = "{" +
+                "\"use_float_max_for_missing\": true," +
+                "\"splits\": [{" +
+                "   \"nodeid\": 0," +
+                "   \"split\":\"feat1\"," +
+                "   \"depth\":0," +
+                "   \"split_condition\":0.123," +
+                "   \"yes\":1," +
+                "   \"no\": 2," +
+                "   \"missing\":2,"+
+                "   \"children\": [" +
+                "      {\"nodeid\": 1, \"depth\": 1, \"leaf\": 0.5}," +
+                "      {\"nodeid\": 2, \"depth\": 1, \"leaf\": 0.2}" +
+                "]}]}";
+
+        FeatureSet set = new StoredFeatureSet("set", singletonList(randomFeature("feat1")));
+        NaiveAdditiveDecisionTree tree = parser.parse(set, model);
+        FeatureVector v = tree.newFeatureVector(null);
+        v.setFeatureScore(0, 0.124F);
+        assertEquals(0.2F, tree.score(v), Math.ulp(0.2F));
+        v.setFeatureScore(0, 0.122F);
+        assertEquals(0.5F, tree.score(v), Math.ulp(0.5F));
+        v.setFeatureScore(0, 0.123F);
+        assertEquals(0.2F, tree.score(v), Math.ulp(0.2F));
+        v.setFeatureScore(0, Float.MAX_VALUE);
+        assertEquals(0.2F, tree.score(v), Math.ulp(0.2F));
+    }
+
     public void testReadSplitWithUnknownParams() throws IOException {
         String model = "{" +
                 "\"not_param\": \"value\"," +

--- a/src/test/resources/com/o19s/es/ltr/ranker/dectree/simple_tree.txt
+++ b/src/test/resources/com/o19s/es/ltr/ranker/dectree/simple_tree.txt
@@ -1,7 +1,7 @@
 # first line after split is right
 # data point: feature1:1, feature2:2, feature3:3
 - tree:3.4
-  - split:feature1:2.3
+  - split:feature1:false:2.3
     - output:3.2
 # right wins
     - split:feature2:2.2
@@ -11,7 +11,7 @@
 # left wins => output 1.2*3.4
       - output:1.2
 - tree:2.8
-  - split:feature1:0.1
+  - split:feature1:false:0.1
 # right wins
     - split:feature2:1.8
 # right wins

--- a/src/test/resources/com/o19s/es/ltr/ranker/dectree/simple_tree.txt
+++ b/src/test/resources/com/o19s/es/ltr/ranker/dectree/simple_tree.txt
@@ -1,7 +1,7 @@
 # first line after split is right
 # data point: feature1:1, feature2:2, feature3:3
 - tree:3.4
-  - split:feature1:false:2.3
+  - split:feature1:2.3
     - output:3.2
 # right wins
     - split:feature2:2.2
@@ -11,7 +11,7 @@
 # left wins => output 1.2*3.4
       - output:1.2
 - tree:2.8
-  - split:feature1:false:0.1
+  - split:feature1:0.1
 # right wins
     - split:feature2:1.8
 # right wins

--- a/src/test/resources/com/o19s/es/ltr/ranker/dectree/tree_with_missing_branches.txt
+++ b/src/test/resources/com/o19s/es/ltr/ranker/dectree/tree_with_missing_branches.txt
@@ -1,0 +1,18 @@
+# first line after split is right
+# third field in split -> take left branch on missing
+- tree:3.4
+  - split:feature1:true:2.3
+    - output:3.2
+    - split:feature2:false:2.2
+      - split:feature3:true:3.2
+        - output:11
+        - output:17
+      - output:1.2
+- tree:2.8
+  - split:feature1:true:0.1
+    - split:feature2:true:1.8
+      - split:feature3:false:3.2
+        - output:10
+        - output:3.2
+      - output:15
+    - output:23


### PR DESCRIPTION
This is a follow up from #248.

Added new parameter `use_float_max_for_missing` to indicate missing features can be represented as float max value in the feature vector.

cc @aprudhomme 