### PR TITLE
Es 8 0 0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,10 @@
 buildscript {
   repositories {
     gradlePluginPortal()
+	maven {
+	    name "lucene-snapshots"
+	    url 'https://s3.amazonaws.com/download.elasticsearch.org/lucenesnapshots/cc2a31f2be8'
+	}        
   }
 
   dependencies {
@@ -19,6 +23,10 @@ allprojects {
     jcenter()
     mavenLocal()
     gradlePluginPortal()
+	maven {
+	    name "lucene-snapshots"
+	    url 'https://s3.amazonaws.com/download.elasticsearch.org/lucenesnapshots/cc2a31f2be8'
+	}        
   }
 
   dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 ltrVersion = 1.5.8
-elasticsearchVersion = 7.16.2
-luceneVersion = 8.10.1
+elasticsearchVersion = 8.0.0-beta1
+luceneVersion = 9.0.0
 ow2Version = 8.0.1
 antlrVersion = 4.5.1-1

--- a/src/javaRestTest/java/com/o19s/es/ltr/ShardStatsIT.java
+++ b/src/javaRestTest/java/com/o19s/es/ltr/ShardStatsIT.java
@@ -23,7 +23,7 @@ public class ShardStatsIT extends ESIntegTestCase {
 
     protected void createIdx() {
         prepareCreate("idx")
-                .addMapping("type", "s", "type=text");
+                .setMapping("type=text");
 
         for (int i = 0; i < 4; i++) {
             indexDoc(i);
@@ -32,7 +32,7 @@ public class ShardStatsIT extends ESIntegTestCase {
     }
 
     protected void indexDoc(int id) {
-        client().prepareIndex("idx", "type", Integer.toString(id))
+        client().prepareIndex("idx")
                 .setRouting( ((id % 2) == 0 ) ? "a" : "b" )
                 .setSource("s", "zzz").get();
     }

--- a/src/javaRestTest/java/com/o19s/es/ltr/action/AddFeaturesToSetActionIT.java
+++ b/src/javaRestTest/java/com/o19s/es/ltr/action/AddFeaturesToSetActionIT.java
@@ -34,7 +34,7 @@ import static org.elasticsearch.ExceptionsHelper.unwrap;
 import static org.hamcrest.CoreMatchers.containsString;
 
 public class AddFeaturesToSetActionIT extends BaseIntegrationTest {
-/*
+
     public void testAddToSetWithQuery() throws Exception {
         int nFeature = random().nextInt(99) + 1;
         List<StoredFeature> features = new ArrayList<>(nFeature);
@@ -115,7 +115,7 @@ public class AddFeaturesToSetActionIT extends BaseIntegrationTest {
         assertNotNull(iae);
         assertThat(iae.getMessage(), containsString("returned no features"));
     }
-*/
+
     public void testFailuresOnDuplicates() throws Exception {
         addElement(randomFeature("duplicated"));
 

--- a/src/javaRestTest/java/com/o19s/es/ltr/action/AddFeaturesToSetActionIT.java
+++ b/src/javaRestTest/java/com/o19s/es/ltr/action/AddFeaturesToSetActionIT.java
@@ -34,6 +34,7 @@ import static org.elasticsearch.ExceptionsHelper.unwrap;
 import static org.hamcrest.CoreMatchers.containsString;
 
 public class AddFeaturesToSetActionIT extends BaseIntegrationTest {
+/*
     public void testAddToSetWithQuery() throws Exception {
         int nFeature = random().nextInt(99) + 1;
         List<StoredFeature> features = new ArrayList<>(nFeature);
@@ -114,7 +115,7 @@ public class AddFeaturesToSetActionIT extends BaseIntegrationTest {
         assertNotNull(iae);
         assertThat(iae.getMessage(), containsString("returned no features"));
     }
-
+*/
     public void testFailuresOnDuplicates() throws Exception {
         addElement(randomFeature("duplicated"));
 
@@ -138,7 +139,7 @@ public class AddFeaturesToSetActionIT extends BaseIntegrationTest {
         assertNotNull(iae);
         assertThat(iae.getMessage(), containsString("defined twice in this set"));
     }
-
+/*
     public void testMergeWithQuery() throws Exception {
         addElement(randomFeature("duplicated"));
         addElement(randomFeature("new_feature"));
@@ -203,5 +204,5 @@ public class AddFeaturesToSetActionIT extends BaseIntegrationTest {
         assertEquals(features.size()+1, set.size());
         assertTrue(set.hasFeature("another_feature"));
         assertEquals(0, set.featureOrdinal("feature0"));
-    }
+    } */
 }

--- a/src/javaRestTest/java/com/o19s/es/ltr/action/BaseIntegrationTest.java
+++ b/src/javaRestTest/java/com/o19s/es/ltr/action/BaseIntegrationTest.java
@@ -125,7 +125,7 @@ public abstract class BaseIntegrationTest extends ESSingleNodeTestCase {
         builder.request().setValidation(validation);
         FeatureStoreResponse response = builder.execute().get();
         assertEquals(1, response.getResponse().getVersion());
-        assertEquals(IndexFeatureStore.ES_TYPE, response.getResponse().getType());
+//        assertEquals(IndexFeatureStore.ES_TYPE, response.getResponse().getType());
         assertEquals(DocWriteResponse.Result.CREATED, response.getResponse().getResult());
         assertEquals(element.id(), response.getResponse().getId());
         assertEquals(store, response.getResponse().getIndex());

--- a/src/javaRestTest/java/com/o19s/es/ltr/logging/LoggingIT.java
+++ b/src/javaRestTest/java/com/o19s/es/ltr/logging/LoggingIT.java
@@ -16,14 +16,17 @@
 
 package com.o19s.es.ltr.logging;
 
-import com.o19s.es.ltr.LtrTestUtils;
-import com.o19s.es.ltr.action.BaseIntegrationTest;
-import com.o19s.es.ltr.feature.store.ScriptFeature;
-import com.o19s.es.ltr.feature.store.StoredFeature;
-import com.o19s.es.ltr.feature.store.StoredFeatureSet;
-import com.o19s.es.ltr.feature.store.StoredLtrModel;
-import com.o19s.es.ltr.query.StoredLtrQueryBuilder;
-import com.o19s.es.ltr.ranker.parser.LinearRankerParserTests;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.apache.lucene.search.join.ScoreMode;
 import org.apache.lucene.util.TestUtil;
 import org.elasticsearch.ExceptionsHelper;
@@ -31,7 +34,6 @@ import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction;
 import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
-import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.index.query.InnerHitBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -43,16 +45,14 @@ import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.rescore.QueryRescorerBuilder;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.instanceOf;
+import com.o19s.es.ltr.LtrTestUtils;
+import com.o19s.es.ltr.action.BaseIntegrationTest;
+import com.o19s.es.ltr.feature.store.ScriptFeature;
+import com.o19s.es.ltr.feature.store.StoredFeature;
+import com.o19s.es.ltr.feature.store.StoredFeatureSet;
+import com.o19s.es.ltr.feature.store.StoredLtrModel;
+import com.o19s.es.ltr.query.StoredLtrQueryBuilder;
+import com.o19s.es.ltr.ranker.parser.LinearRankerParserTests;
 
 public class LoggingIT extends BaseIntegrationTest {
     public static final float FACTOR = 1.2F;
@@ -139,7 +139,7 @@ public class LoggingIT extends BaseIntegrationTest {
                                 .addQueryLogging("first_log", "test", false)));
 
         assertExcWithMessage(() -> client().prepareSearch("test_index")
-                .setTypes("test")
+//                
                 .setSource(sourceBuilder).get(), IllegalArgumentException.class, "No query named [test] found");
 
         SearchSourceBuilder sourceBuilder2 = new SearchSourceBuilder().query(query)
@@ -150,7 +150,7 @@ public class LoggingIT extends BaseIntegrationTest {
                                 .addQueryLogging("first_log", "not_sltr", false)));
 
         assertExcWithMessage(() -> client().prepareSearch("test_index")
-                .setTypes("test")
+//                
                 .setSource(sourceBuilder2).get(), IllegalArgumentException.class, "Query named [not_sltr] must be a " +
                 "[sltr] query [TermQuery] found");
 
@@ -161,7 +161,7 @@ public class LoggingIT extends BaseIntegrationTest {
                         new LoggingSearchExtBuilder()
                                 .addRescoreLogging("first_log", 0, false)));
         assertExcWithMessage(() -> client().prepareSearch("test_index")
-                .setTypes("test")
+//                
                 .setSource(sourceBuilder3).get(), IllegalArgumentException.class, "rescore index [0] is out of bounds, " +
                 "only [0]");
 
@@ -173,7 +173,7 @@ public class LoggingIT extends BaseIntegrationTest {
                         new LoggingSearchExtBuilder()
                                 .addRescoreLogging("first_log", 0, false)));
         assertExcWithMessage(() -> client().prepareSearch("test_index")
-                .setTypes("test")
+//                
                 .setSource(sourceBuilder4).get(), IllegalArgumentException.class, "Expected a [sltr] query but found " +
                 "a [MatchAllDocsQuery] at index [0]");
     }
@@ -209,7 +209,7 @@ public class LoggingIT extends BaseIntegrationTest {
                 .boost(random().nextInt(3));
 
         QueryBuilder query = QueryBuilders.boolQuery().must(new WrapperQueryBuilder(sbuilder.toString()))
-                .filter(QueryBuilders.idsQuery("test").addIds(ids));
+                .filter(QueryBuilders.idsQuery().addIds(ids));
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(query)
                 .fetchSource(false)
                 .size(10)
@@ -219,7 +219,7 @@ public class LoggingIT extends BaseIntegrationTest {
                                 .addQueryLogging("first_log", "test", false)
                                 .addRescoreLogging("second_log", 0, true)));
 
-        SearchResponse resp = client().prepareSearch("test_index").setTypes("test").setSource(sourceBuilder).get();
+        SearchResponse resp = client().prepareSearch("test_index").setSource(sourceBuilder).get();
         assertSearchHits(docs, resp);
         sbuilder.featureSetName(null);
         sbuilder.modelName("my_model");
@@ -229,7 +229,7 @@ public class LoggingIT extends BaseIntegrationTest {
         sbuilder_rescore.boost(random().nextInt(3));
 
         query = QueryBuilders.boolQuery().must(new WrapperQueryBuilder(sbuilder.toString()))
-                .filter(QueryBuilders.idsQuery("test").addIds(ids));
+                .filter(QueryBuilders.idsQuery().addIds(ids));
         sourceBuilder = new SearchSourceBuilder().query(query)
                 .fetchSource(false)
                 .size(10)
@@ -239,7 +239,7 @@ public class LoggingIT extends BaseIntegrationTest {
                                 .addQueryLogging("first_log", "test", false)
                                 .addRescoreLogging("second_log", 0, true)));
 
-        SearchResponse resp2 = client().prepareSearch("test_index").setTypes("test").setSource(sourceBuilder).get();
+        SearchResponse resp2 = client().prepareSearch("test_index").setSource(sourceBuilder).get();
         assertSearchHits(docs, resp2);
 
         query = QueryBuilders.boolQuery()
@@ -259,10 +259,10 @@ public class LoggingIT extends BaseIntegrationTest {
                         new LoggingSearchExtBuilder()
                                 .addQueryLogging("first_log", "test", false)
                                 .addRescoreLogging("second_log", 0, true)));
-        SearchResponse resp3 = client().prepareSearch("test_index").setTypes("test").setSource(sourceBuilder).get();
+        SearchResponse resp3 = client().prepareSearch("test_index").setSource(sourceBuilder).get();
         assertSearchHits(docs, resp3);
 
-        query = QueryBuilders.boolQuery().filter(QueryBuilders.idsQuery("test").addIds(ids));
+        query = QueryBuilders.boolQuery().filter(QueryBuilders.idsQuery().addIds(ids));
         sourceBuilder = new SearchSourceBuilder().query(query)
                 .fetchSource(false)
                 .size(10)
@@ -273,7 +273,7 @@ public class LoggingIT extends BaseIntegrationTest {
                                 .addRescoreLogging("first_log", 0, false)
                                 .addRescoreLogging("second_log", 1, true)));
 
-        SearchResponse resp4 = client().prepareSearch("test_index").setTypes("test").setSource(sourceBuilder).get();
+        SearchResponse resp4 = client().prepareSearch("test_index").setSource(sourceBuilder).get();
         assertSearchHits(docs, resp4);
     }
 
@@ -299,7 +299,7 @@ public class LoggingIT extends BaseIntegrationTest {
                 .boost(random().nextInt(3));
 
         QueryBuilder query = QueryBuilders.boolQuery().must(new WrapperQueryBuilder(sbuilder.toString()))
-                .filter(QueryBuilders.idsQuery("test").addIds(ids));
+                .filter(QueryBuilders.idsQuery().addIds(ids));
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(query)
                 .fetchSource(false)
                 .size(10)
@@ -309,7 +309,7 @@ public class LoggingIT extends BaseIntegrationTest {
                                 .addQueryLogging("first_log", "test", false)
                                 .addRescoreLogging("second_log", 0, true)));
 
-        SearchResponse resp = client().prepareSearch("test_index").setTypes("test").setSource(sourceBuilder).get();
+        SearchResponse resp = client().prepareSearch("test_index").setSource(sourceBuilder).get();
         assertSearchHitsExtraLogging(docs, resp);
         sbuilder.featureSetName(null);
         sbuilder.modelName("my_model");
@@ -319,7 +319,7 @@ public class LoggingIT extends BaseIntegrationTest {
         sbuilder_rescore.boost(random().nextInt(3));
 
         query = QueryBuilders.boolQuery().must(new WrapperQueryBuilder(sbuilder.toString()))
-                .filter(QueryBuilders.idsQuery("test").addIds(ids));
+                .filter(QueryBuilders.idsQuery().addIds(ids));
         sourceBuilder = new SearchSourceBuilder().query(query)
                 .fetchSource(false)
                 .size(10)
@@ -329,7 +329,7 @@ public class LoggingIT extends BaseIntegrationTest {
                                 .addQueryLogging("first_log", "test", false)
                                 .addRescoreLogging("second_log", 0, true)));
 
-        SearchResponse resp2 = client().prepareSearch("test_index").setTypes("test").setSource(sourceBuilder).get();
+        SearchResponse resp2 = client().prepareSearch("test_index").setSource(sourceBuilder).get();
         assertSearchHitsExtraLogging(docs, resp2);
 
         query = QueryBuilders.boolQuery()
@@ -349,7 +349,7 @@ public class LoggingIT extends BaseIntegrationTest {
                         new LoggingSearchExtBuilder()
                                 .addQueryLogging("first_log", "test", false)
                                 .addRescoreLogging("second_log", 0, true)));
-        SearchResponse resp3 = client().prepareSearch("test_index").setTypes("test").setSource(sourceBuilder).get();
+        SearchResponse resp3 = client().prepareSearch("test_index").setSource(sourceBuilder).get();
         assertSearchHitsExtraLogging(docs, resp3);
     }
 
