### PR TITLE
bump ES version to 7.17.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 ltrVersion = 1.5.8
-elasticsearchVersion = 7.17.2
+elasticsearchVersion = 7.17.3
 luceneVersion = 8.11.1
 ow2Version = 8.0.1
 antlrVersion = 4.5.1-1


### PR DESCRIPTION
ES 7.17.3 is out:

```
{
  "name" : "...",
  "cluster_name" : "....",
  "cluster_uuid" : "NThobugSQR-qRPGkFr_tVw",
  "version" : {
    "number" : "7.17.3",
    "build_flavor" : "default",
    "build_type" : "docker",
    "build_hash" : "5ad023604c8d7416c9eb6c0eadb62b14e766caff",
    "build_date" : "2022-04-19T08:11:19.070913226Z",
    "build_snapshot" : false,
    "lucene_version" : "8.11.1",
    "minimum_wire_compatibility_version" : "6.8.0",
    "minimum_index_compatibility_version" : "6.0.0-beta1"
  },
  "tagline" : "You Know, for Search"
}
```

This builds the plugin against it. 