### PR TITLE
Update README.md - Fix Broken Berlin Buzzwords URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,6 @@ We do our best to officially support `*.*.1` releases of Elasticsearch.  If you 
 
 ## Other Acknowledgments & Stuff To Read
 - Bloomberg's [Learning to Rank work for Solr](https://issues.apache.org/jira/browse/SOLR-8542)
-- Our Berlin Buzzwords Talk, [We built an Elasticsearch Learning to Rank plugin. Then came the hard part](https://berlinbuzzwords.de/17/session/we-built-elasticsearch-learning-rank-plugin-then-came-hard-part)
+- Our Berlin Buzzwords Talk, [We built an Elasticsearch Learning to Rank plugin. Then came the hard part](https://2017.berlinbuzzwords.de/17/session/we-built-elasticsearch-learning-rank-plugin-then-came-hard-part.html)
 - Blog article on [How is Search Different from Other Machine Learning Problems](http://opensourceconnections.com/blog/2017/08/03/search-as-machine-learning-prob/)
 - Also check out our other relevance/search thingies: book [Relevant Search](http://manning.com/books/relevant-search), projects [Elyzer](http://github.com/o19s/elyzer), [Splainer](http://splainer.io), and [Quepid](http://quepid.com)


### PR DESCRIPTION
Noticed a broken link for the Berlin Buzzwords talk while reading the README. It seems the URL redirects to a 2024 subdomain which results in a 404 page. Figured I'd post a quick PR to fix the link (assuming I found the correct URL).