### PR TITLE
Add optional extra logging for native scripts

### DIFF
--- a/docs/advanced-functionality.rst
+++ b/docs/advanced-functionality.rst
@@ -172,7 +172,7 @@ Characteristics of the internal cache can be controlled with these node settings
 Extra Logging
 =============================
 
-As described in :doc:`logging-features`, it is possible to used the logging extension to return the feature values with each document. For native scripts, it is also possible to return extra arbitrary information with the logged features.
+As described in :doc:`logging-features`, it is possible to use the logging extension to return the feature values with each document. For native scripts, it is also possible to return extra arbitrary information with the logged features.
 
 For native scripts, the parameter :code:`extra_logging` is injected into the script parameters. The parameter value is a `Supplier <https://docs.oracle.com/javase/8/docs/api/java/util/function/Supplier.html>`_ <`Map <https://docs.oracle.com/javase/8/docs/api/java/util/Map.html>`_>, which provides a non-null :code:`Map<String,Object>` **only** during the logging fetch phase. Any values added to this Map will be returned with the logged features::
 

--- a/docs/advanced-functionality.rst
+++ b/docs/advanced-functionality.rst
@@ -167,3 +167,48 @@ Characteristics of the internal cache can be controlled with these node settings
     ltr.caches.expire_after_write: 10m
     # Evict cache entries 10 minutes after access (defaults to 1hour, set to 0 to disable)
     ltr.caches.expire_after_read: 10m
+
+=============================
+Extra Logging
+=============================
+
+As described in :doc:`logging-features`, it is possible to used the logging extension to return the feature values with each document. For native scripts, it is also possible to return extra arbitrary information with the logged features.
+
+For native scripts, the parameter :code:`extra_logging` is injected into the script parameters. The parameter value is a `Supplier <https://docs.oracle.com/javase/8/docs/api/java/util/function/Supplier.html>`_ <`Map <https://docs.oracle.com/javase/8/docs/api/java/util/Map.html>`_>, which provides a non-null :code:`Map<String,Object>` **only** during the logging fetch phase. Any values added to this Map will be returned with the logged features::
+
+    @Override
+    public double runAsDouble() {
+    ...
+        Map<String,Object> extraLoggingMap = ((Supplier<Map<String,Object>>) getParams().get("extra_logging")).get();
+        if (extraLoggingMap != null) {
+            extraLoggingMap.put("extra_float", 10.0f);
+            extraLoggingMap.put("extra_string", "additional_info");
+        }
+    ...
+    }
+
+If (and only if) the extra logging Map is accessed, it will be returned as an additional entry with the logged features::
+
+    {
+        "log_entry1": [
+            {
+                "name": "title_query"
+                "value": 9.510193
+            },
+            {
+                "name": "body_query"
+                "value": 10.7808075
+            },
+            {
+                "name": "user_rating",
+                "value": 7.8
+            },
+            {
+                "name": "extra_logging",
+                "value": {
+                    "extra_float": 10.0,
+                    "extra_string": "additional_info"
+                }
+            }
+        ]
+    }

