### PR TITLE
Fix minor syntax errors in docs examples

### DIFF
--- a/docs/advanced-functionality.rst
+++ b/docs/advanced-functionality.rst
@@ -352,7 +352,7 @@ You have the following options for sending in parameters to scripts.  If you alw
                "source": "params.termStats['df'].size()",
                "params": {
                  "term_stat": {
-                    "analyzer": "!standard"
+                    "analyzer": "!standard",
                     "terms": ["rambo rocky"],
                     "fields": ["overview"]
                  }
@@ -379,7 +379,7 @@ To set parameter lookups simply pass the name of the parameter to pull the value
                "source": "params.termStats['df'].size()",
                "params": {
                  "term_stat": {
-                    "analyzer": "analyzerParam"
+                    "analyzer": "analyzerParam",
                     "terms": "termsParam",
                     "fields": "fieldsParam"
                  }

--- a/docs/building-features.rst
+++ b/docs/building-features.rst
@@ -48,8 +48,8 @@ One could also imagine a query based on the user's location::
                     "geo_distance" : {
                         "distance" : "200km",
                         "pin.location" : {
-                            "lat" : {{users_lat}},
-                            "lon" : {{users_lon}}
+                            "lat" : "{{users_lat}}",
+                            "lon" : "{{users_lon}}"
                         }
                     }
                 }


### PR DESCRIPTION
Update `building-features.rst` by adding quotes around mustache variables for geo_distance example.
Add missing commas in examples in `advanced-functionality.rst`