### PR TITLE
Fix exception in LoggingSearchExtBuilder JSON

### DIFF
--- a/src/main/java/com/o19s/es/ltr/logging/LoggingSearchExtBuilder.java
+++ b/src/main/java/com/o19s/es/ltr/logging/LoggingSearchExtBuilder.java
@@ -77,7 +77,7 @@ public class LoggingSearchExtBuilder extends SearchExtBuilder {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject();
+        builder.startObject(NAME);
         builder.field(LOG_SPECS.getPreferredName(), logSpecs);
         return builder.endObject();
     }

--- a/src/test/java/com/o19s/es/ltr/logging/LoggingSearchExtBuilderTests.java
+++ b/src/test/java/com/o19s/es/ltr/logging/LoggingSearchExtBuilderTests.java
@@ -69,9 +69,11 @@ public class LoggingSearchExtBuilderTests extends ESTestCase {
     public void testToXCtontent() throws IOException {
         LoggingSearchExtBuilder ext1 = buildTestExt();
         XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
         ext1.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
         builder.close();
-        assertEquals(getTestExtAsString(), Strings.toString(builder));
+        assertEquals("{\"ltr_log\":" + getTestExtAsString() + "}", Strings.toString(builder));
     }
 
     public void testSer() throws IOException {


### PR DESCRIPTION
this PR solves the following exception, thrown when trying to build the Ext property for ES

```
org.elasticsearch.ElasticsearchException: com.fasterxml.jackson.core.JsonGenerationException: Can not start an object, expecting field name (context: Object)

Caused by: com.fasterxml.jackson.core.JsonGenerationException: Can not start an object, expecting field name (context: Object)
[..]
at com.o19s.es.ltr.logging.LoggingSearchExtBuilder.toXContent(LoggingSearchExtBuilder.java:80) ~[elasticsearch-learning-to-rank-1.5.7-es7.13.4.jar:1.5.7-es7.13.4]
[..]
```

The current fix I used in one of my projects is to create a new class:
```java

import java.io.IOException;
import org.elasticsearch.common.xcontent.XContentBuilder;

/**
 * The original implementation is affected by a bug, and it is building an invalid JSON.
 */
public final class LoggingSearchExtBuilderFix extends com.o19s.es.ltr.logging.LoggingSearchExtBuilder {
	@Override
	public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
		builder.field(NAME);
		return super.toXContent(builder, params);
	}
}
```

But I would prefer a fix in the original library :)