### PR TITLE
Fix IDEA build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,5 @@
 buildscript {
   repositories {
-    mavenCentral()
-    jcenter()
-    mavenLocal()
     gradlePluginPortal()
   }
 
@@ -16,6 +13,13 @@ allprojects {
   version = "${ltrVersion}-es${elasticsearchVersion}"
 
   apply plugin: 'java'
+
+  repositories {
+    mavenCentral()
+    jcenter()
+    mavenLocal()
+    gradlePluginPortal()
+  }
 
   dependencies {
     implementation "org.apache.lucene:lucene-expressions:${luceneVersion}"


### PR DESCRIPTION
Importing the build.gradle into intellij has some oddities around the publish and rest-api-spec subprojects.  Because the build.gradle says allprojects have the dependencies they also need the repos to be happy.