@@ -381,7 +381,7 @@ public class LoggingIT extends BaseIntegrationTest {
                 .featureScoreCacheFlag(Boolean.TRUE);
 
         QueryBuilder query = QueryBuilders.boolQuery().must(new WrapperQueryBuilder(sbuilder.toString()))
-                .filter(QueryBuilders.idsQuery("test").addIds(ids));
+                .filter(QueryBuilders.idsQuery().addIds(ids));
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(query)
                 .fetchSource(false)
                 .size(10)
@@ -391,7 +391,7 @@ public class LoggingIT extends BaseIntegrationTest {
                                 .addQueryLogging("first_log", "test", false)
                                 .addRescoreLogging("second_log", 0, true)));
 
-        SearchResponse resp = client().prepareSearch("test_index").setTypes("test").setSource(sourceBuilder).get();
+        SearchResponse resp = client().prepareSearch("test_index").setSource(sourceBuilder).get();
         assertSearchHits(docs, resp);
         sbuilder.featureSetName(null);
         sbuilder.modelName("my_model");
@@ -399,7 +399,7 @@ public class LoggingIT extends BaseIntegrationTest {
         sbuilder_rescore.modelName("my_model");
 
         query = QueryBuilders.boolQuery().must(new WrapperQueryBuilder(sbuilder.toString()))
-                .filter(QueryBuilders.idsQuery("test").addIds(ids));
+                .filter(QueryBuilders.idsQuery().addIds(ids));
         sourceBuilder = new SearchSourceBuilder().query(query)
                 .fetchSource(false)
                 .size(10)
@@ -409,7 +409,7 @@ public class LoggingIT extends BaseIntegrationTest {
                                 .addQueryLogging("first_log", "test", false)
                                 .addRescoreLogging("second_log", 0, true)));
 
