### PR TITLE
Upgrade to 7.4.x WIP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,12 +6,12 @@ buildscript {
   }
 
   dependencies {
-    classpath "org.elasticsearch.gradle:build-tools:7.3.1"
+    classpath "org.elasticsearch.gradle:build-tools:7.4.2"
   }
 }
 
 group = 'com.o19s'
-version = '1.1.2-es7.3.1'
+version = '1.1.2-es7.4.2'
 
 apply plugin: 'java'
 apply plugin: 'idea'
@@ -51,10 +51,10 @@ dependencies {
   compile 'org.ow2.asm:asm:5.0.4'
   compile 'org.ow2.asm:asm-commons:5.0.4'
   compile 'org.ow2.asm:asm-tree:5.0.4'
-  compile 'org.elasticsearch:elasticsearch:7.3.1'
+  compile 'org.elasticsearch:elasticsearch:7.4.2'
   compile 'com.o19s:RankyMcRankFace:0.1.1'
   compile "com.github.spullara.mustache.java:compiler:0.9.3"
-  testCompile 'org.elasticsearch.test:framework:7.3.1'
+  testCompile 'org.elasticsearch.test:framework:7.4.2'
 
 }
 
@@ -69,7 +69,7 @@ dependencyLicenses {
 // https://github.com/elastic/elasticsearch/issues/45891#issuecomment-525399411
 configurations.restSpec.withDependencies { dependencies ->
   dependencies.clear()
-  dependencies.add(project.dependencies.create("org.elasticsearch:rest-api-spec:7.3.1"))
+  dependencies.add(project.dependencies.create("org.elasticsearch:rest-api-spec:7.4.2"))
 }
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/o19s/es/ltr/action/AddFeaturesToSetAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/AddFeaturesToSetAction.java
@@ -43,7 +43,7 @@ public class AddFeaturesToSetAction extends ActionType<AddFeaturesToSetResponse>
     public static final String NAME = "cluster:admin/ltr/store/add-features-to-set";
 
     protected AddFeaturesToSetAction() {
-        super(NAME);
+        super(NAME, AddFeaturesToSetResponse::new);
     }
 
     @Override
@@ -66,6 +66,24 @@ public class AddFeaturesToSetAction extends ActionType<AddFeaturesToSetResponse>
         private String routing;
         private FeatureValidation validation;
 
+        public AddFeaturesToSetRequest() {
+        }
+
+
+        public  AddFeaturesToSetRequest(StreamInput in) throws IOException {
+            super(in);
+            store = in.readString();
+            features = in.readList(StoredFeature::new);
+            if (in.readBoolean()) {
+                featureNameQuery = in.readOptionalString();
+            }
+            merge = in.readBoolean();
+            featureSet = in.readString();
+            routing = in.readOptionalString();
+            validation = in.readOptionalWriteable(FeatureValidation::new);
+        }
+
+
         @Override
         public ActionRequestValidationException validate() {
             ActionRequestValidationException arve = null;
@@ -81,20 +99,6 @@ public class AddFeaturesToSetAction extends ActionType<AddFeaturesToSetResponse>
                 arve = addValidationError("featureSet must be set", arve);
             }
             return arve;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            store = in.readString();
-            features = in.readList(StoredFeature::new);
-            if (in.readBoolean()) {
-                featureNameQuery = in.readOptionalString();
-            }
-            merge = in.readBoolean();
-            featureSet = in.readString();
-            routing = in.readOptionalString();
-            validation = in.readOptionalWriteable(FeatureValidation::new);
         }
 
         @Override
@@ -173,8 +177,7 @@ public class AddFeaturesToSetAction extends ActionType<AddFeaturesToSetResponse>
 
         public AddFeaturesToSetResponse(StreamInput in) throws IOException {
             super(in);
-            response = new IndexResponse();
-            response.readFrom(in);
+            response = new IndexResponse(in);
         }
 
         public AddFeaturesToSetResponse(IndexResponse response) {
@@ -183,7 +186,6 @@ public class AddFeaturesToSetAction extends ActionType<AddFeaturesToSetResponse>
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            super.writeTo(out);
             response.writeTo(out);
         }
 

