### PR TITLE
update elasticsearch to 8.8.2 and lucene to 9.6.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 ltrVersion = 1.5.8
-elasticsearchVersion = 8.7.1
-luceneVersion = 9.5.0
+elasticsearchVersion = 8.8.1
+luceneVersion = 9.6.0
 ow2Version = 8.0.1
 antlrVersion = 4.5.1-1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 ltrVersion = 1.5.8
-elasticsearchVersion = 8.8.1
+elasticsearchVersion = 8.8.2
 luceneVersion = 9.6.0
 ow2Version = 8.0.1
 antlrVersion = 4.5.1-1

--- a/src/javaRestTest/java/com/o19s/es/ltr/logging/LoggingIT.java
+++ b/src/javaRestTest/java/com/o19s/es/ltr/logging/LoggingIT.java
@@ -623,7 +623,7 @@ public class LoggingIT extends BaseIntegrationTest {
             Doc d = docs.get(hit.getId());
 
             assertEquals(6, log1.size());
-            assertEquals(6, log2.size());
+            assertTrue(log2.size() > 3);
             if (d.field1.equals("found")) {
                 assertEquals(log1.get(0).get("name"), "text_feature1");
                 assertEquals(log2.get(0).get("name"), "text_feature1");

--- a/src/javaRestTest/java/com/o19s/es/ltr/logging/LoggingIT.java
+++ b/src/javaRestTest/java/com/o19s/es/ltr/logging/LoggingIT.java
@@ -623,7 +623,7 @@ public class LoggingIT extends BaseIntegrationTest {
             Doc d = docs.get(hit.getId());
 
             assertEquals(6, log1.size());
-            assertTrue(log2.size() > 3);
+            assertEquals(6, log2.size());
             if (d.field1.equals("found")) {
                 assertEquals(log1.get(0).get("name"), "text_feature1");
                 assertEquals(log2.get(0).get("name"), "text_feature1");

--- a/src/main/java/com/o19s/es/ltr/logging/LoggingFetchSubPhase.java
+++ b/src/main/java/com/o19s/es/ltr/logging/LoggingFetchSubPhase.java
@@ -108,9 +108,9 @@ public class LoggingFetchSubPhase implements FetchSubPhase {
                     "at index [" + logSpec.getRescoreIndex() + "]");
         }
         QueryRescorer.QueryRescoreContext qrescore = (QueryRescorer.QueryRescoreContext) context;
-        return toLogger(logSpec, inspectQuery(qrescore.query())
+        return toLogger(logSpec, inspectQuery(qrescore.parsedQuery().query())
                 .orElseThrow(() -> new IllegalArgumentException("Expected a [sltr] query but found a " +
-                        "[" + qrescore.query().getClass().getSimpleName() + "] " +
+                        "[" + qrescore.parsedQuery().query().getClass().getSimpleName() + "] " +
                         "at index [" + logSpec.getRescoreIndex() + "]")));
     }
 

--- a/src/main/java/com/o19s/es/ltr/utils/Suppliers.java
+++ b/src/main/java/com/o19s/es/ltr/utils/Suppliers.java
@@ -17,7 +17,7 @@
 package com.o19s.es.ltr.utils;
 
 import com.o19s.es.ltr.ranker.LtrRanker;
-import org.elasticsearch.Assertions;
+import org.elasticsearch.core.Assertions;
 import org.elasticsearch.common.CheckedSupplier;
 
 import java.util.Objects;


### PR DESCRIPTION
PR to update ES to 8.8.2 and Lucene to 9.6.0 based on original PR from @israelsimas (thanks!)