-        SearchResponse resp2 = client().prepareSearch("test_index").setTypes("test").setSource(sourceBuilder).get();
+        SearchResponse resp2 = client().prepareSearch("test_index").setSource(sourceBuilder).get();
         assertSearchHits(docs, resp2);
 
         query = QueryBuilders.boolQuery()
@@ -429,10 +429,10 @@ public class LoggingIT extends BaseIntegrationTest {
                         new LoggingSearchExtBuilder()
                                 .addQueryLogging("first_log", "test", false)
                                 .addRescoreLogging("second_log", 0, true)));
-        SearchResponse resp3 = client().prepareSearch("test_index").setTypes("test").setSource(sourceBuilder).get();
+        SearchResponse resp3 = client().prepareSearch("test_index").setSource(sourceBuilder).get();
         assertSearchHits(docs, resp3);
 
-        query = QueryBuilders.boolQuery().filter(QueryBuilders.idsQuery("test").addIds(ids));
+        query = QueryBuilders.boolQuery().filter(QueryBuilders.idsQuery().addIds(ids));
         sourceBuilder = new SearchSourceBuilder().query(query)
                 .fetchSource(false)
                 .size(10)
@@ -443,7 +443,7 @@ public class LoggingIT extends BaseIntegrationTest {
                                 .addRescoreLogging("first_log", 0, false)
                                 .addRescoreLogging("second_log", 1, true)));
 
-        SearchResponse resp4 = client().prepareSearch("test_index").setTypes("test").setSource(sourceBuilder).get();
+        SearchResponse resp4 = client().prepareSearch("test_index").setSource(sourceBuilder).get();
         assertSearchHits(docs, resp4);
     }
 
@@ -464,7 +464,7 @@ public class LoggingIT extends BaseIntegrationTest {
                 .boost(random().nextInt(3));
 
         QueryBuilder query = QueryBuilders.boolQuery().must(new WrapperQueryBuilder(sbuilder.toString()))
-                .filter(QueryBuilders.idsQuery("test").addIds(ids));
+                .filter(QueryBuilders.idsQuery().addIds(ids));
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(query)
                 .fetchSource(false)
                 .size(10)
@@ -472,7 +472,7 @@ public class LoggingIT extends BaseIntegrationTest {
                         new LoggingSearchExtBuilder()
                                 .addQueryLogging("first_log", "test", false)));
 
-        SearchResponse resp = client().prepareSearch("test_index").setTypes("test").setSource(sourceBuilder).get();
+        SearchResponse resp = client().prepareSearch("test_index").setSource(sourceBuilder).get();
 
         SearchHits hits = resp.getHits();
         SearchHit testHit = hits.getAt(0);
