### PR TITLE
Fix raw_tf in match_explorer

### DIFF
--- a/docs/feature-engineering.rst
+++ b/docs/feature-engineering.rst
@@ -33,6 +33,7 @@ The statistics available include:
 - :code:`raw_df` -- the direct document frequency for a term. So if rambo occurs in 3 movie titles, this is 3.
 - :code:`classic_idf` -- the IDF calculation of the classic similarity :code:`log((NUM_DOCS+1)/(raw_df+1)) + 1`.
 - :code:`raw_ttf` -- the total term frequency for the term across the index. So if rambo is mentioned a total of 100 times in the overview field, this would be 100.
+- :code:`raw_tf` -- the term frequency for a document. So if rambo occurs in 3 in movie synopsis in same document, this is 3.
 
 Putting the operation and the statistic together, you can see some examples. To get stddev of classic_idf, you would write :code:`stddev_classic_idf`. To get the minimum total term frequency, you'd write :code:`min_raw_ttf`.
 

--- a/src/main/java/com/o19s/es/explore/ExplorerQuery.java
+++ b/src/main/java/com/o19s/es/explore/ExplorerQuery.java
@@ -247,16 +247,16 @@ public class ExplorerQuery extends Query {
 
             // This impl always scores docs in order, so we can
             // ignore scoreDocsInOrder:
-            return new LalaDefaultBulkScorer(scorer);
+            return new ExplorerDefaultBulkScorer(scorer);
         }
 
