### PR TITLE
Update elasticsearch to 8.5.3 and lucene to 9.4.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 ltrVersion = 1.5.8
-elasticsearchVersion = 8.5.2
-luceneVersion = 9.4.1
+elasticsearchVersion = 8.5.3
+luceneVersion = 9.4.2
 ow2Version = 8.0.1
 antlrVersion = 4.5.1-1


### PR DESCRIPTION
According to the release note of elasticsearch 8.5.3 lucene got an upgrade in it: https://www.elastic.co/guide/en/elasticsearch/reference/8.5/release-notes-8.5.3.html.