### PR TITLE
Fix rescore nested hits

### DIFF
--- a/src/javaRestTest/java/com/o19s/es/ltr/logging/LoggingIT.java
+++ b/src/javaRestTest/java/com/o19s/es/ltr/logging/LoggingIT.java
@@ -261,6 +261,20 @@ public class LoggingIT extends BaseIntegrationTest {
                                 .addRescoreLogging("second_log", 0, true)));
         SearchResponse resp3 = client().prepareSearch("test_index").setTypes("test").setSource(sourceBuilder).get();
         assertSearchHits(docs, resp3);
+
+        query = QueryBuilders.boolQuery().filter(QueryBuilders.idsQuery("test").addIds(ids));
+        sourceBuilder = new SearchSourceBuilder().query(query)
+                .fetchSource(false)
+                .size(10)
+                .addRescorer(new QueryRescorerBuilder(new WrapperQueryBuilder(sbuilder.toString())))
+                .addRescorer(new QueryRescorerBuilder(new WrapperQueryBuilder(sbuilder_rescore.toString())))
+                .ext(Collections.singletonList(
+                        new LoggingSearchExtBuilder()
+                                .addRescoreLogging("first_log", 0, false)
+                                .addRescoreLogging("second_log", 1, true)));
+
+        SearchResponse resp4 = client().prepareSearch("test_index").setTypes("test").setSource(sourceBuilder).get();
+        assertSearchHits(docs, resp4);
     }
 
     public void testLogExtraLogging() throws Exception {
@@ -318,6 +332,8 @@ public class LoggingIT extends BaseIntegrationTest {
         SearchResponse resp2 = client().prepareSearch("test_index").setTypes("test").setSource(sourceBuilder).get();
         assertSearchHitsExtraLogging(docs, resp2);
 
+        // FIXME
+        /*
         query = QueryBuilders.boolQuery()
                 .must(new WrapperQueryBuilder(sbuilder.toString()))
                 .must(
@@ -337,6 +353,7 @@ public class LoggingIT extends BaseIntegrationTest {
                                 .addRescoreLogging("second_log", 0, true)));
         SearchResponse resp3 = client().prepareSearch("test_index").setTypes("test").setSource(sourceBuilder).get();
         assertSearchHitsExtraLogging(docs, resp3);
+         */
     }
 
     public void testScriptLogInternalParams() throws Exception {

--- a/src/javaRestTest/java/com/o19s/es/ltr/logging/LoggingIT.java
+++ b/src/javaRestTest/java/com/o19s/es/ltr/logging/LoggingIT.java
@@ -332,8 +332,6 @@ public class LoggingIT extends BaseIntegrationTest {
         SearchResponse resp2 = client().prepareSearch("test_index").setTypes("test").setSource(sourceBuilder).get();
         assertSearchHitsExtraLogging(docs, resp2);
 
-        // FIXME
-        /*
         query = QueryBuilders.boolQuery()
                 .must(new WrapperQueryBuilder(sbuilder.toString()))
                 .must(
@@ -353,7 +351,6 @@ public class LoggingIT extends BaseIntegrationTest {
                                 .addRescoreLogging("second_log", 0, true)));
         SearchResponse resp3 = client().prepareSearch("test_index").setTypes("test").setSource(sourceBuilder).get();
         assertSearchHitsExtraLogging(docs, resp3);
-         */
     }
 
     public void testScriptLogInternalParams() throws Exception {

--- a/src/main/java/com/o19s/es/ltr/logging/LoggingFetchSubPhase.java
+++ b/src/main/java/com/o19s/es/ltr/logging/LoggingFetchSubPhase.java
@@ -63,14 +63,13 @@ public class LoggingFetchSubPhase implements FetchSubPhase {
                 builder.add(new BooleanClause(query.v1(), BooleanClause.Occur.MUST));
                 loggers.add(query.v2());
             });
-
-            ext.logSpecsStream().filter((l) -> l.getRescoreIndex() != null).forEach((l) -> {
-                Tuple<RankerQuery, HitLogConsumer> query = extractRescore(l, context.rescore());
-                builder.add(new BooleanClause(query.v1(), BooleanClause.Occur.MUST));
-                loggers.add(query.v2());
-            });
         }
 
+        ext.logSpecsStream().filter((l) -> l.getRescoreIndex() != null).forEach((l) -> {
+            Tuple<RankerQuery, HitLogConsumer> query = extractRescore(l, context.rescore());
+            builder.add(new BooleanClause(query.v1(), BooleanClause.Occur.MUST));
+            loggers.add(query.v2());
+        });
 
 
         Weight w = context.searcher().rewrite(builder.build()).createWeight(context.searcher(), ScoreMode.COMPLETE, 1.0F);

--- a/src/main/java/com/o19s/es/ltr/utils/Suppliers.java
+++ b/src/main/java/com/o19s/es/ltr/utils/Suppliers.java
@@ -18,6 +18,7 @@ package com.o19s.es.ltr.utils;
 
 import com.o19s.es.ltr.ranker.LtrRanker;
 import org.elasticsearch.Assertions;
+import org.elasticsearch.common.CheckedSupplier;
 
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -93,6 +94,30 @@ public final class Suppliers {
         public void set(LtrRanker.FeatureVector obj) {
             assert threadId == Thread.currentThread().getId();
             super.set(obj);
+        }
+    }
+
+    /**
+     * memoize the return value of the checked supplier (thread unsafe)
+     */
+    public static <R, E extends Exception> CheckedSupplier<R, E> memoizeCheckedSupplier(CheckedSupplier<R, E> supplier) {
+        return new CheckedMemoizeSupplier<R, E>(supplier);
+    }
+
+    private static class CheckedMemoizeSupplier<R, E extends Exception> implements CheckedSupplier<R, E> {
+        private final CheckedSupplier<R, E> supplier;
+        private R value;
+
+        private CheckedMemoizeSupplier(CheckedSupplier<R, E> supplier) {
+            this.supplier = supplier;
+        }
+
+        @Override
+        public R get() throws E {
+            if (value == null) {
+                value = supplier.get();
+            }
+            return value;
         }
     }
 }

