### PR TITLE
Elastic LTR 7.5.0 port, Fixes #260

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+// Remove after 7.5.1
+import org.elasticsearch.gradle.testclusters.TestClustersRegistry
+import org.elasticsearch.gradle.testclusters.TestClustersPlugin
+
 buildscript {
   repositories {
     mavenCentral()
@@ -96,3 +100,9 @@ thirdPartyAudit.enabled = false
 
 // Uncomment this to skip license header checks
 licenseHeaders.enabled = false
+
+// Remove after 7.5.1
+TestClustersRegistry registry = project.rootProject.extensions.create("testClustersRegistry", TestClustersRegistry)
+TestClustersPlugin.configureClaimClustersHook(project.gradle, registry)
+TestClustersPlugin.configureStartClustersHook(project.gradle, registry)
+TestClustersPlugin.configureStopClustersHook(project.gradle, registry)

--- a/build.gradle
+++ b/build.gradle
@@ -6,12 +6,12 @@ buildscript {
   }
 
   dependencies {
-    classpath "org.elasticsearch.gradle:build-tools:7.4.2"
+    classpath "org.elasticsearch.gradle:build-tools:7.5.0"
   }
 }
 
 group = 'com.o19s'
-version = '1.1.2-es7.4.2'
+version = '1.1.2-es7.5.0'
 
 apply plugin: 'java'
 apply plugin: 'idea'
@@ -56,10 +56,10 @@ dependencies {
   compile 'org.ow2.asm:asm:5.0.4'
   compile 'org.ow2.asm:asm-commons:5.0.4'
   compile 'org.ow2.asm:asm-tree:5.0.4'
-  compile 'org.elasticsearch:elasticsearch:7.4.2'
+  compile 'org.elasticsearch:elasticsearch:7.5.0'
   compile 'com.o19s:RankyMcRankFace:0.1.1'
   compile "com.github.spullara.mustache.java:compiler:0.9.3"
-  testCompile 'org.elasticsearch.test:framework:7.4.2'
+  testCompile 'org.elasticsearch.test:framework:7.5.0'
 }
 
 dependencyLicenses {
@@ -73,7 +73,7 @@ dependencyLicenses {
 // https://github.com/elastic/elasticsearch/issues/45891#issuecomment-525399411
 configurations.restSpec.withDependencies { dependencies ->
   dependencies.clear()
-  dependencies.add(project.dependencies.create("org.elasticsearch:rest-api-spec:7.4.2"))
+  dependencies.add(project.dependencies.create("org.elasticsearch:rest-api-spec:7.5.0"))
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,12 +10,12 @@ buildscript {
   }
 
   dependencies {
-    classpath "org.elasticsearch.gradle:build-tools:7.5.0"
+    classpath "org.elasticsearch.gradle:build-tools:7.5.1"
   }
 }
 
 group = 'com.o19s'
-version = '1.1.2-es7.5.0'
+version = '1.1.2-es7.5.1'
 
 apply plugin: 'java'
 apply plugin: 'idea'
@@ -60,10 +60,10 @@ dependencies {
   compile 'org.ow2.asm:asm:5.0.4'
   compile 'org.ow2.asm:asm-commons:5.0.4'
   compile 'org.ow2.asm:asm-tree:5.0.4'
-  compile 'org.elasticsearch:elasticsearch:7.5.0'
+  compile 'org.elasticsearch:elasticsearch:7.5.1'
   compile 'com.o19s:RankyMcRankFace:0.1.1'
   compile "com.github.spullara.mustache.java:compiler:0.9.3"
-  testCompile 'org.elasticsearch.test:framework:7.5.0'
+  testCompile 'org.elasticsearch.test:framework:7.5.1'
 }
 
 dependencyLicenses {
@@ -77,13 +77,13 @@ dependencyLicenses {
 // https://github.com/elastic/elasticsearch/issues/45891#issuecomment-525399411
 configurations.restSpec.withDependencies { dependencies ->
   dependencies.clear()
-  dependencies.add(project.dependencies.create("org.elasticsearch:rest-api-spec:7.5.0"))
+  dependencies.add(project.dependencies.create("org.elasticsearch:rest-api-spec:7.5.1"))
 }
 
 // REMOVE PAST 7.5.1
 configurations.whenObjectAdded { c ->
-  if (c.name == 'elasticsearch_7.5.0_integ_test_zip_null') {
-    project.dependencies.add('elasticsearch_7.5.0_integ_test_zip_null', 'org.elasticsearch.distribution.integ-test-zip:elasticsearch:7.5.0@zip')
+  if (c.name == 'elasticsearch_7.5.1_integ_test_zip_null') {
+    project.dependencies.add('elasticsearch_7.5.1_integ_test_zip_null', 'org.elasticsearch.distribution.integ-test-zip:elasticsearch:7.5.1@zip')
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ repositories {
 }
 
 dependencies {
-  compile "org.apache.lucene:lucene-expressions:8.2.0"
+  compile "org.apache.lucene:lucene-expressions:8.3.0"
   compile 'org.antlr:antlr4-runtime:4.5.1-1'
   compile 'org.ow2.asm:asm:5.0.4'
   compile 'org.ow2.asm:asm-commons:5.0.4'

--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,13 @@ configurations.restSpec.withDependencies { dependencies ->
   dependencies.add(project.dependencies.create("org.elasticsearch:rest-api-spec:7.5.0"))
 }
 
+// REMOVE PAST 7.5.1
+configurations.whenObjectAdded { c ->
+  if (c.name == 'elasticsearch_7.5.0_integ_test_zip_null') {
+    project.dependencies.add('elasticsearch_7.5.0_integ_test_zip_null', 'org.elasticsearch.distribution.integ-test-zip:elasticsearch:7.5.0@zip')
+  }
+}
+
 
 // Set to false to not use elasticsearch checkstyle rules
 checkstyleMain.enabled = true

--- a/src/main/java/com/o19s/es/ltr/feature/store/ScriptFeature.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/ScriptFeature.java
@@ -21,7 +21,6 @@ import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.index.query.functionscore.ScriptScoreFunctionBuilder;
 import org.elasticsearch.script.ScoreScript;
 import org.elasticsearch.script.Script;
 

--- a/src/main/java/com/o19s/es/ltr/feature/store/ScriptFeature.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/ScriptFeature.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.query.functionscore.ScriptScoreFunctionBuilder;
 import org.elasticsearch.script.ScoreScript;
 import org.elasticsearch.script.Script;
 
@@ -118,7 +119,10 @@ public class ScriptFeature implements Feature {
             this.script.getIdOrCode(), this.script.getOptions(), nparams);
         ScoreScript.Factory factoryFactory  = context.getQueryShardContext().getScriptService().compile(script, ScoreScript.CONTEXT);
         ScoreScript.LeafFactory leafFactory = factoryFactory.newFactory(nparams, context.getQueryShardContext().lookup());
-        ScriptScoreFunction function = new ScriptScoreFunction(script, leafFactory);
+        ScriptScoreFunction function = new ScriptScoreFunction(script, leafFactory,
+                context.getQueryShardContext().index().getName(),
+                context.getQueryShardContext().getShardId(),
+                context.getQueryShardContext().indexVersionCreated());
         return new LtrScript(function, supplier);
     }
 

--- a/src/test/java/com/o19s/es/explore/ExplorerQueryBuilderTests.java
+++ b/src/test/java/com/o19s/es/explore/ExplorerQueryBuilderTests.java
@@ -18,9 +18,9 @@ package com.o19s.es.explore;
 import com.o19s.es.ltr.LtrQueryParserPlugin;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.AbstractQueryTestCase;
 
 import java.io.IOException;
@@ -85,7 +85,7 @@ public class ExplorerQueryBuilderTests extends AbstractQueryTestCase<ExplorerQue
     }
 
     @Override
-    protected void doAssertLuceneQuery(ExplorerQueryBuilder queryBuilder, Query query, SearchContext context) throws IOException {
+    protected void doAssertLuceneQuery(ExplorerQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
         assertThat(query, instanceOf(ExplorerQuery.class));
     }
 }

--- a/src/test/java/com/o19s/es/ltr/action/BaseIntegrationTest.java
+++ b/src/test/java/com/o19s/es/ltr/action/BaseIntegrationTest.java
@@ -182,7 +182,7 @@ public abstract class BaseIntegrationTest extends ESSingleNodeTestCase {
                                     public ScoreScript newInstance(LeafReaderContext ctx) throws IOException {
                                         return new ScoreScript(p, lookup, ctx) {
                                             @Override
-                                            public double execute() {
+                                            public double execute(ExplanationHolder explainationHolder ) {
                                                 return extraMultiplier == 0.0d ?
                                                         featureSupplier.get(dependentFeature) * 10 :
                                                         featureSupplier.get(dependentFeature) * extraMultiplier;

--- a/src/test/java/com/o19s/es/ltr/query/LtrQueryBuilderTests.java
+++ b/src/test/java/com/o19s/es/ltr/query/LtrQueryBuilderTests.java
@@ -28,7 +28,6 @@ import org.elasticsearch.index.query.WrapperQueryBuilder;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
-import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.AbstractQueryTestCase;
 
 import java.io.IOException;
@@ -233,7 +232,7 @@ public class LtrQueryBuilderTests extends AbstractQueryTestCase<LtrQueryBuilder>
     }
 
     @Override
-    protected void doAssertLuceneQuery(LtrQueryBuilder queryBuilder, Query query, SearchContext context) throws IOException {
+    protected void doAssertLuceneQuery(LtrQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
         assertThat(query, instanceOf(RankerQuery.class));
     }
 

--- a/src/test/java/com/o19s/es/ltr/query/StoredLtrQueryBuilderTests.java
+++ b/src/test/java/com/o19s/es/ltr/query/StoredLtrQueryBuilderTests.java
@@ -42,7 +42,6 @@ import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.index.query.functionscore.FieldValueFactorFunctionBuilder;
 import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.AbstractQueryTestCase;
 import org.junit.Before;
 
@@ -182,7 +181,7 @@ public class StoredLtrQueryBuilderTests extends AbstractQueryTestCase<StoredLtrQ
 
     @Override
     protected void doAssertLuceneQuery(StoredLtrQueryBuilder queryBuilder,
-                                       Query query, SearchContext context) throws IOException {
+                                       Query query, QueryShardContext context) throws IOException {
         assertThat(query, instanceOf(RankerQuery.class));
         RankerQuery rquery = (RankerQuery) query;
         Iterator<Query> ite = rquery.stream().iterator();

--- a/src/test/java/com/o19s/es/ltr/query/ValidatingLtrQueryBuilderTests.java
+++ b/src/test/java/com/o19s/es/ltr/query/ValidatingLtrQueryBuilderTests.java
@@ -16,6 +16,7 @@
 
 package com.o19s.es.ltr.query;
 
+import com.carrotsearch.randomizedtesting.RandomizedRunner;
 import com.o19s.es.ltr.LtrQueryParserPlugin;
 import com.o19s.es.ltr.feature.FeatureValidation;
 import com.o19s.es.ltr.feature.store.StorableElement;
@@ -27,9 +28,10 @@ import com.o19s.es.ltr.ranker.parser.LtrRankerParserFactory;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.AbstractQueryTestCase;
+import org.junit.runner.RunWith;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -48,6 +50,7 @@ import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.joining;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
+@RunWith(RandomizedRunner.class)
 public class ValidatingLtrQueryBuilderTests extends AbstractQueryTestCase<ValidatingLtrQueryBuilder> {
     private final LtrRankerParserFactory factory = new LtrRankerParserFactory.Builder()
             .register(LinearRankerParser.TYPE, LinearRankerParser::new)
@@ -119,7 +122,7 @@ public class ValidatingLtrQueryBuilderTests extends AbstractQueryTestCase<Valida
     }
 
     @Override
-    protected void doAssertLuceneQuery(ValidatingLtrQueryBuilder queryBuilder, Query query, SearchContext context) throws IOException {
+    protected void doAssertLuceneQuery(ValidatingLtrQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
         if (StoredFeature.TYPE.equals(queryBuilder.getElement().type())) {
             assertThat(query, instanceOf(MatchNoDocsQuery.class));
         } else if (StoredFeatureSet.TYPE.equals(queryBuilder.getElement().type())) {


### PR DESCRIPTION
Upgrading plugin to Elasticsearch 7.5.0

Related Elastic changes/issues for reference:

- [Building ES plugin for 7.5.0 fails](https://github.com/elastic/elasticsearch/issues/49787)
- [Replace SearchContext -> QueryShardContext](https://github.com/elastic/elasticsearch/commit/4414fccb2765dd24895216636e68aabea2d156ca)