### PR TITLE
Update es7_17_X to Elasticsearch 7.17.11

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 ltrVersion = 1.5.8
-elasticsearchVersion = 7.17.10
+elasticsearchVersion = 7.17.11
 luceneVersion = 8.11.1
 ow2Version = 8.0.1
 antlrVersion = 4.5.1-1


### PR DESCRIPTION
We're looking into usage of this plugin but we'd like to install a matching Version on our Clusters.