### PR TITLE
Add support for query time parameters for ScriptFeature term statistics

### DIFF
--- a/docs/advanced-functionality.rst
+++ b/docs/advanced-functionality.rst
@@ -280,6 +280,8 @@ Also you can limit the information to a single node in the cluster::
 TermStat Query
 =============================
 
+**Experimental** - This query is currently in an experimental stage and the DSL may change as the code advances.  For stable term statistic access please see the `ExplorerQuery`.
+
 The :code:`TermStatQuery` is a re-imagination of the legacy :code:`ExplorerQuery` which offers clearer specification of terms and more freedom to experiment.  This query surfaces the same data as the `ExplorerQuery` but it allows the user to specify a custom Lucene expression for the type of data they would like to retrieve.  For example::
 
     POST tmdb/_search

--- a/docs/advanced-functionality.rst
+++ b/docs/advanced-functionality.rst
@@ -309,6 +309,7 @@ Supported aggregation types are:
 - :code:`min` -- the minimum 
 - :code:`max` -- the maximum
 - :code:`avg` -- the mean
+- :code:`sum` -- the sum
 - :code:`stddev` -- the standard deviation 
 
 The :code:`terms` parameter is array of terms to gather statistics for.  Currently only single terms are supported, there is not support for phrases or span queries. Note: If your field is tokenized you can pass multiple terms in one string in the array.

--- a/docs/advanced-functionality.rst
+++ b/docs/advanced-functionality.rst
@@ -341,6 +341,7 @@ You have the following options for sending in parameters to scripts.  If you alw
                "source": "params.termStats['df'].size()",
                "params": {
                  "term_stat": {
+                    "analyzer": "!standard"
                     "terms": ["rambo rocky"],
                     "fields": ["overview"]
                  }
@@ -351,7 +352,34 @@ You have the following options for sending in parameters to scripts.  If you alw
        }
     }
 
-You can also pass in parameters at query time, query time parameters will take priority over parameters saved with the script::
+    Note: Analyzer names must be prefixed with a bang(!) if specifying locally, otherwise it will treat the value as a parameter lookup.
+
+To set parameter lookups simply pass the name of the parameter to pull the value from like so::
+
+    POST _ltr/_featureset/test
+    {
+       "featureset": {
+         "features": [
+           {
+             "name": "injection",
+             "template_language": "script_feature",
+             "template": {
+               "lang": "painless",
+               "source": "params.termStats['df'].size()",
+               "params": {
+                 "term_stat": {
+                    "analyzer": "analyzerParam"
+                    "terms": "termsParam",
+                    "fields": "fieldsParam"
+                 }
+               }
+             }
+           }
+         ]
+       }
+    }
+
+The following example shows how to set the parameters at query time::
 
     POST tmdb/_search
     {
@@ -368,8 +396,9 @@ You can also pass in parameters at query time, query time parameters will take p
                             "_name": "logged_featureset",
                             "featureset": "test",
                             "params": {
-                              "terms": ["troutman"],
-                              "fields": ["overview"]
+                              "analyzerParam": "standard",
+                              "termsParam": ["troutman"],
+                              "fieldsParam": ["overview"]
                             }
                     }}
                 ]

--- a/docs/advanced-functionality.rst
+++ b/docs/advanced-functionality.rst
@@ -314,6 +314,10 @@ Supported aggregation types are:
 - :code:`sum` -- the sum
 - :code:`stddev` -- the standard deviation 
 
+Additionally the following counts are available:
+- :code:`matches` -- The number of terms that matched in the current document
+- :code:`unique` -- The unique number of terms that were passed in
+
 The :code:`terms` parameter is array of terms to gather statistics for.  Currently only single terms are supported, there is not support for phrases or span queries. Note: If your field is tokenized you can pass multiple terms in one string in the array.
 
 The :code:`fields` parameter specifies which fields to check for the specified :code:`terms`.  Note if no :code:`analyzer` is specified then we use the analyzer specified for the field.
@@ -328,6 +332,11 @@ Script Injection
 ----------------
 
 Finally, one last addition that this functionality provides is the ability to inject term statistics into a scripting context.  When working with :code:`ScriptFeatures` if you pass a :code:`term_stat` object in with the :code:`terms`, :code:`fields` and :code:`analyzer` parameters you can access the raw values directly in a custom script via an injected variable named :code:`termStats`.  This provides for advanced feature engineering when you need to look at all the data to make decisions.