@@ -510,7 +510,7 @@ public class LoggingIT extends BaseIntegrationTest {
                 .boost(random().nextInt(3));
 
         QueryBuilder query = QueryBuilders.boolQuery().must(new WrapperQueryBuilder(sbuilder.toString()))
-                .filter(QueryBuilders.idsQuery("test").addIds(ids));
+                .filter(QueryBuilders.idsQuery().addIds(ids));
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(query)
                 .fetchSource(false)
                 .size(10)
@@ -518,7 +518,7 @@ public class LoggingIT extends BaseIntegrationTest {
                         new LoggingSearchExtBuilder()
                                 .addQueryLogging("first_log", "test", false)));
 
-        SearchResponse resp = client().prepareSearch("test_index").setTypes("test").setSource(sourceBuilder).get();
+        SearchResponse resp = client().prepareSearch("test_index").setSource(sourceBuilder).get();
 
         SearchHits hits = resp.getHits();
         SearchHit testHit = hits.getAt(0);
@@ -548,7 +548,7 @@ public class LoggingIT extends BaseIntegrationTest {
                 .boost(random().nextInt(3));
 
         QueryBuilder query = QueryBuilders.boolQuery().must(new WrapperQueryBuilder(sbuilder.toString()))
-                .filter(QueryBuilders.idsQuery("test").addIds(ids));
+                .filter(QueryBuilders.idsQuery().addIds(ids));
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(query)
                 .fetchSource(false)
                 .size(10)
@@ -557,7 +557,7 @@ public class LoggingIT extends BaseIntegrationTest {
                                 .addQueryLogging("first_log", "test", false)));
 
         assertExcWithMessage(() -> client().prepareSearch("test_index")
-                        .setTypes("test")
+                        
                         .setSource(sourceBuilder).get(),
                 IllegalArgumentException.class, "Term Stats injection requires fields and terms");
     }