--- a/src/test/java/com/o19s/es/ltr/logging/LoggingFetchSubPhaseTests.java
+++ b/src/test/java/com/o19s/es/ltr/logging/LoggingFetchSubPhaseTests.java
@@ -44,6 +44,7 @@ import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.TestUtil;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.lucene.search.function.CombineFunction;
 import org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction;
 import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
@@ -114,10 +115,9 @@ public class LoggingFetchSubPhaseTests extends LuceneTestCase {
                 .add(new BooleanClause(query1, BooleanClause.Occur.MUST))
                 .add(new BooleanClause(query2, BooleanClause.Occur.MUST))
                 .build();
-        LoggingFetchSubPhase subPhase = new LoggingFetchSubPhase();
         Weight weight = searcher.createWeight(query, ScoreMode.COMPLETE, 1.0F);
         List<LoggingFetchSubPhase.HitLogConsumer> loggers = Arrays.asList(logger1, logger2);
-        LoggingFetchSubPhaseProcessor processor = new LoggingFetchSubPhaseProcessor(weight, loggers);
+        LoggingFetchSubPhaseProcessor processor = new LoggingFetchSubPhaseProcessor(() -> new Tuple<>(weight, loggers));
 
         SearchHit[] hits = preprocessRandomHits(processor);
         for (SearchHit hit : hits) {
@@ -195,7 +195,7 @@ public class LoggingFetchSubPhaseTests extends LuceneTestCase {
         return hits.toArray(new SearchHit[0]);
     }
 
-    public static Document buildDoc(String text, float value) throws IOException {
+    public static Document buildDoc(String text, float value) {
         String id = UUID.randomUUID().toString();
         Document d = new Document();
         d.add(newStringField("id", id, Field.Store.YES));


### PR DESCRIPTION
Do not log nested hits.
Since there does not seem to be a way to know from FetchContext that we're running on the nested hits we have to delay the construction of the query weight and logging consumers after we read the first hit.

It'd be great if FetchContext provide some hints to know in which contect the the fetch processor is going to be applied.

fixes #357