+
+Scripts access matching and unique counts slightly differently than inside the TermStatQuery:
+
+To access the count of matched tokens: `params.matchCount.get()`
+To access the count of unique tokens: `params.uniqueTerms`
 
 You have the following options for sending in parameters to scripts.  If you always want to find stats about the same terms (i.e. stopwords or other common terms in your index) you can hardcode the parameters along with your script::
 

--- a/src/main/java/com/o19s/es/explore/StatisticsHelper.java
+++ b/src/main/java/com/o19s/es/explore/StatisticsHelper.java
@@ -28,7 +28,8 @@ public class StatisticsHelper {
         MAX("max"),
         MIN("min"),
         SUM("sum"),
-        STDDEV("stddev");
+        STDDEV("stddev"),
+        MATCHES("matches");
 
         private String type;
 

--- a/src/main/java/com/o19s/es/explore/StatisticsHelper.java
+++ b/src/main/java/com/o19s/es/explore/StatisticsHelper.java
@@ -27,6 +27,7 @@ public class StatisticsHelper {
         AVG("avg"),
         MAX("max"),
         MIN("min"),
+        SUM("sum"),
         STDDEV("stddev");
 
         private String type;
@@ -118,6 +119,8 @@ public class StatisticsHelper {
                 return getMax();
             case MIN:
                 return getMin();
+            case SUM:
+                return getSum();
             case STDDEV:
                 return getStdDev();
             default:

--- a/src/main/java/com/o19s/es/ltr/feature/store/ScriptFeature.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/ScriptFeature.java
@@ -132,15 +132,15 @@ public class ScriptFeature implements Feature {
             String analyzerName = (String) termspec.get("analyzer");
 
             // Support reading terms/fields from query time parameters to better support stored feature usage
-            if (termList == null && params.containsKey("terms")) {
+            if (params.containsKey("terms")) {
                 termList = (ArrayList<String>) params.get("terms");
             }
 
-            if (fields == null && params.containsKey("fields")) {
+            if (params.containsKey("fields")) {
                 fields = (ArrayList<String>) params.get("fields");
             }
 
-            if (analyzerName == null && params.containsKey("analyzer")) {
+            if (params.containsKey("analyzer")) {
                 analyzerName = (String) params.get("analyzer");
             }
 

--- a/src/main/java/com/o19s/es/ltr/feature/store/ScriptFeature.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/ScriptFeature.java
@@ -45,6 +45,8 @@ public class ScriptFeature implements Feature {
     public static final String TEMPLATE_LANGUAGE = "script_feature";
     public static final String FEATURE_VECTOR = "feature_vector";
     public static final String TERM_STAT = "termStats";
+    public static final String MATCH_COUNT = "matchCount";
+    public static final String UNIQUE_TERMS = "uniqueTerms";
     public static final String EXTRA_LOGGING = "extra_logging";
     public static final String EXTRA_SCRIPT_PARAMS = "extra_script_params";
 
@@ -171,7 +173,7 @@ public class ScriptFeature implements Feature {
             Analyzer analyzer = null;
             for(String field : fields) {
                 if (analyzerName == null) {
-                    MappedFieldType fieldType = context.getQueryShardContext().getMapperService().fieldType(field);
+                    final MappedFieldType fieldType = context.getQueryShardContext().getMapperService().fieldType(field);
                     analyzer = context.getQueryShardContext().getSearchAnalyzer(fieldType);
                 } else {
                     analyzer = context.getQueryShardContext().getIndexAnalyzers().get(analyzerName);
@@ -182,8 +184,8 @@ public class ScriptFeature implements Feature {
                 }
 
                 for (String termString : termList) {
-                    TokenStream ts = analyzer.tokenStream(field, termString);
-                    TermToBytesRefAttribute termAtt = ts.getAttribute(TermToBytesRefAttribute.class);
+                    final TokenStream ts = analyzer.tokenStream(field, termString);
+                    final TermToBytesRefAttribute termAtt = ts.getAttribute(TermToBytesRefAttribute.class);
 
                     try {
                         ts.reset();
@@ -198,6 +200,8 @@ public class ScriptFeature implements Feature {
             }
 
             nparams.put(TERM_STAT, termstatSupplier);
+            nparams.put(MATCH_COUNT, termstatSupplier.getMatchedTermCountSupplier());
+            nparams.put(UNIQUE_TERMS, terms.size());
         }
 
         nparams.putAll(baseScriptParams);

--- a/src/main/java/com/o19s/es/ltr/feature/store/ScriptFeature.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/ScriptFeature.java
@@ -44,7 +44,7 @@ import java.util.stream.Collectors;
 public class ScriptFeature implements Feature {
     public static final String TEMPLATE_LANGUAGE = "script_feature";
     public static final String FEATURE_VECTOR = "feature_vector";
-    public static final String TERM_STAT = "terms";
+    public static final String TERM_STAT = "termStats";
     public static final String EXTRA_LOGGING = "extra_logging";
     public static final String EXTRA_SCRIPT_PARAMS = "extra_script_params";
 

--- a/src/main/java/com/o19s/es/termstat/TermStatScorer.java
+++ b/src/main/java/com/o19s/es/termstat/TermStatScorer.java
@@ -89,6 +89,8 @@ public class TermStatScorer extends Scorer {
             termStatDict.put("tf", tsq.get("tf").get(i));
             termStatDict.put("tp", tsq.get("tp").get(i));
             termStatDict.put("ttf", tsq.get("ttf").get(i));
+            termStatDict.put("matches", (float) tsq.getMatchedTermCount());
+            termStatDict.put("unique", (float) terms.size());
 
             // Run the expression and store the result in computed
             DoubleValuesSource dvSrc = compiledExpression.getDoubleValuesSource(bindings);

--- a/src/main/java/com/o19s/es/termstat/TermStatSupplier.java
+++ b/src/main/java/com/o19s/es/termstat/TermStatSupplier.java
@@ -2,6 +2,7 @@ package com.o19s.es.termstat;
 
 import com.o19s.es.explore.StatisticsHelper;
 import com.o19s.es.explore.StatisticsHelper.AggrType;
+import com.o19s.es.ltr.utils.Suppliers;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.ReaderUtil;
@@ -28,10 +29,14 @@ public class TermStatSupplier extends AbstractMap<String, ArrayList<Float>>  {
     private final List<String> ACCEPTED_KEYS = Arrays.asList(new String[]{"df", "idf", "tf", "ttf", "tp"});
     private AggrType posAggrType = AggrType.AVG;
 
-    private ClassicSimilarity sim;
-    private StatisticsHelper df_stats, idf_stats, tf_stats, ttf_stats, tp_stats;
+    private final ClassicSimilarity sim;
+    private final StatisticsHelper df_stats, idf_stats, tf_stats, ttf_stats, tp_stats;
+    private final Suppliers.MutableSupplier<Integer> matchedCountSupplier;
+
+    private int matchedTermCount = 0;
 
     public TermStatSupplier() {
+        this.matchedCountSupplier = new Suppliers.MutableSupplier<>();
         this.sim = new ClassicSimilarity();
         this.df_stats = new StatisticsHelper();
         this.idf_stats = new StatisticsHelper();
@@ -48,6 +53,7 @@ public class TermStatSupplier extends AbstractMap<String, ArrayList<Float>>  {
         tf_stats.getData().clear();
         ttf_stats.getData().clear();
         tp_stats.getData().clear();
+        matchedTermCount = 0;
 
         PostingsEnum postingsEnum = null;
         for (Term term : terms) {
@@ -79,6 +85,8 @@ public class TermStatSupplier extends AbstractMap<String, ArrayList<Float>>  {
 
             // Verify document is in postings
             if (postingsEnum.advance(docID) == docID){
+                matchedTermCount++;
+
                 tf_stats.add(postingsEnum.freq());
 
                 if(postingsEnum.freq() > 0) {
@@ -97,6 +105,8 @@ public class TermStatSupplier extends AbstractMap<String, ArrayList<Float>>  {
                 tp_stats.add(0.0f);
             }
         }
+
+        matchedCountSupplier.set(matchedTermCount);
     }
 
     /**
@@ -194,6 +204,14 @@ public class TermStatSupplier extends AbstractMap<String, ArrayList<Float>>  {
                 return idf_stats.getData().size();
             }
         };
+    }
+
+    public int getMatchedTermCount() {
+        return matchedTermCount;
+    }
+
+    public Suppliers.MutableSupplier<Integer> getMatchedTermCountSupplier() {
+        return matchedCountSupplier;
     }
 
     public void setPosAggr(AggrType type) {

--- a/src/main/java/com/o19s/es/termstat/TermStatSupplier.java
+++ b/src/main/java/com/o19s/es/termstat/TermStatSupplier.java
@@ -63,6 +63,7 @@ public class TermStatSupplier extends AbstractMap<String, ArrayList<Float>>  {
             TermState state = termStates.get(context);
 
             if (state == null) {
+                insertZeroes(); // Zero out stats for terms we don't know about in the index
                 continue;
             }
 
@@ -197,6 +198,14 @@ public class TermStatSupplier extends AbstractMap<String, ArrayList<Float>>  {
 
     public void setPosAggr(AggrType type) {
         this.posAggrType = type;
+    }
+
+    private void insertZeroes() {
+        df_stats.add(0.0f);
+        idf_stats.add(0.0f);
+        tf_stats.add(0.0f);
+        ttf_stats.add(0.0f);
+        tp_stats.add(0.0f);
     }
 }
 

--- a/src/test/java/com/o19s/es/ltr/action/BaseIntegrationTest.java
+++ b/src/test/java/com/o19s/es/ltr/action/BaseIntegrationTest.java
@@ -176,9 +176,9 @@ public abstract class BaseIntegrationTest extends ESSingleNodeTestCase {
                                         @Override
                                         public double execute(ExplanationHolder explainationHolder) {
                                             // For testing purposes just look for the "terms" key and see if stats were injected
-                                            if(p.containsKey("terms")) {
+                                            if(p.containsKey("termStats")) {
                                                 AbstractMap<String, ArrayList<Float>> termStats = (AbstractMap<String,
-                                                        ArrayList<Float>>) p.get("terms");
+                                                        ArrayList<Float>>) p.get("termStats");
                                                 ArrayList<Float> dfStats = termStats.get("df");
                                                 return dfStats.size() > 0 ? dfStats.get(0) : 0.0;
                                             } else {

--- a/src/test/java/com/o19s/es/ltr/logging/LoggingIT.java
+++ b/src/test/java/com/o19s/es/ltr/logging/LoggingIT.java
@@ -101,13 +101,24 @@ public class LoggingIT extends BaseIntegrationTest {
                         LinearRankerParserTests.generateRandomModelString(set), true));
         addElement(model);
     }
-    public void prepareScriptFeatures() throws Exception {
+    public void prepareExternalScriptFeatures() throws Exception {
         List<StoredFeature> features = new ArrayList<>(3);
         features.add(new StoredFeature("test_inject", Arrays.asList(), ScriptFeature.TEMPLATE_LANGUAGE,
                 "{\"lang\": \"inject\", \"source\": \"df\", \"params\": {\"term_stat\": {} } }"));
 
         StoredFeatureSet set = new StoredFeatureSet("my_set", features);
         set.optimize();
+        addElement(set);
+    }
+
+    public void prepareInternalScriptFeatures() throws Exception {
+        List<StoredFeature> features = new ArrayList<>(3);
+        features.add(new StoredFeature("test_inject", Arrays.asList("query"), ScriptFeature.TEMPLATE_LANGUAGE,
+                "{\"lang\": \"inject\", \"source\": \"df\", \"params\": {\"term_stat\": { " +
+                        "\"terms\": [\"found\"], " +
+                        "\"fields\": [\"field1\"] } } }"));
+
+        StoredFeatureSet set = new StoredFeatureSet("my_set", features);
         addElement(set);
     }
 
@@ -325,8 +336,46 @@ public class LoggingIT extends BaseIntegrationTest {
         assertSearchHitsExtraLogging(docs, resp3);
     }
 
-    public void testScriptLog() throws Exception {
-        prepareScriptFeatures();
+    public void testScriptLogInternalParams() throws Exception {
+        prepareInternalScriptFeatures();
+        Map<String, Doc> docs = buildIndex();
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("query", "found");
+
+        List<String> idsColl = new ArrayList<>(docs.keySet());
+        Collections.shuffle(idsColl, random());
+        String[] ids = idsColl.subList(0, TestUtil.nextInt(random(), 5, 15)).toArray(new String[0]);
+        StoredLtrQueryBuilder sbuilder = new StoredLtrQueryBuilder(LtrTestUtils.nullLoader())
+                .featureSetName("my_set")
+                .params(params)
+                .queryName("test")
+                .boost(random().nextInt(3));
+
+        QueryBuilder query = QueryBuilders.boolQuery().must(new WrapperQueryBuilder(sbuilder.toString()))
+                .filter(QueryBuilders.idsQuery("test").addIds(ids));
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(query)
+                .fetchSource(false)
+                .size(10)
+                .ext(Collections.singletonList(
+                        new LoggingSearchExtBuilder()
+                                .addQueryLogging("first_log", "test", false)));
+
+        SearchResponse resp = client().prepareSearch("test_index").setTypes("test").setSource(sourceBuilder).get();
+
+        SearchHits hits = resp.getHits();
+        SearchHit testHit = hits.getAt(0);
+        Map<String, List<Map<String, Object>>> logs = testHit.getFields().get("_ltrlog").getValue();
+
+        assertTrue(logs.containsKey("first_log"));
+        List<Map<String, Object>> log = logs.get("first_log");
+
+        assertEquals(log.get(0).get("name"), "test_inject");
+        assertTrue((Float)log.get(0).get("value") > 0.0F);
+    }
+
+    public void testScriptLogExternalParams() throws Exception {
+        prepareExternalScriptFeatures();
         Map<String, Doc> docs = buildIndex();
 
         Map<String, Object> params = new HashMap<>();
@@ -368,6 +417,7 @@ public class LoggingIT extends BaseIntegrationTest {
         assertEquals(log.get(0).get("name"), "test_inject");
         assertTrue((Float)log.get(0).get("value") > 0.0F);
     }
+
 
     protected void assertSearchHits(Map<String, Doc> docs, SearchResponse resp) {
         for (SearchHit hit: resp.getHits()) {

--- a/src/test/java/com/o19s/es/ltr/logging/LoggingIT.java
+++ b/src/test/java/com/o19s/es/ltr/logging/LoggingIT.java
@@ -104,10 +104,12 @@ public class LoggingIT extends BaseIntegrationTest {
     public void prepareExternalScriptFeatures() throws Exception {
         List<StoredFeature> features = new ArrayList<>(3);
         features.add(new StoredFeature("test_inject", Arrays.asList(), ScriptFeature.TEMPLATE_LANGUAGE,
-                "{\"lang\": \"inject\", \"source\": \"df\", \"params\": {\"term_stat\": {} } }"));
+                "{\"lang\": \"inject\", \"source\": \"df\", \"params\": {\"term_stat\": { " +
+                        "\"analyzer\": \"analyzerParam\", " +
+                        "\"terms\": \"termsParam\", " +
+                        "\"fields\": \"fieldsParam\" } } }"));
 
         StoredFeatureSet set = new StoredFeatureSet("my_set", features);
-        set.optimize();
         addElement(set);
     }
 
@@ -115,7 +117,8 @@ public class LoggingIT extends BaseIntegrationTest {
         List<StoredFeature> features = new ArrayList<>(3);
         features.add(new StoredFeature("test_inject", Arrays.asList("query"), ScriptFeature.TEMPLATE_LANGUAGE,
                 "{\"lang\": \"inject\", \"source\": \"df\", \"params\": {\"term_stat\": { " +
-                        "\"terms\": [\"found\"], " +
+                        "\"analyzer\": \"!standard\", " +
+                        "\"terms\": [\"found find\"], " +
                         "\"fields\": [\"field1\"] } } }"));
 
         StoredFeatureSet set = new StoredFeatureSet("my_set", features);
@@ -380,12 +383,14 @@ public class LoggingIT extends BaseIntegrationTest {
 
         Map<String, Object> params = new HashMap<>();
         ArrayList<String> terms = new ArrayList<>();
-        terms.add("found");
-        params.put("terms", terms);
+        terms.add("found find");
+        params.put("termsParam", terms);
 
         ArrayList<String> fields = new ArrayList<>();
         fields.add("field1");
-        params.put("fields", fields);
+        params.put("fieldsParam", fields);
+
+        params.put("analyzerParam", "standard");
 
         List<String> idsColl = new ArrayList<>(docs.keySet());
         Collections.shuffle(idsColl, random());

--- a/src/test/java/com/o19s/es/ltr/logging/LoggingIT.java
+++ b/src/test/java/com/o19s/es/ltr/logging/LoggingIT.java
@@ -118,7 +118,7 @@ public class LoggingIT extends BaseIntegrationTest {
         features.add(new StoredFeature("test_inject", Arrays.asList("query"), ScriptFeature.TEMPLATE_LANGUAGE,
                 "{\"lang\": \"inject\", \"source\": \"df\", \"params\": {\"term_stat\": { " +
                         "\"analyzer\": \"!standard\", " +
-                        "\"terms\": [\"found find\"], " +
+                        "\"terms\": [\"found\"], " +
                         "\"fields\": [\"field1\"] } } }"));
 
         StoredFeatureSet set = new StoredFeatureSet("my_set", features);
@@ -383,7 +383,7 @@ public class LoggingIT extends BaseIntegrationTest {
 
         Map<String, Object> params = new HashMap<>();
         ArrayList<String> terms = new ArrayList<>();
-        terms.add("found find");
+        terms.add("found");
         params.put("termsParam", terms);
 
         ArrayList<String> fields = new ArrayList<>();

--- a/src/test/java/com/o19s/es/ltr/logging/LoggingIT.java
+++ b/src/test/java/com/o19s/es/ltr/logging/LoggingIT.java
@@ -103,12 +103,11 @@ public class LoggingIT extends BaseIntegrationTest {
     }
     public void prepareScriptFeatures() throws Exception {
         List<StoredFeature> features = new ArrayList<>(3);
-        features.add(new StoredFeature("test_inject", Arrays.asList("query"), ScriptFeature.TEMPLATE_LANGUAGE,
-                "{\"lang\": \"inject\", \"source\": \"df\", \"params\": {\"term_stat\": { " +
-                    "\"terms\": [\"found\"], " +
-                    "\"fields\": [\"field1\"] } } }"));
+        features.add(new StoredFeature("test_inject", Arrays.asList(), ScriptFeature.TEMPLATE_LANGUAGE,
+                "{\"lang\": \"inject\", \"source\": \"df\", \"params\": {\"term_stat\": {} } }"));
 
         StoredFeatureSet set = new StoredFeatureSet("my_set", features);
+        set.optimize();
         addElement(set);
     }
 
@@ -331,7 +330,13 @@ public class LoggingIT extends BaseIntegrationTest {
         Map<String, Doc> docs = buildIndex();
 
         Map<String, Object> params = new HashMap<>();
-        params.put("query", "found");
+        ArrayList<String> terms = new ArrayList<>();
+        terms.add("found");
+        params.put("terms", terms);
+
+        ArrayList<String> fields = new ArrayList<>();
+        fields.add("field1");
+        params.put("fields", fields);
 
         List<String> idsColl = new ArrayList<>(docs.keySet());
         Collections.shuffle(idsColl, random());

--- a/src/test/java/com/o19s/es/termstat/TermStatQueryTests.java
+++ b/src/test/java/com/o19s/es/termstat/TermStatQueryTests.java
@@ -119,4 +119,42 @@ public class TermStatQueryTests extends LuceneTestCase {
         Explanation explanation = searcher.explain(tsq, docs.scoreDocs[0].doc);
         assertThat(explanation.toString().trim(), equalTo("1.8472979 = weight(" + expr + " in doc 0)"));
     }
+
+    public void testMatchCount() throws Exception {
+        String expr = "matches";
+        AggrType aggr = AggrType.AVG;
+        AggrType pos_aggr = AggrType.AVG;
+
+        Set<Term> terms = new HashSet<>();
+        terms.add(new Term("text", "brown"));
+        terms.add(new Term("text", "cow"));
+        terms.add(new Term("text", "horse"));
+
+        Expression compiledExpression = (Expression) Scripting.compile(expr);
+        TermStatQuery tsq = new TermStatQuery(compiledExpression, aggr, pos_aggr, terms);
+
+        // Verify explain
+        TopDocs docs = searcher.search(tsq, 4);
+        Explanation explanation = searcher.explain(tsq, docs.scoreDocs[0].doc);
+        assertThat(explanation.toString().trim(), equalTo("2.0 = weight(" + expr + " in doc 0)"));
+    }
+
+    public void testUniqueCount() throws Exception {
+        String expr = "unique";
+        AggrType aggr = AggrType.AVG;
+        AggrType pos_aggr = AggrType.AVG;
+
+        Set<Term> terms = new HashSet<>();
+        terms.add(new Term("text", "brown"));
+        terms.add(new Term("text", "cow"));
+        terms.add(new Term("text", "horse"));
+
+        Expression compiledExpression = (Expression) Scripting.compile(expr);
+        TermStatQuery tsq = new TermStatQuery(compiledExpression, aggr, pos_aggr, terms);
+
+        // Verify explain
+        TopDocs docs = searcher.search(tsq, 4);
+        Explanation explanation = searcher.explain(tsq, docs.scoreDocs[0].doc);
+        assertThat(explanation.toString().trim(), equalTo("3.0 = weight(" + expr + " in doc 0)"));
+    }
 }


### PR DESCRIPTION
The term statistic injection functionality on ScriptFeatures wasn't very friendly towards query time parameters. This update will check the query parameters as a fallback if nothing is set in the script parameters.