### PR TITLE
Compatibility with ES v7.6.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,12 +6,12 @@ buildscript {
   }
 
   dependencies {
-    classpath "org.elasticsearch.gradle:build-tools:7.6.0"
+    classpath "org.elasticsearch.gradle:build-tools:7.6.1"
   }
 }
 
 group = 'com.o19s'
-version = '1.2.0-es7.6.0'
+version = '1.2.0-es7.6.1'
 
 apply plugin: 'java'
 apply plugin: 'idea'
@@ -53,10 +53,10 @@ dependencies {
   compile 'org.ow2.asm:asm:5.0.4'
   compile 'org.ow2.asm:asm-commons:5.0.4'
   compile 'org.ow2.asm:asm-tree:5.0.4'
-  compile 'org.elasticsearch:elasticsearch:7.6.0'
+  compile 'org.elasticsearch:elasticsearch:7.6.1'
   compile 'com.o19s:RankyMcRankFace:0.1.1'
   compile "com.github.spullara.mustache.java:compiler:0.9.3"
-  testCompile 'org.elasticsearch.test:framework:7.6.0'
+  testCompile 'org.elasticsearch.test:framework:7.6.1'
 }
 
 dependencyLicenses {

--- a/src/main/java/com/o19s/es/ltr/ranker/ranklib/RankLibScriptEngine.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/ranklib/RankLibScriptEngine.java
@@ -98,6 +98,6 @@ public class RankLibScriptEngine implements ScriptEngine {
             return _ranker;
         }
 
-
+        public void execute () {}
     }
 }


### PR DESCRIPTION
Makes the plugin compatible with ES 7.6.1
- [x] Update library dependencies to elasticsearch 7.6.1
- [x] Fix failing test due to missing `RankLibModelContainer::execute()` method