### PR TITLE
Add gradle scripts to upload plugin to maven central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,3 +45,11 @@ jobs:
         asset_path: ./ltr-plugin-${{ env.RELEASE_VERSION }}.zip
         asset_name: ltr-plugin-${{ env.RELEASE_VERSION }}.zip
         asset_content_type: application/zip
+    - name: Publish to Maven Central
+      env:
+        SONATYPE_REPO_URL: ${{ secrets.SONATYPE_REPO_URL }}
+        SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
+        SONATYPE_PASS: ${{ secrets.SONATYPE_PASS }}
+        GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+        GPG_SIGNING_PASS: ${{ secrets.GPG_SIGNING_PASS }}
+      run: ./gradlew publish

--- a/build.gradle
+++ b/build.gradle
@@ -10,10 +10,23 @@ buildscript {
   }
 }
 
-group = 'com.o19s'
-version = "${ltrVersion}-es${elasticsearchVersion}"
+allprojects {
+  group = 'com.o19s'
+  version = "${ltrVersion}-es${elasticsearchVersion}"
 
-apply plugin: 'java'
+  apply plugin: 'java'
+
+  dependencies {
+    compile "org.apache.lucene:lucene-expressions:${luceneVersion}"
+    compile "org.antlr:antlr4-runtime:${antlrVersion}"
+    compile "org.ow2.asm:asm:${ow2Version}"
+    compile "org.ow2.asm:asm-commons:${ow2Version}"
+    compile "org.ow2.asm:asm-tree:${ow2Version}"
+    compile 'com.o19s:RankyMcRankFace:0.1.1'
+    compile "com.github.spullara.mustache.java:compiler:0.9.3"
+  }
+}
+
 apply plugin: 'idea'
 apply plugin: 'elasticsearch.esplugin'
 apply plugin: 'elasticsearch.rest-resources'
@@ -47,16 +60,6 @@ repositories {
       artifact()
     }
   }
-}
-
-dependencies {
-  compile "org.apache.lucene:lucene-expressions:${luceneVersion}"
-  compile "org.antlr:antlr4-runtime:${antlrVersion}"
-  compile "org.ow2.asm:asm:${ow2Version}"
-  compile "org.ow2.asm:asm-commons:${ow2Version}"
-  compile "org.ow2.asm:asm-tree:${ow2Version}"
-  compile 'com.o19s:RankyMcRankFace:0.1.1'
-  compile "com.github.spullara.mustache.java:compiler:0.9.3"
 }
 
 dependencyLicenses {

--- a/publish/build.gradle
+++ b/publish/build.gradle
@@ -1,0 +1,51 @@
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+publishing {
+  publications {
+    ltr(MavenPublication) {
+      from components.java
+
+      pom {
+        name = 'Elasticsearch Learning to Rank plugin'
+        artifactId = 'elasticsearch-learning-to-rank'
+        description = 'Learing to Rank Query w/ RankLib Models'
+        url = 'https://elasticsearch-learning-to-rank.readthedocs.io/'
+
+        licenses {
+          license {
+            name = 'The Apache Software License, Version 2.0'
+            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+          }
+        }
+
+        scm {
+          url = 'https://github.com/o19s/elasticsearch-learning-to-rank'
+          connection = 'scm:git:git://github.com/o19s/elasticsearch-learning-to-rank.git'
+          developerConnection = 'scm:git:https://github.com/o19s/elasticsearch-learning-to-rank.git'
+        }
+      }
+    }
+  }
+
+  repositories {
+    maven {
+      name = "MavenCentral"
+      url = System.getenv('SONATYPE_REPO_URL')
+
+        credentials {
+          username = System.getenv('SONATYPE_USER')
+          password = System.getenv('SONATYPE_PASS')
+        }
+    }
+  }
+}
+
+signing {
+  required { gradle.taskGraph.hasTask('publish') }
+  def signingKey = System.getenv('GPG_SIGNING_KEY')
+  def signingPass = System.getenv('GPG_SIGNING_PASS')
+
+  useInMemoryPgpKeys(signingKey, signingPass)
+  sign publishing.publications.ltr
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,3 @@
 rootProject.name = 'ltr'
 include ':rest-api-spec'
+include 'publish'


### PR DESCRIPTION
## Description
Added gradle script for deploying to maven central repo on Release with GitHub Actions.
Need to 
* Create account on sonatype and add url, username, password to GitHub secrets as name below
  * SONATYPE_REPO_URL
  * SONATYPE_USER
  * SONATYPE_PASS
* Create GPG Key and add key, password to GitHub secrets as name below
  * GPG_SIGNING_KEY
  * GPG_SIGNING_PASS

To test locally, 
1. Set SONATYPE_REPO_URL to `file://path/to/output/'
1. comment out credentials clause at publish/build.gradle
1. Generate GPG key and set GPG_SIGNING_KEY, GPG_SIGNING_PASS
1. run `./gradlew publish`

## Related Issue
https://github.com/o19s/elasticsearch-learning-to-rank/issues/298

I checked scripts work correctly except uploading process. (I couldn't create account on sonatype... sorry) But other process seems to be ok. Result pom will be like below.

<details>
    <summary>pom.xml</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <!-- This module was also published with a richer model, Gradle metadata,  -->
  <!-- which should be used instead. Do not delete the following line which  -->
  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
  <!-- that they should prefer consuming it instead. -->
  <!-- do_not_remove: published-with-gradle-metadata -->
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.o19s</groupId>
  <artifactId>elasticsearch-learning-to-rank</artifactId>
  <version>1.5.3-es7.9.3</version>
  <name>Elasticsearch Learning to Rank plugin</name>
  <description>Learing to Rank Query w/ RankLib Models</description>
  <url>https://elasticsearch-learning-to-rank.readthedocs.io/</url>
  <licenses>
    <license>
      <name>The Apache Software License, Version 2.0</name>
      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
    </license>
  </licenses>
  <scm>
    <connection>scm:git:git://github.com/o19s/elasticsearch-learning-to-rank.git</connection>
    <developerConnection>scm:git:https://github.com/o19s/elasticsearch-learning-to-rank.git</developerConnection>
    <url>https://github.com/o19s/elasticsearch-learning-to-rank</url>
  </scm>
  <dependencies>
    <dependency>
      <groupId>org.apache.lucene</groupId>
      <artifactId>lucene-expressions</artifactId>
      <version>8.6.2</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.antlr</groupId>
      <artifactId>antlr4-runtime</artifactId>
      <version>4.5.1-1</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.ow2.asm</groupId>
      <artifactId>asm</artifactId>
      <version>7.2</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.ow2.asm</groupId>
      <artifactId>asm-commons</artifactId>
      <version>7.2</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.ow2.asm</groupId>
      <artifactId>asm-tree</artifactId>
      <version>7.2</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>com.o19s</groupId>
      <artifactId>RankyMcRankFace</artifactId>
      <version>0.1.1</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>com.github.spullara.mustache.java</groupId>
      <artifactId>compiler</artifactId>
      <version>0.9.3</version>
      <scope>compile</scope>
    </dependency>
  </dependencies>
</project>
```

</details>
