### PR TITLE
Update elasticsearch 7.x from 7.17.17 to 7.17.19

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 ltrVersion = 1.5.8
-elasticsearchVersion = 7.17.7
+elasticsearchVersion = 7.17.9
 luceneVersion = 8.11.1
 ow2Version = 8.0.1
 antlrVersion = 4.5.1-1


### PR DESCRIPTION
Hi,

Latest version of ES **7.x** is `7.17.19`.
This PR is made for releasing this version.

I don't know if this PR is appropriate, given the conflict with master that support ES 8.x.

I checked out latest 7.x from the history, and incremented the version in gradle.properties.
Test are passing.
