### PR TITLE
Feature Score Caching for Efficient Feature Score Logging

### DIFF
--- a/docs/advanced-functionality.rst
+++ b/docs/advanced-functionality.rst
@@ -214,6 +214,56 @@ If (and only if) the extra logging Map is accessed, it will be returned as an ad
     }
 
 =============================
+Feature Score Caching
+=============================
+
+By default, this plugin calculates feature scores for model inference and for feature score logging separately.
+For example, if we write a query as below to rescore top-100 documents then return top-10 among them with feature scores, this plugin calculates the feature scores on the 100 documents for model inference then calculates again and logs 10 of them::
+
+    POST tmdb/_search
+    {
+        "size": 10,
+        "query": {
+            "match": {
+                "_all": "rambo"
+            }
+        },
+        "rescore": {
+            "window_size" : 100,
+            "query": {
+                "rescore_query": {
+                    "sltr": {
+                        "params": {
+                            "keywords": "rambo"
+                        },
+                        "model": "my_model"
+                    }
+                }
+            }
+        },
+        "ext": {
+            "ltr_log": {
+                "log_specs": {
+                    "name": "log_entry1",
+                    "rescore_index": 0
+                }
+            }
+        }
+    }
+
+In some environments, it may be faster to cache the feature scores for model inference and just reuse them for logging.
+This plugin supports this behavior.
+To enable the feature score caching, add :code:`cache: "true"` flag to the LTR query which is the target of feature score logging::
+
+                    "sltr": {
+                        "cache": true,
+                        "params": {
+                            "keywords": "rambo"
+                        },
+                        "model": "my_model"
+                    }
+
+=============================
 Stats
 =============================
 The stats API gives the overall plugin status and statistics::

--- a/src/main/java/com/o19s/es/ltr/query/ValidatingLtrQueryBuilder.java
+++ b/src/main/java/com/o19s/es/ltr/query/ValidatingLtrQueryBuilder.java
@@ -173,10 +173,10 @@ public class ValidatingLtrQueryBuilder extends AbstractQueryBuilder<ValidatingLt
             FeatureSet set = ((StoredFeatureSet) element).optimize();
             LinearRanker ranker = new LinearRanker(new float[set.size()]);
             CompiledLtrModel model = new CompiledLtrModel("validation", set, ranker);
-            return RankerQuery.build(model, context, validation.getParams());
+            return RankerQuery.build(model, context, validation.getParams(), false);
         } else if (StoredLtrModel.TYPE.equals(element.type())) {
             CompiledLtrModel model = ((StoredLtrModel) element).compile(factory);
-            return RankerQuery.build(model, context, validation.getParams());
+            return RankerQuery.build(model, context, validation.getParams(), false);
         } else {
             throw new QueryShardException(searchExecutionContext, "Unknown element type [" + element.type() + "]");
         }


### PR DESCRIPTION
Hi, I would like to share a simple idea for improving efficiency of feature score logging.
The idea is to cache feature scores at model execution and use them at feature score logging.

We have developed this patch based on the idea, and
in our development environment, this patch significantly reduced average latency without changing the results.
What do you think about merging this patch? Thanks.

Usage of this patch: Set `"cache": true` option to a `sltr` query which is the target of feature score logging.
```diff
           "sltr": {
             "model": "...",
+            "cache": true,
             "params": { 
             ...
```