### PR TITLE
Add rank:ndcg and rank:map as valid objectives

### DIFF
--- a/docs/training-models.rst
+++ b/docs/training-models.rst
@@ -57,7 +57,7 @@ Currently supported parameters:
 
 **objective** - Defines the model learning objective as specified in the `XGBoost documentation <https://xgboost.readthedocs.io/en/latest/parameter.html#learning-task-parameters>`_. This parameter can transform the final model prediction. Using logistic objectives applies a sigmoid normalization.
 
-Currently supported values: 'binary:logistic', 'binary:logitraw', 'rank:pairwise', 'reg:linear', 'reg:logistic'
+Currently supported values: 'binary:logistic', 'binary:logitraw', 'rank:ndcg', 'rank:map', 'rank:pairwise', 'reg:linear', 'reg:logistic'
 
 ===================
 Simple linear models

--- a/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParser.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParser.java
@@ -118,6 +118,8 @@ public class XGBoostJsonParser implements LtrRankerParser {
         void setNormalizer(String objectiveName) {
             switch (objectiveName) {
                 case "binary:logitraw":
+                case "rank:ndcg":
+                case "rank:map":
                 case "rank:pairwise":
                 case "reg:linear":
                     normalizer = Normalizers.get(Normalizers.NOOP_NORMALIZER_NAME);


### PR DESCRIPTION
When attempting to use `rank:ndcg` as an objective model deployment failed unexpectedly, stating that the objective was invalid.

As per the [XGBoost docs](https://github.com/dmlc/xgboost/blob/1094d6015df7be6f5829e53a4c257f3481b43ee5/doc/parameter.rst#parameters-for-learning-to-rank-rank-ndcg-rank-map-rank-pairwise) `rank:ndcg` and `rank:map` are valid objectives, but are currently rejected by the parser.

This change resolves this by extending the list of objectives which map to the no-op normalizer, allowing the models to be parsed and used by the plugin.