### PR TITLE
Bugfix: change target component to publish

### DIFF
--- a/publish/build.gradle
+++ b/publish/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'signing'
 publishing {
   publications {
     ltr(MavenPublication) {
-      from components.java
+      from project(':').components.java
 
       pom {
         name = 'Elasticsearch Learning to Rank plugin'


### PR DESCRIPTION
# Related Issue
#350 

# Description
Fixed build script to include all classes into jar. Present script is made as subproject, which doesn't contain main project's script.

To see result jar is containing classes properly, 
* run `gradle publishLtrPublicationToMavenLocal`
* go `~/.m2/repository/com/o19s/ltr/....` and chose generated jar, unzip it. Then you can find all the classes are contained in the jar.