### PR TITLE
Update elasticsearch 7.x to 7.17.10

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 ltrVersion = 1.5.8
-elasticsearchVersion = 7.17.7
+elasticsearchVersion = 7.17.10
 luceneVersion = 8.11.1
 ow2Version = 8.0.1
 antlrVersion = 4.5.1-1


### PR DESCRIPTION
Bump latest version of ES **7.x** to 7.17.10.

@nathancday Thanks for the release of last time (es 7.17.9) :+1: 