### PR TITLE
update demo link to hello-ltr

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ Elasticsearch Learning to Rank: the documentation
 Get started
 -------------------------------
 
-- Want a quickstart? Check out the `demo <https://github.com/o19s/elasticsearch-learning-to-rank/tree/master/demo>`_. 
+- Want a quickstart? Check out the demo in `hello-ltr <https://github.com/o19s/hello-ltr>`_. 
 - Brand new to learning to rank? head to :doc:`core-concepts`. 
 - Otherwise, start with :doc:`fits-in`
 


### PR DESCRIPTION
The demo has moved to hello-ltr.

It was updated in README.md but not here.