--- a/src/main/java/com/o19s/es/ltr/action/CachesStatsAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/CachesStatsAction.java
@@ -51,6 +51,10 @@ public class CachesStatsAction extends ActionType<CachesStatsNodesResponse> {
         public CachesStatsNodesRequest(StreamInput in) throws IOException {
             super(in);
         }
+
+        public CachesStatsNodesRequest() {
+            super((String[]) null);
+        }
     }
 
     public static class CachesStatsNodesResponse extends BaseNodesResponse<CachesStatsNodeResponse> implements ToXContent {

--- a/src/main/java/com/o19s/es/ltr/action/CachesStatsAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/CachesStatsAction.java
@@ -30,7 +30,6 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 

--- a/src/main/java/com/o19s/es/ltr/action/CachesStatsAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/CachesStatsAction.java
@@ -48,6 +48,9 @@ public class CachesStatsAction extends ActionType<CachesStatsNodesResponse> {
     }
 
     public static class CachesStatsNodesRequest extends BaseNodesRequest<CachesStatsNodesRequest> {
+        public CachesStatsNodesRequest(StreamInput in) throws IOException {
+            super(in);
+        }
     }
 
     public static class CachesStatsNodesResponse extends BaseNodesResponse<CachesStatsNodeResponse> implements ToXContent {
@@ -55,7 +58,7 @@ public class CachesStatsAction extends ActionType<CachesStatsNodesResponse> {
         private Map<String, StatDetails> byStore;
 
         public CachesStatsNodesResponse(StreamInput in) throws IOException {
-            super.readFrom(in);
+            super(in);
             allStores = new StatDetails(in);
             byStore = in.readMap(StreamInput::readString, StatDetails::new);
         }
@@ -77,7 +80,7 @@ public class CachesStatsAction extends ActionType<CachesStatsNodesResponse> {
 
         @Override
         protected void writeNodesTo(StreamOutput out, List<CachesStatsNodeResponse> nodes) throws IOException {
-            out.writeStreamableList(nodes);
+            out.writeList(nodes);
         }
 
         @Override
@@ -115,30 +118,22 @@ public class CachesStatsAction extends ActionType<CachesStatsNodesResponse> {
         private StatDetails allStores;
         private Map<String, StatDetails> byStore;
 
-        CachesStatsNodeResponse() {
-            empty();
-        }
         CachesStatsNodeResponse(DiscoveryNode node) {
             super(node);
             empty();
         }
 
         CachesStatsNodeResponse(StreamInput in) throws IOException {
-            readFrom(in);
+            super(in);
+            allStores = new StatDetails(in);
+            byStore = in.readMap(StreamInput::readString, StatDetails::new);
         }
 
-            @Override
+        @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             allStores.writeTo(out);
             out.writeMap(byStore, StreamOutput::writeString, (o, s) -> s.writeTo(o));
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            allStores = new StatDetails(in);
-            byStore = in.readMap(StreamInput::readString, StatDetails::new);
         }
 
         public void empty() {

--- a/src/main/java/com/o19s/es/ltr/action/CachesStatsAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/CachesStatsAction.java
@@ -44,12 +44,7 @@ public class CachesStatsAction extends ActionType<CachesStatsNodesResponse> {
     public static final CachesStatsAction INSTANCE = new CachesStatsAction();
 
     protected CachesStatsAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Reader<CachesStatsNodesResponse> getResponseReader() {
-        return CachesStatsNodesResponse::new;
+        super(NAME, CachesStatsNodesResponse::new);
     }
 
     public static class CachesStatsNodesRequest extends BaseNodesRequest<CachesStatsNodesRequest> {

--- a/src/main/java/com/o19s/es/ltr/action/ClearCachesAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/ClearCachesAction.java
@@ -42,7 +42,7 @@ public class ClearCachesAction extends ActionType<ClearCachesNodesResponse> {
     public static final ClearCachesAction INSTANCE = new ClearCachesAction();
 
     private ClearCachesAction() {
-        super(NAME);
+        super(NAME, ClearCachesNodesResponse::new);
     }
 
     @Override
@@ -61,6 +61,14 @@ public class ClearCachesAction extends ActionType<ClearCachesNodesResponse> {
         private Operation operation;
         private String name;
 
+
+        public ClearCachesNodesRequest(StreamInput in ) throws IOException {
+            super(in);
+            store = in.readString();
+            operation = Operation.values()[in.readVInt()];
+            name = in.readOptionalString();
+        }
+
         @Override
         public ActionRequestValidationException validate() {
             ActionRequestValidationException arve = null;
@@ -76,14 +84,6 @@ public class ClearCachesAction extends ActionType<ClearCachesNodesResponse> {
                 arve = addValidationError("name must be provided if clearing a specific element", arve);
             }
             return arve;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            store = in.readString();
-            operation = Operation.values()[in.readVInt()];
-            name = in.readOptionalString();
         }
 
         public void clearStore(String storeName) {
@@ -139,7 +139,7 @@ public class ClearCachesAction extends ActionType<ClearCachesNodesResponse> {
 
     public static class ClearCachesNodesResponse extends BaseNodesResponse<ClearCachesNodeResponse> {
         public ClearCachesNodesResponse(StreamInput in) throws IOException {
-            super.readFrom(in);
+            super(in);
         }
 
         public ClearCachesNodesResponse(ClusterName clusterName, List<ClearCachesNodeResponse> responses,
@@ -154,21 +154,20 @@ public class ClearCachesAction extends ActionType<ClearCachesNodesResponse> {
 
         @Override
         protected void writeNodesTo(StreamOutput out, List<ClearCachesNodeResponse> nodes) throws IOException {
-            out.writeStreamableList(nodes);
+            out.writeList(nodes);
         }
     }
 
     // NOOP response
     public static class ClearCachesNodeResponse extends BaseNodeResponse {
-        public ClearCachesNodeResponse() {
+        public ClearCachesNodeResponse(StreamInput in) throws IOException {
+            super(in);
         }
 
         public ClearCachesNodeResponse(DiscoveryNode node) {
             super(node);
         }
 
-        public ClearCachesNodeResponse(StreamInput in) throws IOException {
-            readFrom(in);
-        }
+
     }
 }

--- a/src/main/java/com/o19s/es/ltr/action/ClearCachesAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/ClearCachesAction.java
@@ -51,7 +51,7 @@ public class ClearCachesAction extends ActionType<ClearCachesNodesResponse> {
     }
 
     public static class RequestBuilder extends ActionRequestBuilder<ClearCachesNodesRequest, ClearCachesNodesResponse> {
-        public RequestBuilder(ElasticsearchClient client) {
+        public RequestBuilder(ElasticsearchClient client) throws IOException {
             super(client, ClearCachesAction.INSTANCE, new ClearCachesNodesRequest());
         }
     }
@@ -62,11 +62,15 @@ public class ClearCachesAction extends ActionType<ClearCachesNodesResponse> {
         private String name;
 
 
-        public ClearCachesNodesRequest(StreamInput in ) throws IOException {
+        public ClearCachesNodesRequest(StreamInput in) throws IOException {
             super(in);
             store = in.readString();
             operation = Operation.values()[in.readVInt()];
             name = in.readOptionalString();
+        }
+
+        public ClearCachesNodesRequest() {
+            super((String[]) null);
         }
 
         @Override

--- a/src/main/java/com/o19s/es/ltr/action/CreateModelFromSetAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/CreateModelFromSetAction.java
@@ -28,7 +28,6 @@ import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.xcontent.StatusToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.RestStatus;

--- a/src/main/java/com/o19s/es/ltr/action/CreateModelFromSetAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/CreateModelFromSetAction.java
@@ -42,16 +42,9 @@ public class CreateModelFromSetAction extends ActionType<CreateModelFromSetRespo
     public static final CreateModelFromSetAction INSTANCE = new CreateModelFromSetAction();
 
     protected CreateModelFromSetAction() {
-        super(NAME);
+        super(NAME, CreateModelFromSetResponse::new);
     }
 
-    /**
-     * Creates a new response instance.
-     */
-    @Override
-    public Reader<CreateModelFromSetResponse> getResponseReader() {
-        return CreateModelFromSetResponse::new;
-    }
 
     public static class CreateModelFromSetRequestBuilder extends ActionRequestBuilder<CreateModelFromSetRequest,
         CreateModelFromSetResponse> {
@@ -96,6 +89,18 @@ public class CreateModelFromSetAction extends ActionType<CreateModelFromSetRespo
         private FeatureValidation validation;
 
         public CreateModelFromSetRequest() {
+
+        }
+
+        public CreateModelFromSetRequest(StreamInput in) throws IOException {
+            super(in);
+            store = in.readString();
+            featureSetName = in.readString();
+            expectedSetVersion = in.readOptionalLong();
+            modelName = in.readString();
+            definition = new StoredLtrModel.LtrModelDefinition(in);
+            routing = in.readOptionalString();
+            validation = in.readOptionalWriteable(FeatureValidation::new);
         }
 
         @Override
@@ -114,18 +119,6 @@ public class CreateModelFromSetAction extends ActionType<CreateModelFromSetRespo
                 arve = addValidationError("defition must be set", arve);
             }
             return arve;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            store = in.readString();
-            featureSetName = in.readString();
-            expectedSetVersion = in.readOptionalLong();
-            modelName = in.readString();
-            definition = new StoredLtrModel.LtrModelDefinition(in);
-            routing = in.readOptionalString();
-            validation = in.readOptionalWriteable(FeatureValidation::new);
         }
 
         @Override
@@ -185,8 +178,7 @@ public class CreateModelFromSetAction extends ActionType<CreateModelFromSetRespo
             super(in);
             int version = in.readVInt();
             assert version == VERSION;
-            response = new IndexResponse();
-            response.readFrom(in);
+            response = new IndexResponse(in);
         }
 
         public CreateModelFromSetResponse(IndexResponse response) {
@@ -195,7 +187,6 @@ public class CreateModelFromSetAction extends ActionType<CreateModelFromSetRespo
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            super.writeTo(out);
             out.writeVInt(VERSION);
             response.writeTo(out);
         }

--- a/src/main/java/com/o19s/es/ltr/action/FeatureStoreAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/FeatureStoreAction.java
@@ -44,7 +44,7 @@ public class FeatureStoreAction extends ActionType<FeatureStoreResponse> {
     public static final FeatureStoreAction INSTANCE = new FeatureStoreAction();
 
     protected FeatureStoreAction() {
-        super(NAME);
+        super(NAME, FeatureStoreResponse::new);
     }
 
     @Override
@@ -69,6 +69,15 @@ public class FeatureStoreAction extends ActionType<FeatureStoreResponse> {
         private FeatureValidation validation;
 
         public FeatureStoreRequest() {}
+
+        public FeatureStoreRequest(StreamInput in) throws IOException {
+            super(in);
+            store = in.readString();
+            routing = in.readOptionalString();
+            action = Action.values()[in.readVInt()];
+            storableElement = in.readNamedWriteable(StorableElement.class);
+            validation = in.readOptionalWriteable(FeatureValidation::new);
+        }
 
         public FeatureStoreRequest(String store, StorableElement storableElement, Action action) {
             this.store = Objects.requireNonNull(store);
@@ -154,16 +163,6 @@ public class FeatureStoreAction extends ActionType<FeatureStoreResponse> {
 
 
         @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            store = in.readString();
-            routing = in.readOptionalString();
-            action = Action.values()[in.readVInt()];
-            storableElement = in.readNamedWriteable(StorableElement.class);
-            validation = in.readOptionalWriteable(FeatureValidation::new);
-        }
-
-        @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeString(store);
@@ -184,8 +183,7 @@ public class FeatureStoreAction extends ActionType<FeatureStoreResponse> {
 
         public FeatureStoreResponse(StreamInput in) throws IOException {
             super(in);
-            response = new IndexResponse();
-            response.readFrom(in);
+            response = new IndexResponse(in);
         }
 
         public FeatureStoreResponse(IndexResponse response) {
@@ -202,7 +200,6 @@ public class FeatureStoreAction extends ActionType<FeatureStoreResponse> {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            super.writeTo(out);
             response.writeTo(out);
         }
 

--- a/src/main/java/com/o19s/es/ltr/action/ListStoresAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/ListStoresAction.java
@@ -43,7 +43,7 @@ public class ListStoresAction extends ActionType<ListStoresActionResponse> {
     public static final ListStoresAction INSTANCE = new ListStoresAction();
 
     private ListStoresAction() {
-        super(NAME);
+        super(NAME, ListStoresActionResponse::new);
     }
 
     @Override
@@ -56,6 +56,8 @@ public class ListStoresAction extends ActionType<ListStoresActionResponse> {
         public ActionRequestValidationException validate() {
             return null;
         }
+
+        public ListStoresActionRequest() {}
     }
 
     public static class ListStoresActionResponse extends ActionResponse implements ToXContentObject {
@@ -81,7 +83,6 @@ public class ListStoresAction extends ActionType<ListStoresActionResponse> {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            super.writeTo(out);
             out.writeMap(stores, StreamOutput::writeString, (w, i) -> i.writeTo(w));
         }
 

--- a/src/main/java/com/o19s/es/ltr/action/ListStoresAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/ListStoresAction.java
@@ -58,6 +58,10 @@ public class ListStoresAction extends ActionType<ListStoresActionResponse> {
         }
 
         public ListStoresActionRequest() {}
+
+        public ListStoresActionRequest(StreamInput in) throws IOException {
+            super(in);
+        }
     }
 
     public static class ListStoresActionResponse extends ActionResponse implements ToXContentObject {

--- a/src/main/java/com/o19s/es/ltr/action/TransportCacheStatsAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportCacheStatsAction.java
@@ -27,10 +27,12 @@ import org.elasticsearch.action.support.nodes.TransportNodesAction;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+import java.io.IOException;
 import java.util.List;
 
 public class TransportCacheStatsAction extends TransportNodesAction<CachesStatsNodesRequest, CachesStatsNodesResponse,
@@ -60,8 +62,8 @@ public class TransportCacheStatsAction extends TransportNodesAction<CachesStatsN
     }
 
     @Override
-    protected CachesStatsNodeResponse newNodeResponse() {
-        return new CachesStatsNodeResponse();
+    protected CachesStatsNodeResponse newNodeResponse(StreamInput in) throws IOException {
+        return new CachesStatsNodeResponse(in);
     }
 
     @Override
@@ -71,5 +73,10 @@ public class TransportCacheStatsAction extends TransportNodesAction<CachesStatsN
 
     public static class CachesStatsNodeRequest extends BaseNodeRequest {
         public CachesStatsNodeRequest() {}
+
+        public CachesStatsNodeRequest(StreamInput in) throws IOException {
+            super(in);
+        }
+
     }
 }

--- a/src/main/java/com/o19s/es/ltr/action/TransportClearCachesAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportClearCachesAction.java
@@ -62,6 +62,11 @@ public class TransportClearCachesAction extends TransportNodesAction<ClearCaches
     }
 
     @Override
+    protected ClearCachesNodeResponse newNodeResponse(StreamInput in) throws IOException {
+        return null; // TODO
+    }
+
+    @Override
     protected ClearCachesNodeResponse newNodeResponse() {
         return new ClearCachesNodeResponse();
     }
@@ -97,12 +102,11 @@ public class TransportClearCachesAction extends TransportNodesAction<ClearCaches
             this.request = req;
         }
 
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            request = new ClearCachesNodesRequest();
-            request.readFrom(in);
+        ClearCachesNodeRequest(StreamInput in) throws IOException {
+            super(in);
+            request = new ClearCachesNodesRequest(in);
         }
+
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {

--- a/src/main/java/com/o19s/es/ltr/action/TransportClearCachesAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportClearCachesAction.java
@@ -67,11 +67,6 @@ public class TransportClearCachesAction extends TransportNodesAction<ClearCaches
     }
 
     @Override
-    protected ClearCachesNodeResponse newNodeResponse() {
-        return new ClearCachesNodeResponse();
-    }
-
-    @Override
     protected ClearCachesNodeResponse nodeOperation(ClearCachesNodeRequest request) {
         ClearCachesNodesRequest r = request.request;
         switch (r.getOperation()) {

--- a/src/main/java/com/o19s/es/ltr/action/TransportFeatureStoreAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportFeatureStoreAction.java
@@ -86,7 +86,7 @@ public class TransportFeatureStoreAction extends HandledTransportAction<FeatureS
         }
     }
 
-    private Optional<ClearCachesNodesRequest> buildClearCache(FeatureStoreRequest request) {
+    private Optional<ClearCachesNodesRequest> buildClearCache(FeatureStoreRequest request) throws IOException {
         if (request.getAction() == FeatureStoreRequest.Action.UPDATE) {
              ClearCachesAction.ClearCachesNodesRequest clearCachesNodesRequest = new ClearCachesAction.ClearCachesNodesRequest();
              switch (request.getStorableElement().type()) {
@@ -174,9 +174,9 @@ public class TransportFeatureStoreAction extends HandledTransportAction<FeatureS
      * Prepare a Runnable to send an index request to store the element, invalidates the cache on success
      */
     private void store(FeatureStoreRequest request, Task task, ActionListener<FeatureStoreResponse> listener) {
-        Optional<ClearCachesNodesRequest> clearCachesNodesRequest = buildClearCache(request);
 
         try {
+            Optional<ClearCachesNodesRequest> clearCachesNodesRequest = buildClearCache(request);
             IndexRequest indexRequest = buildIndexRequest(task, request);
             client.execute(IndexAction.INSTANCE, indexRequest, wrap(
                     (r) -> {

--- a/src/main/java/com/o19s/es/ltr/action/TransportListStoresAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportListStoresAction.java
@@ -34,6 +34,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
@@ -42,6 +43,7 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;

--- a/src/main/java/com/o19s/es/ltr/action/TransportListStoresAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportListStoresAction.java
@@ -65,7 +65,7 @@ public class TransportListStoresAction extends TransportMasterNodeReadAction<Lis
                                      ThreadPool threadPool, ActionFilters actionFilters,
                                      IndexNameExpressionResolver indexNameExpressionResolver, Client client) {
         super(ListStoresAction.NAME, transportService, clusterService, threadPool,
-            actionFilters, indexNameExpressionResolver, ListStoresActionRequest::new);
+            actionFilters, ListStoresActionRequest::new, indexNameExpressionResolver);
         this.client = client;
     }
     

--- a/src/main/java/com/o19s/es/ltr/action/TransportListStoresAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportListStoresAction.java
@@ -68,15 +68,15 @@ public class TransportListStoresAction extends TransportMasterNodeReadAction<Lis
             actionFilters, indexNameExpressionResolver, ListStoresActionRequest::new);
         this.client = client;
     }
-
+    
     @Override
     protected String executor() {
         return ThreadPool.Names.SAME;
     }
 
     @Override
-    protected ListStoresActionResponse newResponse() {
-        return new ListStoresActionResponse();
+    protected ListStoresActionResponse read(StreamInput in) throws IOException {
+        return new ListStoresActionResponse(in);
     }
 
     @Override

--- a/src/main/java/com/o19s/es/ltr/rest/FeatureStoreBaseRestHandler.java
+++ b/src/main/java/com/o19s/es/ltr/rest/FeatureStoreBaseRestHandler.java
@@ -23,7 +23,6 @@ import org.elasticsearch.rest.RestRequest;
 
 public abstract class FeatureStoreBaseRestHandler extends BaseRestHandler {
     protected FeatureStoreBaseRestHandler(Settings settings) {
-        super(settings);
     }
 
     protected String indexName(RestRequest request) {

--- a/src/main/java/com/o19s/es/ltr/rest/RestFeatureStoreCaches.java
+++ b/src/main/java/com/o19s/es/ltr/rest/RestFeatureStoreCaches.java
@@ -72,7 +72,7 @@ public class RestFeatureStoreCaches extends FeatureStoreBaseRestHandler {
         return (channel) -> new CachesStatsAction.CachesStatsActionBuilder(client).execute(new NodesResponseRestListener(channel));
     }
 
-    private RestChannelConsumer clearCache(RestRequest request, NodeClient client) {
+    private RestChannelConsumer clearCache(RestRequest request, NodeClient client) throws IOException {
         String storeName = indexName(request);
         ClearCachesAction.RequestBuilder builder = new ClearCachesAction.RequestBuilder(client);
         builder.request().clearStore(storeName);


### PR DESCRIPTION
Have begun to go through the 7.4 upgrade, and working through compiler errors. Elastic has done some cleanup on how actions are streamed in and out in binary format (that's my work thus far). Still to do: there's some tricky (maybe slightly different) Node Request changes around `ClearCachesNodeRequest` along these lines I haven't had a chance to dig into, @nomoa would you mind looking at that? Maybe one or two other loose ends.

Relevant Elasticsearch commits for my updates so far for reference:

- [Remove usage of ActionType#(String)](https://github.com/elastic/elasticsearch/commit/5a9f81791a1be7fe6dd97728384ebafb189ab211#diff-80df90ca727aadbbe854902f81bda313)
- [Convert Transport Request/Response to Writeable](https://github.com/elastic/elasticsearch/commit/7895dc9915422a33bb6814ec420c3b068aef4410#diff-5a9a7882cd6a84c92df9fe0e112f6808L40)