### PR TITLE
Add support for 7.13.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 ltrVersion = 1.5.5
-elasticsearchVersion = 7.13.0
+elasticsearchVersion = 7.13.2
 luceneVersion = 8.8.2
 ow2Version = 8.0.1
 antlrVersion = 4.5.1-1


### PR DESCRIPTION
After https://github.com/o19s/elasticsearch-learning-to-rank/pull/371 I guess this is all what is needed for a 7.13.2 build.

Let me know if this PR is missing something.