### PR TITLE
xgboost to handle missing values

### DIFF
--- a/src/main/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTree.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTree.java
@@ -94,12 +94,18 @@ public class NaiveAdditiveDecisionTree extends DenseLtrRanker implements Account
         private final Node right;
         private final int feature;
         private final float threshold;
+        private final int leftNodeId;
+        private final int rightNodeId;
+        private final int missingNodeId;
 
-        public Split(Node left, Node right, int feature, float threshold) {
+        public Split(Node left, Node right, int feature, float threshold, int leftNodeId, int rightNodeId, int missingNodeId) {
             this.left = Objects.requireNonNull(left);
             this.right = Objects.requireNonNull(right);
             this.feature = feature;
             this.threshold = threshold;
+            this.leftNodeId = leftNodeId;
+            this.rightNodeId = rightNodeId;
+            this.missingNodeId = missingNodeId;
         }
 
         @Override
@@ -113,7 +119,15 @@ public class NaiveAdditiveDecisionTree extends DenseLtrRanker implements Account
             while (!n.isLeaf()) {
                 assert n instanceof Split;
                 Split s = (Split) n;
-                if (s.threshold > scores[s.feature]) {
+                if (Float.isNaN(scores[s.feature])) {
+                    if (s.missingNodeId == s.leftNodeId) {
+                        n = s.left;
+                    }
+                    else {
+                        n = s.right;
+                    }
+                }
+                else if (s.threshold > scores[s.feature]) {
                     n = s.left;
                 } else {
                     n = s.right;

--- a/src/main/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTree.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTree.java
@@ -129,7 +129,8 @@ public class NaiveAdditiveDecisionTree extends DenseLtrRanker implements Account
                 }
                 else if (s.threshold > scores[s.feature]) {
                     n = s.left;
-                } else {
+                }
+                else {
                     n = s.right;
                 }
             }

--- a/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParser.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParser.java
@@ -247,7 +247,7 @@ public class XGBoostJsonParser implements LtrRankerParser {
         Node toNode(FeatureSet set) {
             if (isSplit()) {
                 return new NaiveAdditiveDecisionTree.Split(children.get(0).toNode(set), children.get(1).toNode(set),
-                        set.featureOrdinal(split), threshold);
+                        set.featureOrdinal(split), threshold, leftNodeId, rightNodeId, missingNodeId);
             } else {
                 return new NaiveAdditiveDecisionTree.Leaf(leaf);
             }

--- a/src/test/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTreeTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTreeTests.java
@@ -125,7 +125,6 @@ public class NaiveAdditiveDecisionTreeTests extends LuceneTestCase {
                 5, 50, counts);
         long actualSize = ranker.ramBytesUsed();
         long expectedApprox = counts.splits.get() * (NUM_BYTES_OBJECT_HEADER + Float.BYTES + NUM_BYTES_OBJECT_REF * 2 + Integer.BYTES * 3);
-        int num_splits = counts.splits.get();
         expectedApprox += counts.leaves.get() * (NUM_BYTES_ARRAY_HEADER + NUM_BYTES_OBJECT_HEADER + Float.BYTES);
         expectedApprox += ranker.size() * Float.BYTES + NUM_BYTES_ARRAY_HEADER;
         assertThat(actualSize, allOf(

--- a/src/test/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParserTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParserTests.java
@@ -58,7 +58,7 @@ public class XGBoostJsonParserTests extends LuceneTestCase {
                 "\"split_condition\":0.123," +
                 "\"yes\":1," +
                 "\"no\": 2," +
-                "\"missing\":2,"+
+                "\"missing\":1,"+
                 "\"children\": [" +
                 "   {\"nodeid\": 1, \"depth\": 1, \"leaf\": 0.5}," +
                 "   {\"nodeid\": 2, \"depth\": 1, \"leaf\": 0.2}" +
@@ -73,6 +73,8 @@ public class XGBoostJsonParserTests extends LuceneTestCase {
         assertEquals(0.5F, tree.score(v), Math.ulp(0.5F));
         v.setFeatureScore(0, 0.123F);
         assertEquals(0.2F, tree.score(v), Math.ulp(0.2F));
+        v.setFeatureScore(0, Float.NaN);
+        assertEquals(0.5F, tree.score(v), Math.ulp(0.2F));
     }
 
     public void testReadSimpleSplitInObject() throws IOException {

--- a/src/test/resources/com/o19s/es/ltr/ranker/dectree/simple_tree.txt
+++ b/src/test/resources/com/o19s/es/ltr/ranker/dectree/simple_tree.txt
@@ -1,4 +1,5 @@
 # first line after split is right
+# on a split line, the last 3 integers correspond to leftNodeId, rightNodeId, missingNodeId
 # data point: feature1:1, feature2:2, feature3:3
 - tree:3.4
   - split:feature1:2.3:1:2:1
@@ -17,7 +18,7 @@
 # right wins
       - split:feature3:3.2:5:6:6
         - output:10
-# left wins => output 3.2*2.8:7:8:1
+# left wins => output 3.2*2.8
         - output:3.2
       - output:15
   - output:23

--- a/src/test/resources/com/o19s/es/ltr/ranker/dectree/simple_tree.txt
+++ b/src/test/resources/com/o19s/es/ltr/ranker/dectree/simple_tree.txt
@@ -1,23 +1,23 @@
 # first line after split is right
 # data point: feature1:1, feature2:2, feature3:3
 - tree:3.4
-  - split:feature1:2.3
+  - split:feature1:2.3:1:2:1
     - output:3.2
 # right wins
-    - split:feature2:2.2
-      - split:feature3:3.2
+    - split:feature2:2.2:3:4:4
+      - split:feature3:3.2:5:6:5
         - output:11
         - output:17
 # left wins => output 1.2*3.4
       - output:1.2
 - tree:2.8
-  - split:feature1:0.1
+  - split:feature1:0.1:1:2:1
 # right wins
-    - split:feature2:1.8
+    - split:feature2:1.8:3:4:4
 # right wins
-      - split:feature3:3.2
+      - split:feature3:3.2:5:6:6
         - output:10
-# left wins => output 3.2*2.8
+# left wins => output 3.2*2.8:7:8:1
         - output:3.2
       - output:15
   - output:23


### PR DESCRIPTION
Currently, the `NaiveAdditiveDecisionTree` class assumes that all feature values are not missing. In certain applications, missing feature values are not easily addressed (it might be hard to decide what appropriate value to fill in for missing). 

This PR enables `NaiveAdditiveDecisionTree` to correctly score features even when some features have a missing value.

Related issue: https://github.com/o19s/elasticsearch-learning-to-rank/issues/135