### PR TITLE
Closes #269 - Enabling shard request cache

### DIFF
--- a/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
+++ b/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
@@ -233,7 +233,8 @@ public class LtrQueryParserPlugin extends Plugin implements SearchPlugin, Script
     }
 
     protected FeatureStoreLoader getFeatureStoreLoader() {
-        return (storeName, client) -> new CachedFeatureStore(new IndexFeatureStore(storeName, client, parserFactory), caches);
+        return (storeName, clientSupplier) ->
+            new CachedFeatureStore(new IndexFeatureStore(storeName, clientSupplier, parserFactory), caches);
     }
 
     // A simplified version of some token filters needed by the feature stores.

--- a/src/main/java/com/o19s/es/ltr/feature/store/index/IndexFeatureStore.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/index/IndexFeatureStore.java
@@ -94,12 +94,12 @@ public class IndexFeatureStore implements FeatureStore {
     }
 
     private final String index;
-    private final Client client;
+    private final Supplier<Client> clientSupplier;
     private final LtrRankerParserFactory parserFactory;
 
-    public IndexFeatureStore(String index, Client client, LtrRankerParserFactory factory) {
+    public IndexFeatureStore(String index, Supplier<Client> clientSupplier, LtrRankerParserFactory factory) {
         this.index = Objects.requireNonNull(index);
-        this.client = Objects.requireNonNull(client);
+        this.clientSupplier = Objects.requireNonNull(clientSupplier);
         this.parserFactory = Objects.requireNonNull(factory);
     }
 
@@ -189,7 +189,7 @@ public class IndexFeatureStore implements FeatureStore {
     }
 
     private Supplier<GetResponse> internalGet(String id) {
-        return () -> client.prepareGet(index, ES_TYPE, id).get();
+        return () -> clientSupplier.get().prepareGet(index, ES_TYPE, id).get();
     }
 
     /**

--- a/src/main/java/com/o19s/es/ltr/query/StoredLtrQueryBuilder.java
+++ b/src/main/java/com/o19s/es/ltr/query/StoredLtrQueryBuilder.java
@@ -155,7 +155,7 @@ public class StoredLtrQueryBuilder extends AbstractQueryBuilder<StoredLtrQueryBu
     @Override
     protected RankerQuery doToQuery(QueryShardContext context) throws IOException {
         String indexName = storeName != null ? IndexFeatureStore.indexName(storeName) : IndexFeatureStore.DEFAULT_STORE;
-        FeatureStore store = storeLoader.load(indexName, context.getClient());
+        FeatureStore store = storeLoader.load(indexName, context::getClient);
         LtrQueryContext ltrQueryContext = new LtrQueryContext(context,
                 activeFeatures == null ? Collections.emptySet() : new HashSet<>(activeFeatures));
         if (modelName != null) {

--- a/src/main/java/com/o19s/es/ltr/utils/FeatureStoreLoader.java
+++ b/src/main/java/com/o19s/es/ltr/utils/FeatureStoreLoader.java
@@ -17,9 +17,10 @@
 package com.o19s.es.ltr.utils;
 
 import com.o19s.es.ltr.feature.store.FeatureStore;
+import java.util.function.Supplier;
 import org.elasticsearch.client.Client;
 
 @FunctionalInterface
 public interface FeatureStoreLoader {
-    FeatureStore load(String storeName, Client client);
+    FeatureStore load(String storeName, Supplier<Client> clientSupplier);
 }

--- a/src/test/java/com/o19s/es/ltr/action/BaseIntegrationTest.java
+++ b/src/test/java/com/o19s/es/ltr/action/BaseIntegrationTest.java
@@ -98,7 +98,7 @@ public abstract class BaseIntegrationTest extends ESSingleNodeTestCase {
     }
 
     public <E extends StorableElement> E getElement(Class<E> clazz, String type, String name, String store) throws IOException {
-        return new IndexFeatureStore(store, client(), parserFactory()).getAndParse(name, clazz, type);
+        return new IndexFeatureStore(store, this::client, parserFactory()).getAndParse(name, clazz, type);
     }
 
     protected LtrRankerParserFactory parserFactory() {

--- a/src/test/java/com/o19s/es/ltr/query/StoredLtrQueryBuilderTests.java
+++ b/src/test/java/com/o19s/es/ltr/query/StoredLtrQueryBuilderTests.java
@@ -223,7 +223,7 @@ public class StoredLtrQueryBuilderTests extends AbstractQueryTestCase<StoredLtrQ
         assert context.isCacheable();
         QueryBuilder rewritten = rewriteQuery(queryBuilder, new QueryShardContext(context));
         assertNotNull(rewritten.toQuery(context));
-        assertFalse("query should not be cacheable: " + queryBuilder.toString(), context.isCacheable());
+        assertTrue("query should be cacheable: " + queryBuilder.toString(), context.isCacheable());
     }
 
     // Hack to inject our MemStore


### PR DESCRIPTION
# What is it?

As reported by this issue: #269.

Today the plugin is not using the [shard request cache](https://www.elastic.co/guide/en/elasticsearch/reference/current/shard-request-cache.html#shard-request-cache) due to this method call `context.getClient()` on `StoredLtrQueryBuilder` class which makes the Elasticsearch set the request as non-cacheable.

This PR proposes to avoid calling this method on every request so ElasticSearch can cache requisitions.

After simulating some load-tests, we have the following results:

- Plugin not using shard request cache:
![Screen Shot 2020-02-13 at 11 53 14](https://user-images.githubusercontent.com/17990126/74447233-cf952200-4e57-11ea-8993-3158d53ff4d1.png)

- Plugin using shard request cache:
![Screen Shot 2020-02-13 at 11 57 11](https://user-images.githubusercontent.com/17990126/74447389-0b2fec00-4e58-11ea-8081-1a321cf986f4.png)

Those tests ran against different types of queries, rescoring 5000 documents using an XGboost model. Analyzing the results we can see an improvement of 40% on throughput.