-        protected static class LalaDefaultBulkScorer extends BulkScorer {
+        protected static class ExplorerDefaultBulkScorer extends BulkScorer {
             private final Scorer scorer;
             private final DocIdSetIterator iterator;
             private final TwoPhaseIterator twoPhase;
 
             /** Sole constructor. */
-            public LalaDefaultBulkScorer(Scorer scorer) {
+            public ExplorerDefaultBulkScorer(Scorer scorer) {
                 if (scorer == null) {
                     throw new NullPointerException();
                 }

--- a/src/main/java/com/o19s/es/explore/ExplorerQuery.java
+++ b/src/main/java/com/o19s/es/explore/ExplorerQuery.java
@@ -366,6 +366,9 @@ public class ExplorerQuery extends Query {
         @Override
         public Scorer scorer(LeafReaderContext context) throws IOException {
             Scorer subscorer = weight.scorer(context);
+            if (subscorer == null) {
+                return null;
+            }
             return new ExplorerScorer(weight, type, subscorer);
         }
     }

--- a/src/main/java/com/o19s/es/explore/ExplorerQuery.java
+++ b/src/main/java/com/o19s/es/explore/ExplorerQuery.java
@@ -20,19 +20,23 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.TermStates;
-import org.apache.lucene.search.BooleanClause;
-import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.ConstantScoreScorer;
-import org.apache.lucene.search.ConstantScoreWeight;
-import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.Explanation;
-import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
-import org.apache.lucene.search.Scorer;
-import org.apache.lucene.search.TermStatistics;
+import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Weight;
+import org.apache.lucene.search.TermStatistics;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.ConstantScoreScorer;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BulkScorer;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.TwoPhaseIterator;
+import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.similarities.ClassicSimilarity;
+import org.apache.lucene.util.Bits;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -230,6 +234,113 @@ public class ExplorerQuery extends Query {
         @Override
         public void extractTerms(Set<Term> terms) {
             weight.extractTerms(terms);
+        }
+
+        @Override
+        public BulkScorer bulkScorer(LeafReaderContext context) throws IOException {
+
+            Scorer scorer = scorer(context);
+            if (scorer == null) {
+                // No docs match
+                return null;
+            }
+
+            // This impl always scores docs in order, so we can
+            // ignore scoreDocsInOrder:
+            return new LalaDefaultBulkScorer(scorer);
+        }
+
+        protected static class LalaDefaultBulkScorer extends BulkScorer {
+            private final Scorer scorer;
+            private final DocIdSetIterator iterator;
+            private final TwoPhaseIterator twoPhase;
+
+            /** Sole constructor. */
+            public LalaDefaultBulkScorer(Scorer scorer) {
+                if (scorer == null) {
+                    throw new NullPointerException();
+                }
+                this.scorer = scorer;
+                this.iterator = scorer.iterator();
+                this.twoPhase = scorer.twoPhaseIterator();
+            }
+
+            @Override
+            public long cost() {
+                return iterator.cost();
+            }
+
+            @Override
+            public int score(LeafCollector collector, Bits acceptDocs, int min, int max) throws IOException {
+                try {
+                    collector.setScorer(scorer);
+                    if (scorer.docID() == -1 && min == 0 && max == DocIdSetIterator.NO_MORE_DOCS) {
+                        scoreAll(collector, iterator, twoPhase, acceptDocs);
+                        return DocIdSetIterator.NO_MORE_DOCS;
+                    } else {
+                        int doc = scorer.docID();
+                        if (doc < min) {
+                            if (twoPhase == null) {
+                                doc = iterator.advance(min);
+                            } else {
+                                doc = twoPhase.approximation().advance(min);
+                            }
+                        }
+                        return scoreRange(collector, iterator, twoPhase, acceptDocs, doc, max);
+                    }
+                }catch (Exception e ) {
+                    return 0;
+                }
+            }
+
+            /** Specialized method to bulk-score a range of hits; we
+             *  separate this from {@link #scoreAll} to help out
+             *  hotspot.
+             *  See <a href="https://issues.apache.org/jira/browse/LUCENE-5487">LUCENE-5487</a> */
+            static int scoreRange(LeafCollector collector, DocIdSetIterator iterator, TwoPhaseIterator twoPhase,
+                                  Bits acceptDocs, int currentDoc, int end) throws IOException {
+                if (twoPhase == null) {
+                    while (currentDoc < end) {
+                        if (acceptDocs == null || acceptDocs.get(currentDoc)) {
+                            collector.collect(currentDoc);
+                        }
+                        currentDoc = iterator.nextDoc();
+                    }
+                    return currentDoc;
+                } else {
+                    final DocIdSetIterator approximation = twoPhase.approximation();
+                    while (currentDoc < end) {
+                        if ((acceptDocs == null || acceptDocs.get(currentDoc)) && twoPhase.matches()) {
+                            collector.collect(currentDoc);
+                        }
+                        currentDoc = approximation.nextDoc();
+                    }
+                    return currentDoc;
+                }
+            }
+
+            /** Specialized method to bulk-score all hits; we
+             *  separate this from {@link #scoreRange} to help out
+             *  hotspot.
+             *  See <a href="https://issues.apache.org/jira/browse/LUCENE-5487">LUCENE-5487</a> */
+            static void scoreAll(LeafCollector collector, DocIdSetIterator iterator,
+                                 TwoPhaseIterator twoPhase, Bits acceptDocs) throws IOException {
+                if (twoPhase == null) {
+                    for (int doc = iterator.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = iterator.nextDoc()) {
+                        if (acceptDocs == null || acceptDocs.get(doc)) {
+                            collector.collect(doc);
+                        }
+                    }
+                } else {
+                    // The scorer has an approximation, so run the approximation first, then check acceptDocs, then confirm
+                    final DocIdSetIterator approximation = twoPhase.approximation();
+                    for (int doc = approximation.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = approximation.nextDoc()) {
+                        if ((acceptDocs == null || acceptDocs.get(doc)) && twoPhase.matches()) {
+                            collector.collect(doc);
+                        }
+                    }
+                }
+            }
         }
 
         @Override

--- a/src/main/java/com/o19s/es/explore/ExplorerScorer.java
+++ b/src/main/java/com/o19s/es/explore/ExplorerScorer.java
@@ -81,7 +81,11 @@ public class ExplorerScorer extends Scorer {
 
     @Override
     public DocIdSetIterator iterator() {
-        return subScorer.iterator();
+        try {
+            return subScorer.iterator();
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/com/o19s/es/explore/ExplorerScorer.java
+++ b/src/main/java/com/o19s/es/explore/ExplorerScorer.java
@@ -81,11 +81,7 @@ public class ExplorerScorer extends Scorer {
 
     @Override
     public DocIdSetIterator iterator() {
-        try {
-            return subScorer.iterator();
-        } catch (Exception e) {
-            return null;
-        }
+        return subScorer.iterator();
     }
 
     /**

--- a/src/test/java/com/o19s/es/explore/ExplorerQueryTests.java
+++ b/src/test/java/com/o19s/es/explore/ExplorerQueryTests.java
@@ -93,6 +93,17 @@ public class ExplorerQueryTests extends LuceneTestCase {
         assertThat(explanation.toString().trim(), equalTo("1.0 = Stat Score: sum_raw_tf"));
     }
 
+    public void testQueryWithEmptyResults() throws Exception {
+        Query q = new TermQuery(new Term("text", "xxxxxxxxxxxxxxxxxx"));
+
+        String statsType = "sum_raw_tf";
+
+        ExplorerQuery eq = new ExplorerQuery(q, statsType);
+
+        // Basic query check, should match 2 docs
+        assertThat(searcher.count(eq), equalTo(0));
+    }
+
     public void testBooleanQuery() throws Exception {
         TermQuery tq1 = new TermQuery(new Term("text", "cow"));
         TermQuery tq2 = new TermQuery(new Term("text", "brown"));

--- a/src/test/java/com/o19s/es/explore/ExplorerQueryTests.java
+++ b/src/test/java/com/o19s/es/explore/ExplorerQueryTests.java
@@ -100,8 +100,12 @@ public class ExplorerQueryTests extends LuceneTestCase {
 
         ExplorerQuery eq = new ExplorerQuery(q, statsType);
 
-        // Basic query check, should match 2 docs
+        // Basic query check, should match 0 docs
         assertThat(searcher.count(eq), equalTo(0));
+
+        // Verify explain
+        TopDocs docs = searcher.search(eq, 4);
+        assertThat(docs.scoreDocs.length, equalTo(0));
     }
 
     public void testBooleanQuery() throws Exception {


### PR DESCRIPTION
Refer: #155 

When you create some feature using the `raw_tf` sometimes when term does not exist in a document we have a null pointer exception. Example:

```
# create feature
POST _ltr/_featureset/some_cool_features
{
  "featureset": {
    "name": "some_cool_features",
    "features": [
      {
        "name": "sum_raw_tf_text",
        "params": [
          "keywords"
        ],
        "template_language": "mustache",
        "template": {
          "match_explorer": {
            "type": "sum_raw_tf",
            "query": {
              "match": {
                "text": "{{keywords}}"
              }
            }
          }
        }
      }
    ]
  }
}

# test features
curl -H 'content-type:application/json' -X POST http://localhost:9200/*_ltr/_search -d '{
  "_source": ["_ltrlog.main"],
  "query": {
    "bool": {
      "filter": [
        {
          "terms": {
            "_id": [
              "165241254"
            ]
          }
        }
      ],
      "should": [
        {
          "sltr": {
            "_name": "some_cool_features",
            "featureset": "some_cool_features",
            "params": {
              "keywords": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
            }
          }
        }
      ]
    }
  },
  "ext": {
    "ltr_log": {
      "log_specs": {
        "name": "main",
        "named_query": "some_cool_features",
        "missing_as_zero": true
      }
    }
  }
}' | jq
```