--- a/src/main/java/com/o19s/es/ltr/feature/store/ExtraLoggingSupplier.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/ExtraLoggingSupplier.java
@@ -1,0 +1,28 @@
+package com.o19s.es.ltr.feature.store;
+
+import com.o19s.es.ltr.ranker.LogLtrRanker;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+
+public class ExtraLoggingSupplier implements Supplier<Map<String,Object>> {
+    protected LogLtrRanker.LogConsumer consumer;
+
+    public void setConsumer(LogLtrRanker.LogConsumer consumer) {
+        this.consumer = consumer;
+    }
+
+    /**
+     * Return a Map to add additional information to be returned when logging feature values.
+     *
+     * This Map will only be non-null during the LoggingFetchSubPhase.
+     */
+    @Override
+    public Map<String, Object> get() {
+        if (consumer != null) {
+            return consumer.getExtraLoggingMap();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/o19s/es/ltr/feature/store/ExtraLoggingSupplier.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/ExtraLoggingSupplier.java
@@ -1,16 +1,14 @@
 package com.o19s.es.ltr.feature.store;
 
-import com.o19s.es.ltr.ranker.LogLtrRanker;
-
 import java.util.Map;
 import java.util.function.Supplier;
 
 
 public class ExtraLoggingSupplier implements Supplier<Map<String,Object>> {
-    protected LogLtrRanker.LogConsumer consumer;
+    protected Supplier<Map<String,Object>> supplier;
 
-    public void setConsumer(LogLtrRanker.LogConsumer consumer) {
-        this.consumer = consumer;
+    public void setSupplier(Supplier<Map<String,Object>> supplier) {
+        this.supplier = supplier;
     }
 
     /**
@@ -20,8 +18,8 @@ public class ExtraLoggingSupplier implements Supplier<Map<String,Object>> {
      */
     @Override
     public Map<String, Object> get() {
-        if (consumer != null) {
-            return consumer.getExtraLoggingMap();
+        if (supplier != null) {
+            return supplier.get();
         }
         return null;
     }

--- a/src/main/java/com/o19s/es/ltr/feature/store/ScriptFeature.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/ScriptFeature.java
@@ -4,6 +4,7 @@ import com.o19s.es.ltr.LtrQueryContext;
 import com.o19s.es.ltr.feature.Feature;
 import com.o19s.es.ltr.feature.FeatureSet;
 import com.o19s.es.ltr.query.LtrRewritableQuery;
+import com.o19s.es.ltr.ranker.LogLtrRanker;
 import com.o19s.es.ltr.ranker.LtrRanker;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
@@ -37,6 +38,7 @@ import java.util.stream.Collectors;
 public class ScriptFeature implements Feature {
     public static final String TEMPLATE_LANGUAGE = "script_feature";
     public static final String FEATURE_VECTOR = "feature_vector";
+    public static final String EXTRA_LOGGING = "extra_logging";
     public static final String EXTRA_SCRIPT_PARAMS = "extra_script_params";
 
     private final String name;
@@ -109,11 +111,13 @@ public class ScriptFeature implements Feature {
 
 
         FeatureSupplier supplier = new FeatureSupplier(featureSet);
+        ExtraLoggingSupplier extraLoggingSupplier = new ExtraLoggingSupplier();
         Map<String, Object> nparams = new HashMap<>();
         nparams.putAll(baseScriptParams);
         nparams.putAll(queryTimeParams);
         nparams.putAll(extraQueryTimeParams);
         nparams.put(FEATURE_VECTOR, supplier);
+        nparams.put(EXTRA_LOGGING, extraLoggingSupplier);
         Script script = new Script(this.script.getType(), this.script.getLang(),
             this.script.getIdOrCode(), this.script.getOptions(), nparams);
         ScoreScript.Factory factoryFactory  = context.getQueryShardContext().getScriptService().compile(script, ScoreScript.CONTEXT);
@@ -122,15 +126,17 @@ public class ScriptFeature implements Feature {
                 context.getQueryShardContext().index().getName(),
                 context.getQueryShardContext().getShardId(),
                 context.getQueryShardContext().indexVersionCreated());
-        return new LtrScript(function, supplier);
+        return new LtrScript(function, supplier, extraLoggingSupplier);
     }
 
     static class LtrScript extends Query implements LtrRewritableQuery {
         private final ScriptScoreFunction function;
         private final FeatureSupplier supplier;
-        LtrScript(ScriptScoreFunction function, FeatureSupplier supplier) {
+        private final ExtraLoggingSupplier extraLoggingSupplier;
+        LtrScript(ScriptScoreFunction function, FeatureSupplier supplier, ExtraLoggingSupplier extraLoggingSupplier) {
             this.function = function;
             this.supplier = supplier;
+            this.extraLoggingSupplier = extraLoggingSupplier;
         }
 
         @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
@@ -161,8 +167,15 @@ public class ScriptFeature implements Feature {
         }
 
         @Override
-        public Query ltrRewrite(Supplier<LtrRanker.FeatureVector> vectorSupplier) throws IOException {
+        public Query ltrRewrite(Supplier<LtrRanker.FeatureVector> vectorSupplier,
+                                LtrRanker ranker) throws IOException {
             supplier.set(vectorSupplier);
+
+            LogLtrRanker.LogConsumer consumer = null;
+            if (ranker instanceof LogLtrRanker) {
+                consumer = ((LogLtrRanker)ranker).getLogConsumer();
+            }
+            extraLoggingSupplier.setConsumer(consumer);
             return this;
         }
     }

--- a/src/main/java/com/o19s/es/ltr/feature/store/ScriptFeature.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/ScriptFeature.java
@@ -4,8 +4,8 @@ import com.o19s.es.ltr.LtrQueryContext;
 import com.o19s.es.ltr.feature.Feature;
 import com.o19s.es.ltr.feature.FeatureSet;
 import com.o19s.es.ltr.query.LtrRewritableQuery;
+import com.o19s.es.ltr.query.LtrRewriteContext;
 import com.o19s.es.ltr.ranker.LogLtrRanker;
-import com.o19s.es.ltr.ranker.LtrRanker;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocIdSetIterator;
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 public class ScriptFeature implements Feature {
@@ -167,15 +166,15 @@ public class ScriptFeature implements Feature {
         }
 
         @Override
-        public Query ltrRewrite(Supplier<LtrRanker.FeatureVector> vectorSupplier,
-                                LtrRanker ranker) throws IOException {
-            supplier.set(vectorSupplier);
+        public Query ltrRewrite(LtrRewriteContext context) throws IOException {
+            supplier.set(context.getFeatureVectorSupplier());
 
-            LogLtrRanker.LogConsumer consumer = null;
-            if (ranker instanceof LogLtrRanker) {
-                consumer = ((LogLtrRanker)ranker).getLogConsumer();
+            LogLtrRanker.LogConsumer consumer = context.getLogConsumer();
+            if (consumer != null) {
+                extraLoggingSupplier.setSupplier(consumer::getExtraLoggingMap);
+            } else {
+                extraLoggingSupplier.setSupplier(() -> null);
             }
-            extraLoggingSupplier.setConsumer(consumer);
             return this;
         }
     }

--- a/src/main/java/com/o19s/es/ltr/logging/LoggingFetchSubPhase.java
+++ b/src/main/java/com/o19s/es/ltr/logging/LoggingFetchSubPhase.java
@@ -203,6 +203,8 @@ public class LoggingFetchSubPhase implements FetchSubPhase {
         }
 
         private void rebuild() {
+            // Allocate one Map per feature, plus one placeholder for an extra logging Map
+            // that will only be added if used.
             List<Map<String, Object>> ini = new ArrayList<>(set.size() + 1);
 
             for (int i = 0; i < set.size(); i++) {
@@ -233,7 +235,7 @@ public class LoggingFetchSubPhase implements FetchSubPhase {
         public Map<String,Object> getExtraLoggingMap() {
             if (extraLogging == null) {
                 extraLogging = new HashMap<>();
-                Map<String,Object> logEntry = new HashMap<>(2);
+                Map<String,Object> logEntry = new HashMap<>();
                 logEntry.put("name", EXTRA_LOGGING_NAME);
                 logEntry.put("value", extraLogging);
                 currentLog.add(logEntry);

--- a/src/main/java/com/o19s/es/ltr/query/DerivedExpressionQuery.java
+++ b/src/main/java/com/o19s/es/ltr/query/DerivedExpressionQuery.java
@@ -66,7 +66,8 @@ public class DerivedExpressionQuery extends Query implements LtrRewritableQuery 
     }
 
     @Override
-    public Query ltrRewrite(Supplier<LtrRanker.FeatureVector> vectorSuppler) {
+    public Query ltrRewrite(Supplier<LtrRanker.FeatureVector> vectorSuppler,
+                            LtrRanker ranker) {
         return new FVDerivedExpressionQuery(this, vectorSuppler);
     }
 

--- a/src/main/java/com/o19s/es/ltr/query/DerivedExpressionQuery.java
+++ b/src/main/java/com/o19s/es/ltr/query/DerivedExpressionQuery.java
@@ -66,9 +66,8 @@ public class DerivedExpressionQuery extends Query implements LtrRewritableQuery 
     }
 
     @Override
-    public Query ltrRewrite(Supplier<LtrRanker.FeatureVector> vectorSuppler,
-                            LtrRanker ranker) {
-        return new FVDerivedExpressionQuery(this, vectorSuppler);
+    public Query ltrRewrite(LtrRewriteContext context) {
+        return new FVDerivedExpressionQuery(this, context.getFeatureVectorSupplier());
     }
 
     @Override

--- a/src/main/java/com/o19s/es/ltr/query/LtrRewritableQuery.java
+++ b/src/main/java/com/o19s/es/ltr/query/LtrRewritableQuery.java
@@ -10,5 +10,6 @@ public interface LtrRewritableQuery {
     /**
      * Rewrite the query so that it holds the vectorSupplier
      */
-    Query ltrRewrite(Supplier<LtrRanker.FeatureVector> vectorSuppler) throws IOException;
+    Query ltrRewrite(Supplier<LtrRanker.FeatureVector> vectorSuppler,
+                     LtrRanker ranker) throws IOException;
 }

--- a/src/main/java/com/o19s/es/ltr/query/LtrRewritableQuery.java
+++ b/src/main/java/com/o19s/es/ltr/query/LtrRewritableQuery.java
@@ -1,15 +1,12 @@
 package com.o19s.es.ltr.query;
 
-import com.o19s.es.ltr.ranker.LtrRanker;
 import org.apache.lucene.search.Query;
 
 import java.io.IOException;
-import java.util.function.Supplier;
 
 public interface LtrRewritableQuery {
     /**
-     * Rewrite the query so that it holds the vectorSupplier
+     * Rewrite the query so that it holds the vectorSupplier and provide extra logging support
      */
-    Query ltrRewrite(Supplier<LtrRanker.FeatureVector> vectorSuppler,
-                     LtrRanker ranker) throws IOException;
+    Query ltrRewrite(LtrRewriteContext context) throws IOException;
 }

--- a/src/main/java/com/o19s/es/ltr/query/LtrRewriteContext.java
+++ b/src/main/java/com/o19s/es/ltr/query/LtrRewriteContext.java
@@ -1,0 +1,35 @@
+package com.o19s.es.ltr.query;
+
+import com.o19s.es.ltr.ranker.LogLtrRanker;
+import com.o19s.es.ltr.ranker.LtrRanker;
+
+import java.util.function.Supplier;
+
+/**
+ * Contains context needed to rewrite queries to holds the vectorSupplier and provide extra logging support
+ */
+public class LtrRewriteContext {
+    private final Supplier<LtrRanker.FeatureVector> vectorSupplier;
+    private final LtrRanker ranker;
+
+    public LtrRewriteContext(LtrRanker ranker, Supplier<LtrRanker.FeatureVector> vectorSupplier) {
+        this.ranker = ranker;
+        this.vectorSupplier = vectorSupplier;
+    }
+
+    public Supplier<LtrRanker.FeatureVector> getFeatureVectorSupplier() {
+        return vectorSupplier;
+    }
+
+    /**
+     * Get LogConsumer used during the LoggingFetchSubPhase
+     *
+     * The returned consumer will only be non-null during the logging fetch phase
+     */
+    public LogLtrRanker.LogConsumer getLogConsumer() {
+        if (ranker instanceof LogLtrRanker) {
+            return ((LogLtrRanker)ranker).getLogConsumer();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/o19s/es/ltr/query/RankerQuery.java
+++ b/src/main/java/com/o19s/es/ltr/query/RankerQuery.java
@@ -196,7 +196,7 @@ public class RankerQuery extends Query {
         FVLtrRankerWrapper ltrRankerWrapper = new FVLtrRankerWrapper(ranker, vectorSupplier);
         for (Query q : queries) {
             if (q instanceof LtrRewritableQuery) {
-                q = ((LtrRewritableQuery)q).ltrRewrite(vectorSupplier);
+                q = ((LtrRewritableQuery)q).ltrRewrite(vectorSupplier, ranker);
             }
             weights.add(searcher.createWeight(q, ScoreMode.COMPLETE, boost));
         }

--- a/src/main/java/com/o19s/es/ltr/query/RankerQuery.java
+++ b/src/main/java/com/o19s/es/ltr/query/RankerQuery.java
@@ -194,9 +194,10 @@ public class RankerQuery extends Query {
         // Hopefully elastic never runs
         MutableSupplier<LtrRanker.FeatureVector> vectorSupplier = new Suppliers.FeatureVectorSupplier();
         FVLtrRankerWrapper ltrRankerWrapper = new FVLtrRankerWrapper(ranker, vectorSupplier);
+        LtrRewriteContext context = new LtrRewriteContext(ranker, vectorSupplier);
         for (Query q : queries) {
             if (q instanceof LtrRewritableQuery) {
-                q = ((LtrRewritableQuery)q).ltrRewrite(vectorSupplier, ranker);
+                q = ((LtrRewritableQuery)q).ltrRewrite(context);
             }
             weights.add(searcher.createWeight(q, ScoreMode.COMPLETE, boost));
         }

--- a/src/main/java/com/o19s/es/ltr/ranker/LogLtrRanker.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/LogLtrRanker.java
@@ -16,6 +16,8 @@
 
 package com.o19s.es.ltr.ranker;
 
+import java.util.Map;
+
 public class LogLtrRanker implements LtrRanker {
     private final LogConsumer logger;
     private final LtrRanker ranker;
@@ -79,9 +81,14 @@ public class LogLtrRanker implements LtrRanker {
         }
     }
 
+    public LogConsumer getLogConsumer() {
+        return logger;
+    }
+
     @FunctionalInterface
     public interface LogConsumer {
         void accept(int featureOrdinal, float score);
+        default Map<String,Object> getExtraLoggingMap() {return null;}
         default void reset() {}
     }
 }

--- a/src/test/java/com/o19s/es/ltr/feature/store/ExtraLoggingSupplierTests.java
+++ b/src/test/java/com/o19s/es/ltr/feature/store/ExtraLoggingSupplierTests.java
@@ -14,11 +14,17 @@ public class ExtraLoggingSupplierTests extends LuceneTestCase {
 
     public void testGetWillNullConsumerSet() {
         ExtraLoggingSupplier supplier = new ExtraLoggingSupplier();
-        supplier.setConsumer(null);
+        supplier.setSupplier(null);
         assertNull(supplier.get());
     }
 
-    public void testGetWithConsumerSet() {
+    public void testGetWithSuppliedNull() {
+        ExtraLoggingSupplier supplier = new ExtraLoggingSupplier();
+        supplier.setSupplier(() -> null);
+        assertNull(supplier.get());
+    }
+
+    public void testGetWithSuppliedMap() {
         Map<String,Object> extraLoggingMap = new HashMap<>();
 
         LogLtrRanker.LogConsumer consumer = new LogLtrRanker.LogConsumer() {
@@ -32,7 +38,7 @@ public class ExtraLoggingSupplierTests extends LuceneTestCase {
         };
 
         ExtraLoggingSupplier supplier = new ExtraLoggingSupplier();
-        supplier.setConsumer(consumer);
+        supplier.setSupplier(consumer::getExtraLoggingMap);
         assertTrue(supplier.get() == extraLoggingMap);
     }
 }

--- a/src/test/java/com/o19s/es/ltr/feature/store/ExtraLoggingSupplierTests.java
+++ b/src/test/java/com/o19s/es/ltr/feature/store/ExtraLoggingSupplierTests.java
@@ -1,0 +1,38 @@
+package com.o19s.es.ltr.feature.store;
+
+import com.o19s.es.ltr.ranker.LogLtrRanker;
+import org.apache.lucene.util.LuceneTestCase;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ExtraLoggingSupplierTests extends LuceneTestCase {
+    public void testGetWithConsumerNotSet() {
+        ExtraLoggingSupplier supplier = new ExtraLoggingSupplier();
+        assertNull(supplier.get());
+    }
+
+    public void testGetWillNullConsumerSet() {
+        ExtraLoggingSupplier supplier = new ExtraLoggingSupplier();
+        supplier.setConsumer(null);
+        assertNull(supplier.get());
+    }
+
+    public void testGetWithConsumerSet() {
+        Map<String,Object> extraLoggingMap = new HashMap<>();
+
+        LogLtrRanker.LogConsumer consumer = new LogLtrRanker.LogConsumer() {
+            @Override
+            public void accept(int featureOrdinal, float score) {}
+
+            @Override
+            public Map<String,Object> getExtraLoggingMap() {
+                return extraLoggingMap;
+            }
+        };
+
+        ExtraLoggingSupplier supplier = new ExtraLoggingSupplier();
+        supplier.setConsumer(consumer);
+        assertTrue(supplier.get() == extraLoggingMap);
+    }
+}


### PR DESCRIPTION
We have had some inconvenience with using logging and our native scripts. For some of our feature extractors, we care about not only the final feature value, but also some 'base' feature(s) used/generated during the computation.

Currently, it would be possible to create an LTR feature for each of these 'base' features, then derive the true feature needed for model evaluation. However, this does not work for all of our uses because:
1) We cannot efficiently cache doc value lookups/intermediate computations across features
2) The 'base' features are not necessarily numeric
3) The Scorer interface requires that all these 'base' features be non-negative, which can be challenging

This branch is an attempt to mitigate some of these issues by allowing native scripts to add arbitrary logging information into an extra_logging map. The map is made available during the LoggingFetchSubPhase through a Supplier provided as a parameter.

The map is String -> Object, allowing for structured and non-numeric data. The map is created on first use by a script and results in an additional entry in the hits' logging:
```
{
  "name": "extra_logging",
  "value": <json serialized map>
}
```
If unused, this entry will not appear at all.

Let me know if this approach seems reasonable, or if there is a better way to go about this.