### PR TITLE
Issue 481 - implement support for missing values with XGBoost

### DIFF
--- a/src/javaRestTest/java/com/o19s/es/ltr/NodeSettingsIT.java
+++ b/src/javaRestTest/java/com/o19s/es/ltr/NodeSettingsIT.java
@@ -81,14 +81,14 @@ public class NodeSettingsIT extends BaseIntegrationTest {
 
     public static class DummyModel extends CompiledLtrModel {
         public DummyModel(String name, long size) throws IOException {
-            super(name, LtrTestUtils.randomFeatureSet(1), new DummryRanker(size));
+            super(name, LtrTestUtils.randomFeatureSet(1), new DummyRanker(size));
         }
     }
 
-    public static class DummryRanker implements LtrRanker, Accountable {
+    public static class DummyRanker implements LtrRanker, Accountable {
         private final long ramUsed;
 
-        public DummryRanker(long ramUsed) {
+        public DummyRanker(long ramUsed) {
             this.ramUsed = ramUsed;
         }
 

--- a/src/javaRestTest/java/com/o19s/es/ltr/logging/LoggingIT.java
+++ b/src/javaRestTest/java/com/o19s/es/ltr/logging/LoggingIT.java
@@ -271,82 +271,82 @@ public class LoggingIT extends BaseIntegrationTest {
         SearchResponse resp4 = client().prepareSearch("test_index").setSource(sourceBuilder).get();
         assertSearchHits(docs, resp4);
     }
-
-    public void testLogExtraLogging() throws Exception {
-        prepareModelsExtraLogging();
-        Map<String, Doc> docs = buildIndex();
-
-        Map<String, Object> params = new HashMap<>();
-        params.put("query", "found");
-        List<String> idsColl = new ArrayList<>(docs.keySet());
-        Collections.shuffle(idsColl, random());
-        String[] ids = idsColl.subList(0, TestUtil.nextInt(random(), 5, 15)).toArray(new String[0]);
-        StoredLtrQueryBuilder sbuilder = new StoredLtrQueryBuilder(LtrTestUtils.nullLoader())
-                .featureSetName("my_set")
-                .params(params)
-                .queryName("test")
-                .boost(random().nextInt(3));
-
-        StoredLtrQueryBuilder sbuilder_rescore = new StoredLtrQueryBuilder(LtrTestUtils.nullLoader())
-                .featureSetName("my_set")
-                .params(params)
-                .queryName("test_rescore")
-                .boost(random().nextInt(3));
-
-        QueryBuilder query = QueryBuilders.boolQuery().must(new WrapperQueryBuilder(sbuilder.toString()))
-                .filter(QueryBuilders.idsQuery().addIds(ids));
-        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(query)
-                .fetchSource(false)
-                .size(10)
-                .addRescorer(new QueryRescorerBuilder(new WrapperQueryBuilder(sbuilder_rescore.toString())))
-                .ext(Collections.singletonList(
-                        new LoggingSearchExtBuilder()
-                                .addQueryLogging("first_log", "test", false)
-                                .addRescoreLogging("second_log", 0, true)));
-
-        SearchResponse resp = client().prepareSearch("test_index").setSource(sourceBuilder).get();
-        assertSearchHitsExtraLogging(docs, resp);
-        sbuilder.featureSetName(null);
-        sbuilder.modelName("my_model");
-        sbuilder.boost(random().nextInt(3));
-        sbuilder_rescore.featureSetName(null);
-        sbuilder_rescore.modelName("my_model");
-        sbuilder_rescore.boost(random().nextInt(3));
-
-        query = QueryBuilders.boolQuery().must(new WrapperQueryBuilder(sbuilder.toString()))
-                .filter(QueryBuilders.idsQuery().addIds(ids));
-        sourceBuilder = new SearchSourceBuilder().query(query)
-                .fetchSource(false)
-                .size(10)
-                .addRescorer(new QueryRescorerBuilder(new WrapperQueryBuilder(sbuilder_rescore.toString())))
-                .ext(Collections.singletonList(
-                        new LoggingSearchExtBuilder()
-                                .addQueryLogging("first_log", "test", false)
-                                .addRescoreLogging("second_log", 0, true)));
-
-        SearchResponse resp2 = client().prepareSearch("test_index").setSource(sourceBuilder).get();
-        assertSearchHitsExtraLogging(docs, resp2);
-
-        query = QueryBuilders.boolQuery()
-                .must(new WrapperQueryBuilder(sbuilder.toString()))
-                .must(
-                        QueryBuilders.nestedQuery(
-                                "nesteddocs1",
-                                QueryBuilders.boolQuery().filter(QueryBuilders.termQuery("nesteddocs1.field1", "nestedvalue")),
-                                ScoreMode.None
-                        ).innerHit(new InnerHitBuilder())
-                );
-        sourceBuilder = new SearchSourceBuilder().query(query)
-                .fetchSource(false)
-                .size(10)
-                .addRescorer(new QueryRescorerBuilder(new WrapperQueryBuilder(sbuilder_rescore.toString())))
-                .ext(Collections.singletonList(
-                        new LoggingSearchExtBuilder()
-                                .addQueryLogging("first_log", "test", false)
-                                .addRescoreLogging("second_log", 0, true)));
-        SearchResponse resp3 = client().prepareSearch("test_index").setSource(sourceBuilder).get();
-        assertSearchHitsExtraLogging(docs, resp3);
-    }
+// TODO turn this back on
+//    public void testLogExtraLogging() throws Exception {
+//        prepareModelsExtraLogging();
+//        Map<String, Doc> docs = buildIndex();
+//
+//        Map<String, Object> params = new HashMap<>();
+//        params.put("query", "found");
+//        List<String> idsColl = new ArrayList<>(docs.keySet());
+//        Collections.shuffle(idsColl, random());
+//        String[] ids = idsColl.subList(0, TestUtil.nextInt(random(), 5, 15)).toArray(new String[0]);
+//        StoredLtrQueryBuilder sbuilder = new StoredLtrQueryBuilder(LtrTestUtils.nullLoader())
+//                .featureSetName("my_set")
+//                .params(params)
+//                .queryName("test")
+//                .boost(random().nextInt(3));
+//
+//        StoredLtrQueryBuilder sbuilder_rescore = new StoredLtrQueryBuilder(LtrTestUtils.nullLoader())
+//                .featureSetName("my_set")
+//                .params(params)
+//                .queryName("test_rescore")
+//                .boost(random().nextInt(3));
+//
+//        QueryBuilder query = QueryBuilders.boolQuery().must(new WrapperQueryBuilder(sbuilder.toString()))
+//                .filter(QueryBuilders.idsQuery().addIds(ids));
+//        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(query)
+//                .fetchSource(false)
+//                .size(10)
+//                .addRescorer(new QueryRescorerBuilder(new WrapperQueryBuilder(sbuilder_rescore.toString())))
+//                .ext(Collections.singletonList(
+//                        new LoggingSearchExtBuilder()
+//                                .addQueryLogging("first_log", "test", false)
+//                                .addRescoreLogging("second_log", 0, true)));
+//
+//        SearchResponse resp = client().prepareSearch("test_index").setSource(sourceBuilder).get();
+//        assertSearchHitsExtraLogging(docs, resp);
+//        sbuilder.featureSetName(null);
+//        sbuilder.modelName("my_model");
+//        sbuilder.boost(random().nextInt(3));
+//        sbuilder_rescore.featureSetName(null);
+//        sbuilder_rescore.modelName("my_model");
+//        sbuilder_rescore.boost(random().nextInt(3));
+//
+//        query = QueryBuilders.boolQuery().must(new WrapperQueryBuilder(sbuilder.toString()))
+//                .filter(QueryBuilders.idsQuery().addIds(ids));
+//        sourceBuilder = new SearchSourceBuilder().query(query)
+//                .fetchSource(false)
+//                .size(10)
+//                .addRescorer(new QueryRescorerBuilder(new WrapperQueryBuilder(sbuilder_rescore.toString())))
+//                .ext(Collections.singletonList(
+//                        new LoggingSearchExtBuilder()
+//                                .addQueryLogging("first_log", "test", false)
+//                                .addRescoreLogging("second_log", 0, true)));
+//
+//        SearchResponse resp2 = client().prepareSearch("test_index").setSource(sourceBuilder).get();
+//        assertSearchHitsExtraLogging(docs, resp2);
+//
+//        query = QueryBuilders.boolQuery()
+//                .must(new WrapperQueryBuilder(sbuilder.toString()))
+//                .must(
+//                        QueryBuilders.nestedQuery(
+//                                "nesteddocs1",
+//                                QueryBuilders.boolQuery().filter(QueryBuilders.termQuery("nesteddocs1.field1", "nestedvalue")),
+//                                ScoreMode.None
+//                        ).innerHit(new InnerHitBuilder())
+//                );
+//        sourceBuilder = new SearchSourceBuilder().query(query)
+//                .fetchSource(false)
+//                .size(10)
+//                .addRescorer(new QueryRescorerBuilder(new WrapperQueryBuilder(sbuilder_rescore.toString())))
+//                .ext(Collections.singletonList(
+//                        new LoggingSearchExtBuilder()
+//                                .addQueryLogging("first_log", "test", false)
+//                                .addRescoreLogging("second_log", 0, true)));
+//        SearchResponse resp3 = client().prepareSearch("test_index").setSource(sourceBuilder).get();
+//        assertSearchHitsExtraLogging(docs, resp3);
+//    }
 
     public void testLogWithFeatureScoreCache() throws Exception {
         prepareModels();

--- a/src/javaRestTest/java/com/o19s/es/ltr/logging/LoggingIT.java
+++ b/src/javaRestTest/java/com/o19s/es/ltr/logging/LoggingIT.java
@@ -271,82 +271,82 @@ public class LoggingIT extends BaseIntegrationTest {
         SearchResponse resp4 = client().prepareSearch("test_index").setSource(sourceBuilder).get();
         assertSearchHits(docs, resp4);
     }
-// TODO turn this back on
-//    public void testLogExtraLogging() throws Exception {
-//        prepareModelsExtraLogging();
-//        Map<String, Doc> docs = buildIndex();
-//
-//        Map<String, Object> params = new HashMap<>();
-//        params.put("query", "found");
-//        List<String> idsColl = new ArrayList<>(docs.keySet());
-//        Collections.shuffle(idsColl, random());
-//        String[] ids = idsColl.subList(0, TestUtil.nextInt(random(), 5, 15)).toArray(new String[0]);
-//        StoredLtrQueryBuilder sbuilder = new StoredLtrQueryBuilder(LtrTestUtils.nullLoader())
-//                .featureSetName("my_set")
-//                .params(params)
-//                .queryName("test")
-//                .boost(random().nextInt(3));
-//
-//        StoredLtrQueryBuilder sbuilder_rescore = new StoredLtrQueryBuilder(LtrTestUtils.nullLoader())
-//                .featureSetName("my_set")
-//                .params(params)
-//                .queryName("test_rescore")
-//                .boost(random().nextInt(3));
-//
-//        QueryBuilder query = QueryBuilders.boolQuery().must(new WrapperQueryBuilder(sbuilder.toString()))
-//                .filter(QueryBuilders.idsQuery().addIds(ids));
-//        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(query)
-//                .fetchSource(false)
-//                .size(10)
-//                .addRescorer(new QueryRescorerBuilder(new WrapperQueryBuilder(sbuilder_rescore.toString())))
-//                .ext(Collections.singletonList(
-//                        new LoggingSearchExtBuilder()
-//                                .addQueryLogging("first_log", "test", false)
-//                                .addRescoreLogging("second_log", 0, true)));
-//
-//        SearchResponse resp = client().prepareSearch("test_index").setSource(sourceBuilder).get();
-//        assertSearchHitsExtraLogging(docs, resp);
-//        sbuilder.featureSetName(null);
-//        sbuilder.modelName("my_model");
-//        sbuilder.boost(random().nextInt(3));
-//        sbuilder_rescore.featureSetName(null);
-//        sbuilder_rescore.modelName("my_model");
-//        sbuilder_rescore.boost(random().nextInt(3));
-//
-//        query = QueryBuilders.boolQuery().must(new WrapperQueryBuilder(sbuilder.toString()))
-//                .filter(QueryBuilders.idsQuery().addIds(ids));
-//        sourceBuilder = new SearchSourceBuilder().query(query)
-//                .fetchSource(false)
-//                .size(10)
-//                .addRescorer(new QueryRescorerBuilder(new WrapperQueryBuilder(sbuilder_rescore.toString())))
-//                .ext(Collections.singletonList(
-//                        new LoggingSearchExtBuilder()
-//                                .addQueryLogging("first_log", "test", false)
-//                                .addRescoreLogging("second_log", 0, true)));
-//
-//        SearchResponse resp2 = client().prepareSearch("test_index").setSource(sourceBuilder).get();
-//        assertSearchHitsExtraLogging(docs, resp2);
-//
-//        query = QueryBuilders.boolQuery()
-//                .must(new WrapperQueryBuilder(sbuilder.toString()))
-//                .must(
-//                        QueryBuilders.nestedQuery(
-//                                "nesteddocs1",
-//                                QueryBuilders.boolQuery().filter(QueryBuilders.termQuery("nesteddocs1.field1", "nestedvalue")),
-//                                ScoreMode.None
-//                        ).innerHit(new InnerHitBuilder())
-//                );
-//        sourceBuilder = new SearchSourceBuilder().query(query)
-//                .fetchSource(false)
-//                .size(10)
-//                .addRescorer(new QueryRescorerBuilder(new WrapperQueryBuilder(sbuilder_rescore.toString())))
-//                .ext(Collections.singletonList(
-//                        new LoggingSearchExtBuilder()
-//                                .addQueryLogging("first_log", "test", false)
-//                                .addRescoreLogging("second_log", 0, true)));
-//        SearchResponse resp3 = client().prepareSearch("test_index").setSource(sourceBuilder).get();
-//        assertSearchHitsExtraLogging(docs, resp3);
-//    }
+
+    public void testLogExtraLogging() throws Exception {
+        prepareModelsExtraLogging();
+        Map<String, Doc> docs = buildIndex();
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("query", "found");
+        List<String> idsColl = new ArrayList<>(docs.keySet());
+        Collections.shuffle(idsColl, random());
+        String[] ids = idsColl.subList(0, TestUtil.nextInt(random(), 5, 15)).toArray(new String[0]);
+        StoredLtrQueryBuilder sbuilder = new StoredLtrQueryBuilder(LtrTestUtils.nullLoader())
+                .featureSetName("my_set")
+                .params(params)
+                .queryName("test")
+                .boost(random().nextInt(3));
+
+        StoredLtrQueryBuilder sbuilder_rescore = new StoredLtrQueryBuilder(LtrTestUtils.nullLoader())
+                .featureSetName("my_set")
+                .params(params)
+                .queryName("test_rescore")
+                .boost(random().nextInt(3));
+
+        QueryBuilder query = QueryBuilders.boolQuery().must(new WrapperQueryBuilder(sbuilder.toString()))
+                .filter(QueryBuilders.idsQuery().addIds(ids));
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(query)
+                .fetchSource(false)
+                .size(10)
+                .addRescorer(new QueryRescorerBuilder(new WrapperQueryBuilder(sbuilder_rescore.toString())))
+                .ext(Collections.singletonList(
+                        new LoggingSearchExtBuilder()
+                                .addQueryLogging("first_log", "test", false)
+                                .addRescoreLogging("second_log", 0, true)));
+
+        SearchResponse resp = client().prepareSearch("test_index").setSource(sourceBuilder).get();
+        assertSearchHitsExtraLogging(docs, resp);
+        sbuilder.featureSetName(null);
+        sbuilder.modelName("my_model");
+        sbuilder.boost(random().nextInt(3));
+        sbuilder_rescore.featureSetName(null);
+        sbuilder_rescore.modelName("my_model");
+        sbuilder_rescore.boost(random().nextInt(3));
+
+        query = QueryBuilders.boolQuery().must(new WrapperQueryBuilder(sbuilder.toString()))
+                .filter(QueryBuilders.idsQuery().addIds(ids));
+        sourceBuilder = new SearchSourceBuilder().query(query)
+                .fetchSource(false)
+                .size(10)
+                .addRescorer(new QueryRescorerBuilder(new WrapperQueryBuilder(sbuilder_rescore.toString())))
+                .ext(Collections.singletonList(
+                        new LoggingSearchExtBuilder()
+                                .addQueryLogging("first_log", "test", false)
+                                .addRescoreLogging("second_log", 0, true)));
+
+        SearchResponse resp2 = client().prepareSearch("test_index").setSource(sourceBuilder).get();
+        assertSearchHitsExtraLogging(docs, resp2);
+
+        query = QueryBuilders.boolQuery()
+                .must(new WrapperQueryBuilder(sbuilder.toString()))
+                .must(
+                        QueryBuilders.nestedQuery(
+                                "nesteddocs1",
+                                QueryBuilders.boolQuery().filter(QueryBuilders.termQuery("nesteddocs1.field1", "nestedvalue")),
+                                ScoreMode.None
+                        ).innerHit(new InnerHitBuilder())
+                );
+        sourceBuilder = new SearchSourceBuilder().query(query)
+                .fetchSource(false)
+                .size(10)
+                .addRescorer(new QueryRescorerBuilder(new WrapperQueryBuilder(sbuilder_rescore.toString())))
+                .ext(Collections.singletonList(
+                        new LoggingSearchExtBuilder()
+                                .addQueryLogging("first_log", "test", false)
+                                .addRescoreLogging("second_log", 0, true)));
+        SearchResponse resp3 = client().prepareSearch("test_index").setSource(sourceBuilder).get();
+        assertSearchHitsExtraLogging(docs, resp3);
+    }
 
     public void testLogWithFeatureScoreCache() throws Exception {
         prepareModels();

--- a/src/javaRestTest/java/com/o19s/es/ltr/query/StoredLtrQueryIT.java
+++ b/src/javaRestTest/java/com/o19s/es/ltr/query/StoredLtrQueryIT.java
@@ -74,10 +74,10 @@ public class StoredLtrQueryIT extends BaseIntegrationTest {
             "\"nodeid\": 0," +
             "\"split\":\"text_feature1\"," +
             "\"depth\":0," +
-            "\"split_condition\":0.0," +
+            "\"split_condition\":100.0," +
             "\"yes\":1," +
-            "\"no\": 2," +
-            "\"missing\":1," +
+            "\"no\":2," +
+            "\"missing\":2," +
             "\"children\": [" +
             "   {\"nodeid\": 1, \"depth\": 1, \"leaf\": 0.5}," +
             "   {\"nodeid\": 2, \"depth\": 1, \"leaf\": 0.2}" +
@@ -130,11 +130,11 @@ public class StoredLtrQueryIT extends BaseIntegrationTest {
         assertTrue(logs.containsKey("log"));
         List<Map<String, Object>> log = logs.get("log");
 
-        // verify that text_feature1 has a missing value, and that the score results from the model taking the
+        // verify that text_feature1 has a missing value, and that the reported score results from the model taking the
         // corresponding branch
         assertEquals("text_feature1", log.get(0).get("name"));
         assertEquals(null, log.get(0).get("value"));
-        assertEquals(0.5F, resp.getHits().getAt(0).getScore(), Math.ulp(0.5F));
+        assertEquals(0.2F, resp.getHits().getAt(0).getScore(), Math.ulp(0.2F));
     }
 
     public void testScriptFeatureUseCase() throws Exception {

--- a/src/main/java/com/o19s/es/ltr/query/RankerQuery.java
+++ b/src/main/java/com/o19s/es/ltr/query/RankerQuery.java
@@ -259,7 +259,8 @@ public class RankerQuery extends Query {
                 }
                 featureString += ":";
                 if (!explain.isMatch()) {
-                    subs.add(Explanation.noMatch(featureString + String.format(" [no match, default value of %.2f used]", d.getDefaultScore())));
+                    subs.add(Explanation.noMatch(featureString +
+                            String.format(" [no match, default value of %.2f used]", d.getDefaultScore())));
                 } else {
                     subs.add(Explanation.match(explain.getValue(), featureString, explain));
                     d.setFeatureScore(ordinal, explain.getValue().floatValue());

--- a/src/main/java/com/o19s/es/ltr/query/RankerQuery.java
+++ b/src/main/java/com/o19s/es/ltr/query/RankerQuery.java
@@ -259,7 +259,7 @@ public class RankerQuery extends Query {
                 }
                 featureString += ":";
                 if (!explain.isMatch()) {
-                    subs.add(Explanation.noMatch(featureString + " [no match, default value 0.0 used]"));
+                    subs.add(Explanation.noMatch(featureString + " [no match, default value used]"));
                 } else {
                     subs.add(Explanation.match(explain.getValue(), featureString, explain));
                     d.setFeatureScore(ordinal, explain.getValue().floatValue());

--- a/src/main/java/com/o19s/es/ltr/query/RankerQuery.java
+++ b/src/main/java/com/o19s/es/ltr/query/RankerQuery.java
@@ -259,7 +259,7 @@ public class RankerQuery extends Query {
                 }
                 featureString += ":";
                 if (!explain.isMatch()) {
-                    subs.add(Explanation.noMatch(featureString + " [no match, default value used]"));
+                    subs.add(Explanation.noMatch(featureString + String.format(" [no match, default value of %.2f used]", d.getDefaultScore())));
                 } else {
                     subs.add(Explanation.match(explain.getValue(), featureString, explain));
                     d.setFeatureScore(ordinal, explain.getValue().floatValue());

--- a/src/main/java/com/o19s/es/ltr/ranker/ArrayFeatureVector.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/ArrayFeatureVector.java
@@ -16,9 +16,28 @@
 
 package com.o19s.es.ltr.ranker;
 
-public class DenseFeatureVector extends ArrayFeatureVector {
+import java.util.Arrays;
 
-    public DenseFeatureVector(int size) {
-        super(size, 0F);
+public class ArrayFeatureVector implements LtrRanker.FeatureVector {
+    public final float[] scores;
+    public final float defaultScore;
+
+    public ArrayFeatureVector(int size, float value) {
+        scores = new float[size];
+        defaultScore = value;
+    }
+
+    @Override
+    public void setFeatureScore(int featureIdx, float score) {
+        scores[featureIdx] = score;
+    }
+
+    @Override
+    public float getFeatureScore(int featureIdx) {
+        return scores[featureIdx];
+    }
+
+    public void reset() {
+        Arrays.fill(scores, defaultScore);
     }
 }

--- a/src/main/java/com/o19s/es/ltr/ranker/ArrayFeatureVector.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/ArrayFeatureVector.java
@@ -40,4 +40,9 @@ public class ArrayFeatureVector implements LtrRanker.FeatureVector {
     public void reset() {
         Arrays.fill(scores, defaultScore);
     }
+
+    @Override
+    public float getDefaultScore() {
+        return defaultScore;
+    }
 }

--- a/src/main/java/com/o19s/es/ltr/ranker/LogLtrRanker.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/LogLtrRanker.java
@@ -80,6 +80,10 @@ public class LogLtrRanker implements LtrRanker {
             this.inner = ranker.newFeatureVector(inner);
             logger.reset();
         }
+
+        public float getDefaultScore() {
+            return inner.getDefaultScore();
+        }
     }
 
     public LogConsumer getLogConsumer() {

--- a/src/main/java/com/o19s/es/ltr/ranker/LtrRanker.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/LtrRanker.java
@@ -73,5 +73,11 @@ public interface LtrRanker {
          */
         float getFeatureScore(int featureId);
 
+        /**
+         * Retrieve the default score
+         * @return the score computed for the given feature
+         */
+        float getDefaultScore();
+
     }
 }

--- a/src/main/java/com/o19s/es/ltr/ranker/LtrRanker.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/LtrRanker.java
@@ -46,7 +46,7 @@ public interface LtrRanker {
     /**
      * Score the data point.
      * At this point all feature scores are set.
-     * features that did not match are set with a score to 0
+     * features that did not match are set with a default score
      *
      * @param point the feature vector point to compute the score for
      * @return the score computed for the given point

--- a/src/main/java/com/o19s/es/ltr/ranker/SparseFeatureVector.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/SparseFeatureVector.java
@@ -16,9 +16,10 @@
 
 package com.o19s.es.ltr.ranker;
 
-public class DenseFeatureVector extends ArrayFeatureVector {
+public class SparseFeatureVector extends ArrayFeatureVector {
 
-    public DenseFeatureVector(int size) {
-        super(size, 0F);
+    public SparseFeatureVector(int size) {
+        super(size, Float.NaN);
+        reset();
     }
 }

--- a/src/main/java/com/o19s/es/ltr/ranker/SparseLtrRanker.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/SparseLtrRanker.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.ranker;
+
+/**
+ * A dense ranker base class to work with {@link SparseFeatureVector}
+ * where missing feature scores are set to 0.
+ */
+public abstract class SparseLtrRanker implements LtrRanker {
+    @Override
+    public SparseFeatureVector newFeatureVector(FeatureVector reuse) {
+        if (reuse != null) {
+            assert reuse instanceof SparseFeatureVector;
+            SparseFeatureVector vector = (SparseFeatureVector) reuse;
+            vector.reset();
+            return vector;
+        }
+        return new SparseFeatureVector(size());
+    }
+
+    @Override
+    public float score(FeatureVector vector) {
+        assert vector instanceof SparseFeatureVector;
+        return this.score((SparseFeatureVector) vector);
+    }
+
+    protected abstract float score(SparseFeatureVector vector);
+
+    /**
+     * @return the number of features supported by this ranker
+     */
+    protected abstract int size();
+}

--- a/src/main/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTree.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTree.java
@@ -16,8 +16,8 @@
 
 package com.o19s.es.ltr.ranker.dectree;
 
-import com.o19s.es.ltr.ranker.DenseFeatureVector;
-import com.o19s.es.ltr.ranker.DenseLtrRanker;
+import com.o19s.es.ltr.ranker.SparseFeatureVector;
+import com.o19s.es.ltr.ranker.SparseLtrRanker;
 import com.o19s.es.ltr.ranker.normalizer.Normalizer;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Naive implementation of additive decision tree.
  * May be slow when the number of trees and tree complexity if high comparatively to the number of features.
  */
-public class NaiveAdditiveDecisionTree extends DenseLtrRanker implements Accountable {
+public class NaiveAdditiveDecisionTree extends SparseLtrRanker implements Accountable {
     private static final long BASE_RAM_USED = RamUsageEstimator.shallowSizeOfInstance(Split.class);
 
     private final Node[] trees;
@@ -60,7 +60,7 @@ public class NaiveAdditiveDecisionTree extends DenseLtrRanker implements Account
     }
 
     @Override
-    protected float score(DenseFeatureVector vector) {
+    protected float score(SparseFeatureVector vector) {
         float sum = 0;
         float[] scores = vector.scores;
         for (int i = 0; i < trees.length; i++) {

--- a/src/main/java/com/o19s/es/ltr/ranker/ranklib/DenseProgramaticDataPoint.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/ranklib/DenseProgramaticDataPoint.java
@@ -23,7 +23,7 @@ import com.o19s.es.ltr.ranker.LtrRanker;
 import java.util.Arrays;
 
 /**
- * Implements FeatureVector but without needing to pass in a stirng
+ * Implements FeatureVector but without needing to pass in a string
  * to be parsed
  */
 public class DenseProgramaticDataPoint extends DataPoint implements LtrRanker.FeatureVector {
@@ -70,5 +70,9 @@ public class DenseProgramaticDataPoint extends DataPoint implements LtrRanker.Fe
 
     public void reset() {
         Arrays.fill(fVals, 0F);
+    }
+
+    public float getDefaultScore() {
+        return 0.0F;
     }
 }

--- a/src/test/java/com/o19s/es/ltr/ranker/DenseFeatureVectorTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/DenseFeatureVectorTests.java
@@ -19,7 +19,7 @@ package com.o19s.es.ltr.ranker;
 import org.apache.lucene.tests.util.LuceneTestCase;
 
 public class DenseFeatureVectorTests extends LuceneTestCase {
-    public void testConstructor() throws Exception {
+    public void testConstructor() {
         int size = 10;
         DenseFeatureVector featureVector = new DenseFeatureVector(size);
         for (float score : featureVector.scores) {
@@ -27,7 +27,7 @@ public class DenseFeatureVectorTests extends LuceneTestCase {
         }
     }
 
-    public void testSetGetReset() throws Exception {
+    public void testSetGetReset() {
         int size = 10;
         DenseFeatureVector featureVector = new DenseFeatureVector(size);
         featureVector.setFeatureScore(5, 3.15F);
@@ -40,6 +40,10 @@ public class DenseFeatureVectorTests extends LuceneTestCase {
         for (int featureId = 0; featureId < size; featureId++) {
             assertEquals(0F, featureVector.getFeatureScore(featureId), Math.ulp(0F));
         }
+    }
+
+    public void testGetDefaultValue() {
+        assertEquals(0F, new DenseFeatureVector(10).getDefaultScore(), Math.ulp(0F));
     }
 
 }

--- a/src/test/java/com/o19s/es/ltr/ranker/DenseFeatureVectorTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/DenseFeatureVectorTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.ranker;
+
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+public class DenseFeatureVectorTests extends LuceneTestCase {
+    public void testConstructor() throws Exception {
+        int size = 10;
+        DenseFeatureVector featureVector = new DenseFeatureVector(size);
+        for (float score : featureVector.scores) {
+            assertEquals(0F, score, Math.ulp(0F));
+        }
+    }
+
+    public void testSetGetReset() throws Exception {
+        int size = 10;
+        DenseFeatureVector featureVector = new DenseFeatureVector(size);
+        featureVector.setFeatureScore(5, 3.15F);
+
+        assertEquals(3.15F, featureVector.getFeatureScore(5), Math.ulp(3.15F));
+        assertEquals(0F, featureVector.getFeatureScore(0), Math.ulp(0F));
+
+        featureVector.reset();
+
+        for (int featureId = 0; featureId < size; featureId++) {
+            assertEquals(0F, featureVector.getFeatureScore(featureId), Math.ulp(0F));
+        }
+    }
+
+}

--- a/src/test/java/com/o19s/es/ltr/ranker/SparseFeatureVectorTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/SparseFeatureVectorTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.ranker;
+
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+public class SparseFeatureVectorTests extends LuceneTestCase {
+    public void testConstructor() throws Exception {
+        int size = 10;
+        SparseFeatureVector featureVector = new SparseFeatureVector(size);
+        for (float score : featureVector.scores) {
+            assertTrue(Float.isNaN(score));
+        }
+    }
+
+    public void testSetGetReset() throws Exception {
+        int size = 10;
+        SparseFeatureVector featureVector = new SparseFeatureVector(size);
+        featureVector.setFeatureScore(5, 3.15F);
+
+        assertEquals(3.15F, featureVector.getFeatureScore(5), Math.ulp(3.15F));
+        assertTrue(Float.isNaN(featureVector.getFeatureScore(0)));
+
+        featureVector.reset();
+
+        for (int featureId = 0; featureId < size; featureId++) {
+            assertTrue(Float.isNaN(featureVector.getFeatureScore(featureId)));
+        }
+    }
+
+}

--- a/src/test/java/com/o19s/es/ltr/ranker/SparseFeatureVectorTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/SparseFeatureVectorTests.java
@@ -19,7 +19,7 @@ package com.o19s.es.ltr.ranker;
 import org.apache.lucene.tests.util.LuceneTestCase;
 
 public class SparseFeatureVectorTests extends LuceneTestCase {
-    public void testConstructor() throws Exception {
+    public void testConstructor() {
         int size = 10;
         SparseFeatureVector featureVector = new SparseFeatureVector(size);
         for (float score : featureVector.scores) {
@@ -27,7 +27,7 @@ public class SparseFeatureVectorTests extends LuceneTestCase {
         }
     }
 
-    public void testSetGetReset() throws Exception {
+    public void testSetGetReset() {
         int size = 10;
         SparseFeatureVector featureVector = new SparseFeatureVector(size);
         featureVector.setFeatureScore(5, 3.15F);
@@ -40,6 +40,10 @@ public class SparseFeatureVectorTests extends LuceneTestCase {
         for (int featureId = 0; featureId < size; featureId++) {
             assertTrue(Float.isNaN(featureVector.getFeatureScore(featureId)));
         }
+    }
+
+    public void testGetDefaultValue() {
+        assertTrue(Float.isNaN(new SparseFeatureVector(10).getDefaultScore()));
     }
 
 }

--- a/src/test/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTreeTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTreeTests.java
@@ -19,8 +19,8 @@ package com.o19s.es.ltr.ranker.dectree;
 import com.o19s.es.ltr.feature.FeatureSet;
 import com.o19s.es.ltr.feature.PrebuiltFeature;
 import com.o19s.es.ltr.feature.PrebuiltFeatureSet;
-import com.o19s.es.ltr.ranker.DenseFeatureVector;
 import com.o19s.es.ltr.ranker.LtrRanker;
+import com.o19s.es.ltr.ranker.SparseFeatureVector;
 import com.o19s.es.ltr.ranker.linear.LinearRankerTests;
 import com.o19s.es.ltr.ranker.normalizer.Normalizer;
 import com.o19s.es.ltr.ranker.normalizer.Normalizers;
@@ -100,15 +100,15 @@ public class NaiveAdditiveDecisionTreeTests extends LuceneTestCase {
                 100, 1000,
                 5, 50, counts);
 
-        DenseFeatureVector vector = ranker.newFeatureVector(null);
+        SparseFeatureVector vector = ranker.newFeatureVector(null);
         int nPass = TestUtil.nextInt(random(), 10, 8916);
-        LinearRankerTests.fillRandomWeights(vector.scores);
+        fillRandomWeights(vector.scores);
         ranker.score(vector); // warmup
 
         long time = -System.currentTimeMillis();
         for (int i = 0; i < nPass; i++) {
             vector = ranker.newFeatureVector(vector);
-            LinearRankerTests.fillRandomWeights(vector.scores);
+            fillRandomWeights(vector.scores);
             ranker.score(vector);
         }
         time += System.currentTimeMillis();
@@ -338,6 +338,12 @@ public class NaiveAdditiveDecisionTreeTests extends LuceneTestCase {
         @Override
         public void newTree() {
             trees.incrementAndGet();
+        }
+    }
+    public static void fillRandomWeights(float[] weights) {
+        for (int i = 0; i < weights.length; i++) {
+            if (random().nextBoolean())
+                weights[i] = (float) nextInt(random(),1, 100000) / (float) nextInt(random(), 1, 100000);
         }
     }
 }

--- a/src/test/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParserTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParserTests.java
@@ -20,7 +20,7 @@ import com.o19s.es.ltr.LtrTestUtils;
 import com.o19s.es.ltr.feature.FeatureSet;
 import com.o19s.es.ltr.feature.store.StoredFeature;
 import com.o19s.es.ltr.feature.store.StoredFeatureSet;
-import com.o19s.es.ltr.ranker.DenseFeatureVector;
+import com.o19s.es.ltr.ranker.SparseFeatureVector;
 import com.o19s.es.ltr.ranker.LtrRanker.FeatureVector;
 import com.o19s.es.ltr.ranker.dectree.NaiveAdditiveDecisionTree;
 import com.o19s.es.ltr.ranker.linear.LinearRankerTests;
@@ -268,7 +268,7 @@ public class XGBoostJsonParserTests extends LuceneTestCase {
 
         StoredFeatureSet set = new StoredFeatureSet("set", features);
         NaiveAdditiveDecisionTree tree = parser.parse(set, model);
-        DenseFeatureVector v = tree.newFeatureVector(null);
+        SparseFeatureVector v = tree.newFeatureVector(null);
         assertEquals(v.scores.length, features.size());
 
         for (int i = random().nextInt(5000) + 1000; i > 0; i--) {


### PR DESCRIPTION
This PR attempts to implement support for missing values with XGBoost (https://github.com/o19s/elasticsearch-learning-to-rank/issues/481). 

The main logic change pertains to the initialization of the FeatureVector. As of now, the DenseFeatureVector has a default value of 0.0, and feature scores are filled in with actual values only when they are present. Effectively, features which are missing are given a value of 0.0. This happens "upstream," and by the time XGBoost model (NaiveAdditiveDecisionTree) is invoked, there is no longer any missing feature value.

The implementation here adds a new class called SparseFeatureVector that gives features a default value of Float.NaN, enabling XGBoost model to actually follow branches where the feature is missing.