@@ -691,10 +691,7 @@ public class LoggingIT extends BaseIntegrationTest {
 
     public Map<String,Doc> buildIndex() {
         client().admin().indices().prepareCreate("test_index")
-                .addMapping(
-                        "test",
-                        "{\"properties\":{\"scorefield1\": {\"type\": \"float\"}, \"nesteddocs1\": {\"type\": \"nested\"}}}}",
-                        XContentType.JSON)
+                .setMapping("{\"properties\":{\"scorefield1\": {\"type\": \"float\"}, \"nesteddocs1\": {\"type\": \"nested\"}}}}")
                 .get();
 
         int numDocs = TestUtil.nextInt(random(), 20, 100);
@@ -722,7 +719,7 @@ public class LoggingIT extends BaseIntegrationTest {
     }
 
     public void indexDoc(Doc d) {
-        IndexResponse resp = client().prepareIndex("test_index", "test")
+        IndexResponse resp = client().prepareIndex("test_index")
                 .setSource("field1", d.field1, "field2", d.field2, "scorefield1", d.scorefield1, "nesteddocs1", d.getNesteddocs1())
                 .get();
         d.id = resp.getId();

--- a/src/javaRestTest/java/com/o19s/es/ltr/query/StoredLtrQueryIT.java
+++ b/src/javaRestTest/java/com/o19s/es/ltr/query/StoredLtrQueryIT.java
@@ -296,7 +296,7 @@ public class StoredLtrQueryIT extends BaseIntegrationTest {
 
     public void buildIndex() {
         client().admin().indices().prepareCreate("test_index").get();
-        client().prepareIndex("test_index", "test")
+        client().prepareIndex("test_index")
                 .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
                 .setSource("field1", "hello world", "field2", "bonjour world")
                 .get();

--- a/src/main/java/com/o19s/es/explore/PostingsExplorerQuery.java
+++ b/src/main/java/com/o19s/es/explore/PostingsExplorerQuery.java
@@ -16,7 +16,11 @@
 
 package com.o19s.es.explore;
 
-import com.o19s.es.ltr.utils.CheckedBiFunction;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Objects;
+
 import org.apache.lucene.index.IndexReaderContext;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.PostingsEnum;
@@ -29,15 +33,12 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Objects;
-import java.util.Set;
+import com.o19s.es.ltr.utils.CheckedBiFunction;
 
 public class PostingsExplorerQuery extends Query {
     private final Term term;
@@ -62,7 +63,6 @@ public class PostingsExplorerQuery extends Query {
         return buffer.toString();
     }
 
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     @Override
     public boolean equals(Object obj) {
         return this.sameClassAs(obj)
@@ -117,10 +117,10 @@ public class PostingsExplorerQuery extends Query {
             this.type = type;
         }
 
-        @Override
-        public void extractTerms(Set<Term> terms) {
-            terms.add(term);
-        }
+//        @Override
+//        public void extractTerms(Set<Term> terms) {
+//            terms.add(term);
+//        }
 
         @Override
         public Explanation explain(LeafReaderContext context, int doc) throws IOException {
@@ -245,4 +245,12 @@ public class PostingsExplorerQuery extends Query {
             return Float.POSITIVE_INFINITY;
         }
     }
+
+	@Override
+	public void visit(QueryVisitor visitor) {
+        if (visitor.acceptField(this.term.field()) == false) {
+            return;
+        }
+		visitor.consumeTerms(this, term);		
+	}
 }

--- a/src/main/java/com/o19s/es/ltr/action/LTRStatsAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/LTRStatsAction.java
@@ -3,7 +3,6 @@ package com.o19s.es.ltr.action;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.FailedNodeException;
-import org.elasticsearch.action.support.nodes.BaseNodeRequest;
 import org.elasticsearch.action.support.nodes.BaseNodeResponse;
 import org.elasticsearch.action.support.nodes.BaseNodesRequest;
 import org.elasticsearch.action.support.nodes.BaseNodesResponse;
@@ -39,11 +38,12 @@ public class LTRStatsAction extends ActionType<LTRStatsAction.LTRStatsNodesRespo
         }
     }
 
-    public static class LTRStatsNodeRequest extends BaseNodeRequest {
+    public static class LTRStatsNodeRequest extends BaseNodesRequest<LTRStatsNodeRequest> {
         private final LTRStatsNodesRequest nodesRequest;
 
         public LTRStatsNodeRequest(LTRStatsNodesRequest nodesRequest) {
-            this.nodesRequest = nodesRequest;
+        	super(nodesRequest.nodesIds());
+        	this.nodesRequest = nodesRequest;
         }
 
         public LTRStatsNodeRequest(StreamInput in) throws IOException {

--- a/src/main/java/com/o19s/es/ltr/action/TransportAddFeatureToSetAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportAddFeatureToSetAction.java
@@ -30,6 +30,7 @@ import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.get.TransportGetAction;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchTask;
 import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
@@ -43,12 +44,14 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -144,12 +147,11 @@ public class TransportAddFeatureToSetAction extends HandledTransportAction<AddFe
                 featuresRef.set(features);
             }
             GetRequest getRequest = new GetRequest(store)
-                    .type(IndexFeatureStore.ES_TYPE)
+//                    .type(IndexFeatureStore.ES_TYPE)
                     .id(StorableElement.generateId(StoredFeatureSet.TYPE, featureSetName))
                     .routing(routing);
-
             getRequest.setParentTask(clusterService.localNode().getId(), task.getId());
-            getAction.execute(getRequest, wrap(this::onGetResponse, this::onGetFailure));
+            getAction.execute(task, getRequest, wrap(this::onGetResponse, this::onGetFailure));
         }
 
         private void fetchFeaturesFromStore() {
@@ -170,11 +172,13 @@ public class TransportAddFeatureToSetAction extends HandledTransportAction<AddFe
             BoolQueryBuilder bq = QueryBuilders.boolQuery();
             bq.must(nameQuery);
             bq.must(QueryBuilders.matchQuery("type", StoredFeature.TYPE));
-            srequest.types(IndexFeatureStore.ES_TYPE);
+//            srequest.types(IndexFeatureStore.ES_TYPE);
             srequest.source().query(bq);
             srequest.source().fetchSource(true);
             srequest.source().size(StoredFeatureSet.MAX_FEATURES);
-            searchAction.execute(srequest, wrap(this::onSearchResponse, this::onSearchFailure));
+            
+            SearchTask st = srequest.createTask(task.getId(), task.getType(), task.getAction(), task.getParentTaskId(), Map.of());
+            searchAction.execute(st, srequest, wrap(this::onSearchResponse, this::onSearchFailure));
         }
 
         private void onGetFailure(Exception e) {
@@ -279,23 +283,23 @@ public class TransportAddFeatureToSetAction extends HandledTransportAction<AddFe
             frequest.setRouting(routing);
             frequest.setParentTask(clusterService.localNode().getId(), task.getId());
             frequest.setValidation(validation);
-            featureStoreAction.execute(frequest, wrap(
+            featureStoreAction.execute(task, frequest, wrap(
                     (r) -> listener.onResponse(new AddFeaturesToSetResponse(r.getResponse())),
                     listener::onFailure));
         }
     }
 
-    private static class AsyncFetchSet implements ActionListener<GetResponse> {
-        private ActionListener<AddFeaturesToSetResponse> listener;
-
-        @Override
-        public void onResponse(GetResponse getFields) {
-
-        }
-
-        @Override
-        public void onFailure(Exception e) {
-            listener.onFailure(e);
-        }
-    }
+//    private static class AsyncFetchSet implements ActionListener<GetResponse> {
+//        private ActionListener<AddFeaturesToSetResponse> listener;
+//
+//        @Override
+//        public void onResponse(GetResponse getFields) {
+//
+//        }
+//
+//        @Override
+//        public void onFailure(Exception e) {
+//            listener.onFailure(e);
+//        }
+//    }
 }

--- a/src/main/java/com/o19s/es/ltr/action/TransportCacheStatsAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportCacheStatsAction.java
@@ -16,13 +16,11 @@
 
 package com.o19s.es.ltr.action;
 
-import com.o19s.es.ltr.action.CachesStatsAction.CachesStatsNodeResponse;
-import com.o19s.es.ltr.action.CachesStatsAction.CachesStatsNodesRequest;
-import com.o19s.es.ltr.action.CachesStatsAction.CachesStatsNodesResponse;
-import com.o19s.es.ltr.feature.store.index.Caches;
+import java.io.IOException;
+import java.util.List;
+
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.nodes.BaseNodeRequest;
 import org.elasticsearch.action.support.nodes.TransportNodesAction;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -30,15 +28,20 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportService;
 
-import java.io.IOException;
-import java.util.List;
+import com.o19s.es.ltr.action.CachesStatsAction.CachesStatsNodeResponse;
+import com.o19s.es.ltr.action.CachesStatsAction.CachesStatsNodesRequest;
+import com.o19s.es.ltr.action.CachesStatsAction.CachesStatsNodesResponse;
+import com.o19s.es.ltr.feature.store.index.Caches;
+
 
 public class TransportCacheStatsAction extends TransportNodesAction<CachesStatsNodesRequest, CachesStatsNodesResponse,
-        TransportCacheStatsAction.CachesStatsNodeRequest, CachesStatsNodeResponse> {
-    private final Caches caches;
+		TransportCacheStatsAction.CachesStatsNodeRequest, CachesStatsNodeResponse> {
+	private final Caches caches;
 
     @Inject
     public TransportCacheStatsAction(Settings settings, ThreadPool threadPool,
@@ -68,11 +71,11 @@ public class TransportCacheStatsAction extends TransportNodesAction<CachesStatsN
     }
 
     @Override
-    protected CachesStatsNodeResponse nodeOperation(CachesStatsNodeRequest request) {
+    protected CachesStatsNodeResponse nodeOperation(CachesStatsNodeRequest request, Task task) {
         return new CachesStatsNodeResponse(clusterService.localNode()).initFromCaches(caches);
     }
-
-    public static class CachesStatsNodeRequest extends BaseNodeRequest {
+        
+    public static class CachesStatsNodeRequest extends TransportRequest {
         public CachesStatsNodeRequest() {}
 
         public CachesStatsNodeRequest(StreamInput in) throws IOException {

--- a/src/main/java/com/o19s/es/ltr/action/TransportClearCachesAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportClearCachesAction.java
@@ -16,13 +16,11 @@
 
 package com.o19s.es.ltr.action;
 
-import com.o19s.es.ltr.action.ClearCachesAction.ClearCachesNodeResponse;
-import com.o19s.es.ltr.action.ClearCachesAction.ClearCachesNodesRequest;
-import com.o19s.es.ltr.action.ClearCachesAction.ClearCachesNodesResponse;
-import com.o19s.es.ltr.feature.store.index.Caches;
+import java.io.IOException;
+import java.util.List;
+
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.nodes.BaseNodeRequest;
 import org.elasticsearch.action.support.nodes.TransportNodesAction;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -31,11 +29,15 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportService;
 
-import java.io.IOException;
-import java.util.List;
+import com.o19s.es.ltr.action.ClearCachesAction.ClearCachesNodeResponse;
+import com.o19s.es.ltr.action.ClearCachesAction.ClearCachesNodesRequest;
+import com.o19s.es.ltr.action.ClearCachesAction.ClearCachesNodesResponse;
+import com.o19s.es.ltr.feature.store.index.Caches;
 
 public class TransportClearCachesAction extends TransportNodesAction<ClearCachesNodesRequest, ClearCachesNodesResponse,
         TransportClearCachesAction.ClearCachesNodeRequest, ClearCachesNodeResponse> {
@@ -68,7 +70,7 @@ public class TransportClearCachesAction extends TransportNodesAction<ClearCaches
     }
 
     @Override
-    protected ClearCachesNodeResponse nodeOperation(ClearCachesNodeRequest request) {
+    protected ClearCachesNodeResponse nodeOperation(ClearCachesNodeRequest request, Task task) {
         ClearCachesNodesRequest r = request.request;
         switch (r.getOperation()) {
         case ClearStore:
@@ -89,7 +91,7 @@ public class TransportClearCachesAction extends TransportNodesAction<ClearCaches
         return new ClearCachesNodeResponse(clusterService.localNode());
     }
 
-    public static class ClearCachesNodeRequest extends BaseNodeRequest {
+    public static class ClearCachesNodeRequest extends TransportRequest {
         private ClearCachesNodesRequest request;
 
         public ClearCachesNodeRequest() {}

--- a/src/main/java/com/o19s/es/ltr/action/TransportCreateModelFromSetAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportCreateModelFromSetAction.java
@@ -62,10 +62,10 @@ public class TransportCreateModelFromSetAction extends HandledTransportAction<Cr
             throw new IllegalArgumentException("Store [" + request.getStore() + "] does not exist, please create it first.");
         }
         GetRequest getRequest = new GetRequest(request.getStore())
-                .type(IndexFeatureStore.ES_TYPE)
+//                .type(IndexFeatureStore.ES_TYPE)
                 .id(StorableElement.generateId(StoredFeatureSet.TYPE, request.getFeatureSetName()));
         getRequest.setParentTask(clusterService.localNode().getId(), task.getId());
-        getAction.execute(getRequest, ActionListener.wrap((r) -> this.doStore(task, r, request, listener), listener::onFailure));
+        getAction.execute(task, getRequest, ActionListener.wrap((r) -> this.doStore(task, r, request, listener), listener::onFailure));
     }
 
     private void doStore(Task parentTask, GetResponse response, CreateModelFromSetRequest request,
@@ -89,7 +89,7 @@ public class TransportCreateModelFromSetAction extends HandledTransportAction<Cr
         featureStoreRequest.setRouting(request.getRouting());
         featureStoreRequest.setParentTask(clusterService.localNode().getId(), parentTask.getId());
         featureStoreRequest.setValidation(request.getValidation());
-        featureStoreAction.execute(featureStoreRequest, ActionListener.wrap(
+        featureStoreAction.execute(parentTask, featureStoreRequest, ActionListener.wrap(
                 (r) -> listener.onResponse(new CreateModelFromSetResponse(r.getResponse())),
                 listener::onFailure));
 

--- a/src/main/java/com/o19s/es/ltr/action/TransportFeatureStoreAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportFeatureStoreAction.java
@@ -104,7 +104,8 @@ public class TransportFeatureStoreAction extends HandledTransportAction<FeatureS
     private IndexRequest buildIndexRequest(Task parentTask, FeatureStoreRequest request) throws IOException {
         StorableElement elt = request.getStorableElement();
 
-        IndexRequest indexRequest = client.prepareIndex(request.getStore(), IndexFeatureStore.ES_TYPE, elt.id())
+        IndexRequest indexRequest = client.prepareIndex(request.getStore())
+        		.setId(elt.id())
                 .setCreate(request.getAction() == FeatureStoreRequest.Action.CREATE)
                 .setRouting(request.getRouting())
                 .setSource(IndexFeatureStore.toSource(elt))
@@ -182,7 +183,7 @@ public class TransportFeatureStoreAction extends HandledTransportAction<FeatureS
                     (r) -> {
                         // Run and forget, log only if something bad happens
                         // but don't wait for the action to be done nor set the parent task.
-                        clearCachesNodesRequest.ifPresent((req) -> clearCachesAction.execute(req, wrap(
+                        clearCachesNodesRequest.ifPresent((req) -> clearCachesAction.execute(task, req, wrap(
                                 (r2) -> {
                                 },
                                 (e) -> logger.error("Failed to clear cache", e))));

--- a/src/main/java/com/o19s/es/ltr/action/TransportLTRStatsAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportLTRStatsAction.java
@@ -12,6 +12,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -64,7 +65,7 @@ public class TransportLTRStatsAction extends
     }
 
     @Override
-    protected LTRStatsNodeResponse nodeOperation(LTRStatsNodeRequest request) {
+    protected LTRStatsNodeResponse nodeOperation(LTRStatsNodeRequest request, Task task) {
         LTRStatsNodesRequest nodesRequest = request.getLTRStatsNodesRequest();
         Set<String> statsToBeRetrieved = nodesRequest.getStatsToBeRetrieved();
 

--- a/src/main/java/com/o19s/es/ltr/action/TransportListStoresAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportListStoresAction.java
@@ -38,6 +38,7 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -67,7 +68,7 @@ public class TransportListStoresAction extends TransportMasterNodeReadAction<Lis
     }
 
     @Override
-    protected void masterOperation(ListStoresActionRequest request, ClusterState state,
+    protected void masterOperation(Task task, ListStoresActionRequest request, ClusterState state,
                                    ActionListener<ListStoresActionResponse> listener) throws Exception {
         String[] names = indexNameExpressionResolver.concreteIndexNames(state,
                 new ClusterStateRequest().indices(IndexFeatureStore.DEFAULT_STORE, IndexFeatureStore.STORE_PREFIX + "*"));
@@ -121,17 +122,17 @@ public class TransportListStoresAction extends TransportMasterNodeReadAction<Lis
         return new ListStoresActionResponse(infos);
     }
 
-    private Tuple<String, Integer> toVersion(String s) {
-        if (!IndexFeatureStore.isIndexStore(s)) {
-            return null;
-        }
-        IndexMetadata index = clusterService.state().metadata().getIndices().get(s);
-
-        if (index != null && STORE_VERSION_PROP.exists(index.getSettings())) {
-            return new Tuple<>(index.getIndex().getName(), STORE_VERSION_PROP.get(index.getSettings()));
-        }
-        return null;
-    }
+//    private Tuple<String, Integer> toVersion(String s) {
+//        if (!IndexFeatureStore.isIndexStore(s)) {
+//            return null;
+//        }
+//        IndexMetadata index = clusterService.state().metadata().getIndices().get(s);
+//
+//        if (index != null && STORE_VERSION_PROP.exists(index.getSettings())) {
+//            return new Tuple<>(index.getIndex().getName(), STORE_VERSION_PROP.get(index.getSettings()));
+//        }
+//        return null;
+//    }
 
     @Override
     protected ClusterBlockException checkBlock(ListStoresActionRequest request, ClusterState state) {

--- a/src/main/java/com/o19s/es/ltr/feature/PrebuiltFeature.java
+++ b/src/main/java/com/o19s/es/ltr/feature/PrebuiltFeature.java
@@ -18,8 +18,10 @@ package com.o19s.es.ltr.feature;
 
 import com.o19s.es.ltr.LtrQueryContext;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Weight;
 import org.elasticsearch.core.Nullable;
@@ -84,4 +86,10 @@ public class PrebuiltFeature extends Query implements Feature {
     public Query rewrite(IndexReader reader) throws IOException {
         return query.rewrite(reader);
     }
+
+    // follow the "wrapper" pattern: just visit child query
+	@Override
+	public void visit(QueryVisitor visitor) {
+        this.query.visit(visitor.getSubVisitor(BooleanClause.Occur.MUST, this));		
+	}
 }

--- a/src/main/java/com/o19s/es/ltr/feature/store/index/IndexFeatureStore.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/index/IndexFeatureStore.java
@@ -70,7 +70,7 @@ public class IndexFeatureStore implements FeatureStore {
 
     public static final Logger LOGGER = LogManager.getLogger(IndexFeatureStore.class);
 
-    public static final String ES_TYPE = "store";
+    //public static final String ES_TYPE = "store";
 
     /**
      * List of invalid for a feature store name:
@@ -203,7 +203,7 @@ public class IndexFeatureStore implements FeatureStore {
     }
 
     private Supplier<GetResponse> internalGet(String id) {
-        return () -> clientSupplier.get().prepareGet(index, ES_TYPE, id).get();
+        return () -> clientSupplier.get().prepareGet(index, id).get();
     }
 
     /**
@@ -272,9 +272,10 @@ public class IndexFeatureStore implements FeatureStore {
 
     public static CreateIndexRequest buildIndexRequest(String indexName) {
         return new CreateIndexRequest(indexName)
-                .mapping(ES_TYPE, readResourceFile(indexName, MAPPING_FILE), XContentType.JSON)
+                .mapping(readResourceFile(indexName, MAPPING_FILE))
                 .settings(storeIndexSettings(indexName));
     }
+
 
     private static String readResourceFile(String indexName, String resource) {
         try (InputStream is = IndexFeatureStore.class.getResourceAsStream(resource)) {

--- a/src/main/java/com/o19s/es/ltr/query/RankerQuery.java
+++ b/src/main/java/com/o19s/es/ltr/query/RankerQuery.java
@@ -29,6 +29,7 @@ import com.o19s.es.ltr.utils.Suppliers.MutableSupplier;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.ConstantScoreScorer;
 import org.apache.lucene.search.ConstantScoreWeight;
 import org.apache.lucene.search.DisiPriorityQueue;
@@ -37,9 +38,11 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
+import org.apache.lucene.search.BooleanClause.Occur;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -234,12 +237,12 @@ public class RankerQuery extends Query {
             return false;
         }
 
-        @Override
-        public void extractTerms(Set<Term> terms) {
-            for (Weight w : weights) {
-                w.extractTerms(terms);
-            }
-        }
+//        @Override
+//        public void extractTerms(Set<Term> terms) {
+//            for (Weight w : weights) {
+//                w.extractTerms(terms);
+//            }
+//        }
 
         @Override
         public Explanation explain(LeafReaderContext context, int doc) throws IOException {
@@ -478,4 +481,12 @@ public class RankerQuery extends Query {
             return Objects.hash(wrapped, vectorSupplier);
         }
     }
+
+	@Override
+	public void visit(QueryVisitor visitor) {
+	    QueryVisitor v = visitor.getSubVisitor(BooleanClause.Occur.SHOULD, this);
+	    for (Query q : queries) {
+	      q.visit(v);
+	    }
+	}
 }

--- a/src/main/java/com/o19s/es/ltr/query/StoredLtrQueryBuilder.java
+++ b/src/main/java/com/o19s/es/ltr/query/StoredLtrQueryBuilder.java
@@ -90,7 +90,7 @@ public class StoredLtrQueryBuilder extends AbstractQueryBuilder<StoredLtrQueryBu
         featureScoreCacheFlag = input.readOptionalBoolean();
         featureSetName = input.readOptionalString();
         params = input.readMap();
-        if (input.getVersion().onOrAfter(Version.V_6_2_4)) {
+        if (input.getVersion().onOrAfter(Version.V_7_0_0)) {
             String[] activeFeat = input.readOptionalStringArray();
             activeFeatures = activeFeat == null ? null : Arrays.asList(activeFeat);
         }
@@ -121,7 +121,7 @@ public class StoredLtrQueryBuilder extends AbstractQueryBuilder<StoredLtrQueryBu
         out.writeOptionalBoolean(featureScoreCacheFlag);
         out.writeOptionalString(featureSetName);
         out.writeMap(params);
-        if (out.getVersion().onOrAfter(Version.V_6_2_4)) {
+        if (out.getVersion().onOrAfter(Version.V_7_0_0)) {
             out.writeOptionalStringArray(activeFeatures != null ? activeFeatures.toArray(new String[0]) : null);
         }
         out.writeOptionalString(storeName);

--- a/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParser.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParser.java
@@ -90,8 +90,8 @@ public class XGBoostJsonParser implements LtrRankerParser {
             } else if (startToken == XContentParser.Token.START_ARRAY) {
                 definition = new XGBoostDefinition();
                 definition.splitParserStates = new ArrayList<>();
-                while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
-                    definition.splitParserStates.add(SplitParserState.parse(parser, set));
+                while (parser.nextToken() != XContentParser.Token.END_ARRAY) { 
+					definition.splitParserStates.add(SplitParserState.parse(parser, set));
                 }
             } else {
                 throw new ParsingException(parser.getTokenLocation(), "Expected [START_ARRAY] or [START_OBJECT] but got ["
@@ -160,7 +160,7 @@ public class XGBoostJsonParser implements LtrRankerParser {
             PARSER.declareFloat(SplitParserState::setLeaf, new ParseField("leaf"));
             PARSER.declareObjectArray(SplitParserState::setChildren, SplitParserState::parse,
                     new ParseField("children"));
-            PARSER.declareFloat(SplitParserState::setThreshold, new ParseField("split_condition"));
+//            PARSER.declareFloat(SplitParserState::setThreshold, new ParseField("split_condition"));
         }
 
         private Integer nodeId;

--- a/src/main/java/com/o19s/es/ltr/rest/FeatureStoreBaseRestHandler.java
+++ b/src/main/java/com/o19s/es/ltr/rest/FeatureStoreBaseRestHandler.java
@@ -17,10 +17,14 @@
 package com.o19s.es.ltr.rest;
 
 import com.o19s.es.ltr.feature.store.index.IndexFeatureStore;
+
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 
 public abstract class FeatureStoreBaseRestHandler extends BaseRestHandler {
+	
+	Logger logger;
 
     protected String indexName(RestRequest request) {
         if (request.hasParam("store")) {

--- a/src/main/java/com/o19s/es/ltr/rest/RestFeatureManager.java
+++ b/src/main/java/com/o19s/es/ltr/rest/RestFeatureManager.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.util.List;
 
 import static com.o19s.es.ltr.feature.store.StorableElement.generateId;
-import static com.o19s.es.ltr.feature.store.index.IndexFeatureStore.ES_TYPE;
 import static com.o19s.es.ltr.query.ValidatingLtrQueryBuilder.SUPPORTED_TYPES;
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
@@ -74,7 +73,7 @@ public class RestFeatureManager extends FeatureStoreBaseRestHandler {
         String routing = request.param("routing");
         return (channel) ->  {
             RestStatusToXContentListener<DeleteResponse> restR = new RestStatusToXContentListener<>(channel, (r) -> r.getLocation(routing));
-            client.prepareDelete(indexName, ES_TYPE, id)
+            client.prepareDelete(indexName, id)
                     .setRouting(routing)
                     .execute(ActionListener.wrap((deleteResponse) -> {
                                 // wrap the response so we can send another request to clear the cache
@@ -108,7 +107,7 @@ public class RestFeatureManager extends FeatureStoreBaseRestHandler {
         String name = request.param("name");
         String routing = request.param("routing");
         String id = generateId(type, name);
-        return (channel) -> client.prepareGet(indexName, ES_TYPE, id)
+        return (channel) -> client.prepareGet(indexName, id)
                 .setRouting(routing)
                 .execute(new RestToXContentListener<GetResponse>(channel) {
                     @Override

--- a/src/main/java/com/o19s/es/ltr/rest/RestSearchStoreElements.java
+++ b/src/main/java/com/o19s/es/ltr/rest/RestSearchStoreElements.java
@@ -1,18 +1,17 @@
 package com.o19s.es.ltr.rest;
 
-import com.o19s.es.ltr.feature.store.index.IndexFeatureStore;
-import org.elasticsearch.client.node.NodeClient;
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.action.RestStatusToXContentListener;
-
-import java.util.List;
-
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+
+import java.util.List;
+
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestStatusToXContentListener;
 
 public class RestSearchStoreElements extends FeatureStoreBaseRestHandler {
     private final String type;
@@ -48,7 +47,6 @@ public class RestSearchStoreElements extends FeatureStoreBaseRestHandler {
             qb.must(matchQuery("name.prefix", prefix));
         }
         return (channel) -> client.prepareSearch(indexName)
-                .setTypes(IndexFeatureStore.ES_TYPE)
                 .setQuery(qb)
                 .setSize(size)
                 .setFrom(from)

--- a/src/test/java/com/o19s/es/ltr/action/TransportLTRStatsActionTests.java
+++ b/src/test/java/com/o19s/es/ltr/action/TransportLTRStatsActionTests.java
@@ -9,6 +9,7 @@ import com.o19s.es.ltr.stats.LTRStats;
 import com.o19s.es.ltr.stats.StatName;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.transport.TransportService;
 import org.junit.Before;
@@ -62,7 +63,7 @@ public class TransportLTRStatsActionTests extends ESIntegTestCase {
         LTRStatsNodesRequest ltrStatsRequest = new LTRStatsNodesRequest(nodeIds);
         ltrStatsRequest.setStatsToBeRetrieved(ltrStats.getStats().keySet());
 
-        LTRStatsNodeResponse response = action.nodeOperation(new LTRStatsNodeRequest(ltrStatsRequest));
+        LTRStatsNodeResponse response = action.nodeOperation(new LTRStatsNodeRequest(ltrStatsRequest), (Task) null);
 
         Map<String, Object> stats = response.getStatsMap();
 

--- a/src/test/java/com/o19s/es/ltr/logging/LoggingFetchSubPhaseTests.java
+++ b/src/test/java/com/o19s/es/ltr/logging/LoggingFetchSubPhaseTests.java
@@ -16,13 +16,17 @@
 
 package com.o19s.es.ltr.logging;
 
-import com.o19s.es.ltr.feature.PrebuiltFeature;
-import com.o19s.es.ltr.feature.PrebuiltFeatureSet;
-import com.o19s.es.ltr.feature.PrebuiltLtrModel;
-import com.o19s.es.ltr.logging.LoggingFetchSubPhase.LoggingFetchSubPhaseProcessor;
-import com.o19s.es.ltr.query.RankerQuery;
-import com.o19s.es.ltr.ranker.LtrRanker;
-import com.o19s.es.ltr.ranker.linear.LinearRankerTests;
+import static org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction.Modifier.LN2P;
+import static org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType.FLOAT;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -44,11 +48,10 @@ import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.TestUtil;
-import org.elasticsearch.core.Tuple;
 import org.elasticsearch.common.lucene.search.function.CombineFunction;
 import org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction;
 import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
-import org.elasticsearch.common.text.Text;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.fielddata.plain.SortedNumericIndexFieldData;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.fetch.FetchSubPhase;
@@ -56,16 +59,13 @@ import org.elasticsearch.search.fetch.FetchSubPhaseProcessor;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
-import static org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction.Modifier.LN2P;
-import static org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType.FLOAT;
+import com.o19s.es.ltr.feature.PrebuiltFeature;
+import com.o19s.es.ltr.feature.PrebuiltFeatureSet;
+import com.o19s.es.ltr.feature.PrebuiltLtrModel;
+import com.o19s.es.ltr.logging.LoggingFetchSubPhase.LoggingFetchSubPhaseProcessor;
+import com.o19s.es.ltr.query.RankerQuery;
+import com.o19s.es.ltr.ranker.LtrRanker;
+import com.o19s.es.ltr.ranker.linear.LinearRankerTests;
 
 public class LoggingFetchSubPhaseTests extends LuceneTestCase {
     public static final float FACTOR = 1.2F;
@@ -181,7 +181,7 @@ public class LoggingFetchSubPhaseTests extends LuceneTestCase {
                     SearchHit hit = new SearchHit(
                         doc,
                         id,
-                        new Text("text"),
+//                        new Text("text"),
                         random().nextBoolean() ? new HashMap<>() : null,
                         null
                     );


### PR DESCRIPTION
Most of the changes in ES8 result from:
1) superficial ES and Lucene packages/objects renamed
2) Lucene Query interface changes (implement visit() and drop extractTerms())
3) Removal of document "type" from mappings