### PR TITLE
Upgrade to Elasticsearch 8.14.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 ltrVersion = 1.5.8
-elasticsearchVersion = 8.13.4
+elasticsearchVersion = 8.14.0
 luceneVersion = 9.10.0
 ow2Version = 8.0.1
 antlrVersion = 4.5.1-1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 ltrVersion = 1.5.8
-elasticsearchVersion = 8.11.4
-luceneVersion = 9.8.0
+elasticsearchVersion = 8.13.4
+luceneVersion = 9.10.0
 ow2Version = 8.0.1
 antlrVersion = 4.5.1-1

--- a/src/javaRestTest/java/com/o19s/es/ltr/action/BaseIntegrationTest.java
+++ b/src/javaRestTest/java/com/o19s/es/ltr/action/BaseIntegrationTest.java
@@ -26,7 +26,7 @@ import com.o19s.es.ltr.feature.store.index.IndexFeatureStore;
 import com.o19s.es.ltr.ranker.parser.LtrRankerParserFactory;
 import com.o19s.es.ltr.ranker.ranklib.RankLibScriptEngine;
 import org.elasticsearch.action.DocWriteResponse;
-import org.elasticsearch.action.admin.indices.create.CreateIndexAction;
+import org.elasticsearch.action.admin.indices.create.TransportCreateIndexAction;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.core.Nullable;
@@ -70,7 +70,7 @@ public abstract class BaseIntegrationTest extends ESSingleNodeTestCase {
 
     public void createStore(String name) throws Exception {
         assert IndexFeatureStore.isIndexStore(name);
-        CreateIndexResponse resp = client().execute(CreateIndexAction.INSTANCE, IndexFeatureStore.buildIndexRequest(name)).get();
+        CreateIndexResponse resp = client().execute(TransportCreateIndexAction.TYPE, IndexFeatureStore.buildIndexRequest(name)).get();
         assertTrue(resp.isAcknowledged());
     }
 

--- a/src/javaRestTest/java/com/o19s/es/ltr/logging/LoggingIT.java
+++ b/src/javaRestTest/java/com/o19s/es/ltr/logging/LoggingIT.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
@@ -213,9 +214,7 @@ public class LoggingIT extends BaseIntegrationTest {
                         new LoggingSearchExtBuilder()
                                 .addQueryLogging("first_log", "test", false)
                                 .addRescoreLogging("second_log", 0, true)));
-
-        SearchResponse resp = client().prepareSearch("test_index").setSource(sourceBuilder).get();
-        assertSearchHits(docs, resp);
+        assertResponse(client().prepareSearch("test_index").setSource(sourceBuilder), resp -> assertSearchHits(docs, resp));
         sbuilder.featureSetName(null);
         sbuilder.modelName("my_model");
         sbuilder.boost(random().nextInt(3));
@@ -234,8 +233,7 @@ public class LoggingIT extends BaseIntegrationTest {
                                 .addQueryLogging("first_log", "test", false)
                                 .addRescoreLogging("second_log", 0, true)));
 
-        SearchResponse resp2 = client().prepareSearch("test_index").setSource(sourceBuilder).get();
-        assertSearchHits(docs, resp2);
+        assertResponse(client().prepareSearch("test_index").setSource(sourceBuilder), resp -> assertSearchHits(docs, resp));
 
         query = QueryBuilders.boolQuery()
                 .must(new WrapperQueryBuilder(sbuilder.toString()))
@@ -254,8 +252,7 @@ public class LoggingIT extends BaseIntegrationTest {
                         new LoggingSearchExtBuilder()
                                 .addQueryLogging("first_log", "test", false)
                                 .addRescoreLogging("second_log", 0, true)));
-        SearchResponse resp3 = client().prepareSearch("test_index").setSource(sourceBuilder).get();
-        assertSearchHits(docs, resp3);
+        assertResponse(client().prepareSearch("test_index").setSource(sourceBuilder), resp -> assertSearchHits(docs, resp));
 
         query = QueryBuilders.boolQuery().filter(QueryBuilders.idsQuery().addIds(ids));
         sourceBuilder = new SearchSourceBuilder().query(query)
@@ -268,8 +265,7 @@ public class LoggingIT extends BaseIntegrationTest {
                                 .addRescoreLogging("first_log", 0, false)
                                 .addRescoreLogging("second_log", 1, true)));
 
-        SearchResponse resp4 = client().prepareSearch("test_index").setSource(sourceBuilder).get();
-        assertSearchHits(docs, resp4);
+        assertResponse(client().prepareSearch("test_index").setSource(sourceBuilder), resp -> assertSearchHits(docs, resp));
     }
 
     public void testLogExtraLogging() throws Exception {
@@ -304,8 +300,7 @@ public class LoggingIT extends BaseIntegrationTest {
                                 .addQueryLogging("first_log", "test", false)
                                 .addRescoreLogging("second_log", 0, true)));
 
-        SearchResponse resp = client().prepareSearch("test_index").setSource(sourceBuilder).get();
-        assertSearchHitsExtraLogging(docs, resp);
+        assertResponse(client().prepareSearch("test_index").setSource(sourceBuilder), resp -> assertSearchHitsExtraLogging(docs, resp));
         sbuilder.featureSetName(null);
         sbuilder.modelName("my_model");
         sbuilder.boost(random().nextInt(3));
@@ -324,8 +319,7 @@ public class LoggingIT extends BaseIntegrationTest {
                                 .addQueryLogging("first_log", "test", false)
                                 .addRescoreLogging("second_log", 0, true)));
 
-        SearchResponse resp2 = client().prepareSearch("test_index").setSource(sourceBuilder).get();
-        assertSearchHitsExtraLogging(docs, resp2);
+        assertResponse(client().prepareSearch("test_index").setSource(sourceBuilder), resp -> assertSearchHitsExtraLogging(docs, resp));
 
         query = QueryBuilders.boolQuery()
                 .must(new WrapperQueryBuilder(sbuilder.toString()))
@@ -344,8 +338,7 @@ public class LoggingIT extends BaseIntegrationTest {
                         new LoggingSearchExtBuilder()
                                 .addQueryLogging("first_log", "test", false)
                                 .addRescoreLogging("second_log", 0, true)));
-        SearchResponse resp3 = client().prepareSearch("test_index").setSource(sourceBuilder).get();
-        assertSearchHitsExtraLogging(docs, resp3);
+        assertResponse(client().prepareSearch("test_index").setSource(sourceBuilder), resp -> assertSearchHitsExtraLogging(docs, resp));
     }
 
     public void testLogWithFeatureScoreCache() throws Exception {
@@ -386,8 +379,7 @@ public class LoggingIT extends BaseIntegrationTest {
                                 .addQueryLogging("first_log", "test", false)
                                 .addRescoreLogging("second_log", 0, true)));
 
-        SearchResponse resp = client().prepareSearch("test_index").setSource(sourceBuilder).get();
-        assertSearchHits(docs, resp);
+        assertResponse(client().prepareSearch("test_index").setSource(sourceBuilder), resp -> assertSearchHits(docs, resp));
         sbuilder.featureSetName(null);
         sbuilder.modelName("my_model");
         sbuilder_rescore.featureSetName(null);
@@ -404,8 +396,7 @@ public class LoggingIT extends BaseIntegrationTest {
                                 .addQueryLogging("first_log", "test", false)
                                 .addRescoreLogging("second_log", 0, true)));
 
-        SearchResponse resp2 = client().prepareSearch("test_index").setSource(sourceBuilder).get();
-        assertSearchHits(docs, resp2);
+        assertResponse(client().prepareSearch("test_index").setSource(sourceBuilder), resp -> assertSearchHits(docs, resp));
 
         query = QueryBuilders.boolQuery()
                 .must(new WrapperQueryBuilder(sbuilder.toString()))
@@ -424,8 +415,7 @@ public class LoggingIT extends BaseIntegrationTest {
                         new LoggingSearchExtBuilder()
                                 .addQueryLogging("first_log", "test", false)
                                 .addRescoreLogging("second_log", 0, true)));
-        SearchResponse resp3 = client().prepareSearch("test_index").setSource(sourceBuilder).get();
-        assertSearchHits(docs, resp3);
+        assertResponse(client().prepareSearch("test_index").setSource(sourceBuilder), resp -> assertSearchHits(docs, resp));
 
         query = QueryBuilders.boolQuery().filter(QueryBuilders.idsQuery().addIds(ids));
         sourceBuilder = new SearchSourceBuilder().query(query)
@@ -438,8 +428,7 @@ public class LoggingIT extends BaseIntegrationTest {
                                 .addRescoreLogging("first_log", 0, false)
                                 .addRescoreLogging("second_log", 1, true)));
 
-        SearchResponse resp4 = client().prepareSearch("test_index").setSource(sourceBuilder).get();
-        assertSearchHits(docs, resp4);
+        assertResponse(client().prepareSearch("test_index").setSource(sourceBuilder), resp -> assertSearchHits(docs, resp));
     }
 
     public void testScriptLogInternalParams() throws Exception {
@@ -467,17 +456,17 @@ public class LoggingIT extends BaseIntegrationTest {
                         new LoggingSearchExtBuilder()
                                 .addQueryLogging("first_log", "test", false)));
 
-        SearchResponse resp = client().prepareSearch("test_index").setSource(sourceBuilder).get();
+        assertResponse( client().prepareSearch("test_index").setSource(sourceBuilder), resp -> {
+            SearchHits hits = resp.getHits();
+            SearchHit testHit = hits.getAt(0);
+            Map<String, List<Map<String, Object>>> logs = testHit.getFields().get("_ltrlog").getValue();
 
-        SearchHits hits = resp.getHits();
-        SearchHit testHit = hits.getAt(0);
-        Map<String, List<Map<String, Object>>> logs = testHit.getFields().get("_ltrlog").getValue();
+            assertTrue(logs.containsKey("first_log"));
+            List<Map<String, Object>> log = logs.get("first_log");
 
-        assertTrue(logs.containsKey("first_log"));
-        List<Map<String, Object>> log = logs.get("first_log");
-
-        assertEquals(log.get(0).get("name"), "test_inject");
-        assertTrue((Float)log.get(0).get("value") > 0.0F);
+            assertEquals(log.get(0).get("name"), "test_inject");
+            assertTrue((Float)log.get(0).get("value") > 0.0F);
+        });
     }
 
     public void testScriptLogExternalParams() throws Exception {
@@ -513,17 +502,17 @@ public class LoggingIT extends BaseIntegrationTest {
                         new LoggingSearchExtBuilder()
                                 .addQueryLogging("first_log", "test", false)));
 
-        SearchResponse resp = client().prepareSearch("test_index").setSource(sourceBuilder).get();
+        assertResponse(client().prepareSearch("test_index").setSource(sourceBuilder), resp -> {
+            SearchHits hits = resp.getHits();
+            SearchHit testHit = hits.getAt(0);
+            Map<String, List<Map<String, Object>>> logs = testHit.getFields().get("_ltrlog").getValue();
 
-        SearchHits hits = resp.getHits();
-        SearchHit testHit = hits.getAt(0);
-        Map<String, List<Map<String, Object>>> logs = testHit.getFields().get("_ltrlog").getValue();
+            assertTrue(logs.containsKey("first_log"));
+            List<Map<String, Object>> log = logs.get("first_log");
 
-        assertTrue(logs.containsKey("first_log"));
-        List<Map<String, Object>> log = logs.get("first_log");
-
-        assertEquals(log.get(0).get("name"), "test_inject");
-        assertTrue((Float)log.get(0).get("value") > 0.0F);
+            assertEquals(log.get(0).get("name"), "test_inject");
+            assertTrue((Float)log.get(0).get("value") > 0.0F);
+        });
     }
 
     public void testScriptLogInvalidExternalParams() throws Exception {

--- a/src/main/java/com/o19s/es/explore/ExplorerQuery.java
+++ b/src/main/java/com/o19s/es/explore/ExplorerQuery.java
@@ -103,7 +103,7 @@ public class ExplorerQuery extends Query {
             StatisticsHelper ttf_stats = new StatisticsHelper();
 
             for (Term term : terms) {
-                TermStates ctx = TermStates.build(searcher.getTopReaderContext(), term, scoreMode.needsScores());
+                TermStates ctx = TermStates.build(searcher, term, scoreMode.needsScores());
                 if(ctx != null && ctx.docFreq() > 0){
                     TermStatistics tStats = searcher.termStatistics(term, ctx.docFreq(), ctx.totalTermFreq());
                     df_stats.add(tStats.docFreq());

--- a/src/main/java/com/o19s/es/explore/PostingsExplorerQuery.java
+++ b/src/main/java/com/o19s/es/explore/PostingsExplorerQuery.java
@@ -17,7 +17,6 @@
 package com.o19s.es.explore;
 
 import com.o19s.es.ltr.utils.CheckedBiFunction;
-import org.apache.lucene.index.IndexReaderContext;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.ReaderUtil;
@@ -78,9 +77,8 @@ public class PostingsExplorerQuery extends Query {
     @Override
     public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost)
             throws IOException {
-        IndexReaderContext context = searcher.getTopReaderContext();
         assert scoreMode.needsScores() : "Should not be used in filtering mode";
-        return new PostingsExplorerWeight(this, this.term, TermStates.build(context, this.term,
+        return new PostingsExplorerWeight(this, this.term, TermStates.build(searcher, this.term,
                 scoreMode.needsScores()),
                 this.type);
     }

--- a/src/main/java/com/o19s/es/ltr/action/AddFeaturesToSetAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/AddFeaturesToSetAction.java
@@ -29,7 +29,6 @@ import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.client.internal.ElasticsearchClient;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -44,12 +43,7 @@ public class AddFeaturesToSetAction extends ActionType<AddFeaturesToSetResponse>
     public static final String NAME = "cluster:admin/ltr/store/add-features-to-set";
 
     protected AddFeaturesToSetAction() {
-        super(NAME, AddFeaturesToSetResponse::new);
-    }
-
-    @Override
-    public Reader<AddFeaturesToSetResponse> getResponseReader() {
-        return AddFeaturesToSetResponse::new;
+        super(NAME);
     }
 
     public static class AddFeaturesToSetRequestBuilder extends ActionRequestBuilder<AddFeaturesToSetRequest, AddFeaturesToSetResponse> {

--- a/src/main/java/com/o19s/es/ltr/action/CachesStatsAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/CachesStatsAction.java
@@ -43,7 +43,7 @@ public class CachesStatsAction extends ActionType<CachesStatsNodesResponse> {
     public static final CachesStatsAction INSTANCE = new CachesStatsAction();
 
     protected CachesStatsAction() {
-        super(NAME, CachesStatsNodesResponse::new);
+        super(NAME);
     }
 
     public static class CachesStatsNodesRequest extends BaseNodesRequest<CachesStatsNodesRequest> {

--- a/src/main/java/com/o19s/es/ltr/action/ClearCachesAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/ClearCachesAction.java
@@ -33,7 +33,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
-import org.elasticsearch.common.io.stream.Writeable.Reader;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
@@ -42,12 +41,7 @@ public class ClearCachesAction extends ActionType<ClearCachesNodesResponse> {
     public static final ClearCachesAction INSTANCE = new ClearCachesAction();
 
     private ClearCachesAction() {
-        super(NAME, ClearCachesNodesResponse::new);
-    }
-
-    @Override
-    public Reader<ClearCachesNodesResponse> getResponseReader() {
-        return ClearCachesNodesResponse::new;
+        super(NAME);
     }
 
     public static class RequestBuilder extends ActionRequestBuilder<ClearCachesNodesRequest, ClearCachesNodesResponse> {

--- a/src/main/java/com/o19s/es/ltr/action/CreateModelFromSetAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/CreateModelFromSetAction.java
@@ -42,7 +42,7 @@ public class CreateModelFromSetAction extends ActionType<CreateModelFromSetRespo
     public static final CreateModelFromSetAction INSTANCE = new CreateModelFromSetAction();
 
     protected CreateModelFromSetAction() {
-        super(NAME, CreateModelFromSetResponse::new);
+        super(NAME);
     }
 
 

--- a/src/main/java/com/o19s/es/ltr/action/FeatureStoreAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/FeatureStoreAction.java
@@ -30,7 +30,6 @@ import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.client.internal.ElasticsearchClient;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -45,12 +44,7 @@ public class FeatureStoreAction extends ActionType<FeatureStoreResponse> {
     public static final FeatureStoreAction INSTANCE = new FeatureStoreAction();
 
     protected FeatureStoreAction() {
-        super(NAME, FeatureStoreResponse::new);
-    }
-
-    @Override
-    public Reader<FeatureStoreResponse> getResponseReader() {
-        return FeatureStoreResponse::new;
+        super(NAME);
     }
 
     public static class FeatureStoreRequestBuilder

--- a/src/main/java/com/o19s/es/ltr/action/LTRStatsAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/LTRStatsAction.java
@@ -27,7 +27,7 @@ public class LTRStatsAction extends ActionType<LTRStatsAction.LTRStatsNodesRespo
     public static final LTRStatsAction INSTANCE = new LTRStatsAction();
 
     public LTRStatsAction() {
-        super(NAME, LTRStatsNodesResponse::new);
+        super(NAME);
     }
 
     public static class LTRStatsRequestBuilder
@@ -132,7 +132,7 @@ public class LTRStatsAction extends ActionType<LTRStatsAction.LTRStatsNodesRespo
 
         public LTRStatsNodesResponse(StreamInput in) throws IOException {
             super(in);
-            clusterStats = in.readMap();
+            clusterStats = in.readGenericMap();
         }
 
         public LTRStatsNodesResponse(ClusterName clusterName, List<LTRStatsNodeResponse> nodeResponses,

--- a/src/main/java/com/o19s/es/ltr/action/ListStoresAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/ListStoresAction.java
@@ -27,7 +27,6 @@ import org.elasticsearch.client.internal.ElasticsearchClient;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -43,12 +42,7 @@ public class ListStoresAction extends ActionType<ListStoresActionResponse> {
     public static final ListStoresAction INSTANCE = new ListStoresAction();
 
     private ListStoresAction() {
-        super(NAME, ListStoresActionResponse::new);
-    }
-
-    @Override
-    public Reader<ListStoresActionResponse> getResponseReader() {
-        return ListStoresActionResponse::new;
+        super(NAME);
     }
 
     public static class ListStoresActionRequest extends MasterNodeReadRequest<ListStoresActionRequest> {

--- a/src/main/java/com/o19s/es/ltr/action/TransportAddFeatureToSetAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportAddFeatureToSetAction.java
@@ -68,7 +68,8 @@ public class TransportAddFeatureToSetAction extends HandledTransportAction<AddFe
                                              IndexNameExpressionResolver indexNameExpressionResolver,
                                              ClusterService clusterService, TransportSearchAction searchAction,
                                              TransportGetAction getAction, TransportFeatureStoreAction featureStoreAction) {
-        super(AddFeaturesToSetAction.NAME, transportService, actionFilters, AddFeaturesToSetRequest::new);
+        super(AddFeaturesToSetAction.NAME, transportService, actionFilters,
+            AddFeaturesToSetRequest::new, threadPool.executor(ThreadPool.Names.MANAGEMENT));
         this.clusterService = clusterService;
         this.searchAction = searchAction;
         this.getAction = getAction;

--- a/src/main/java/com/o19s/es/ltr/action/TransportCacheStatsAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportCacheStatsAction.java
@@ -46,8 +46,8 @@ public class TransportCacheStatsAction extends TransportNodesAction<CachesStatsN
                                         ClusterService clusterService, TransportService transportService,
                                         ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
                                         Caches caches) {
-        super(CachesStatsAction.NAME, threadPool, clusterService, transportService,
-            actionFilters, CachesStatsNodesRequest::new, CachesStatsNodeRequest::new,
+        super(CachesStatsAction.NAME, clusterService, transportService,
+                actionFilters, CachesStatsNodeRequest::new,
                 threadPool.executor(ThreadPool.Names.MANAGEMENT));
         this.caches = caches;
     }

--- a/src/main/java/com/o19s/es/ltr/action/TransportClearCachesAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportClearCachesAction.java
@@ -47,8 +47,8 @@ public class TransportClearCachesAction extends TransportNodesAction<ClearCaches
                                          ClusterService clusterService, TransportService transportService,
                                          ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
                                          Caches caches) {
-        super(ClearCachesAction.NAME, threadPool, clusterService, transportService, actionFilters,
-                ClearCachesNodesRequest::new, ClearCachesNodeRequest::new, threadPool.executor(ThreadPool.Names.MANAGEMENT));
+        super(ClearCachesAction.NAME, clusterService, transportService, actionFilters,
+                ClearCachesNodeRequest::new, threadPool.executor(ThreadPool.Names.MANAGEMENT));
         this.caches = caches;
     }
 

--- a/src/main/java/com/o19s/es/ltr/action/TransportCreateModelFromSetAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportCreateModelFromSetAction.java
@@ -33,6 +33,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -50,7 +51,8 @@ public class TransportCreateModelFromSetAction extends HandledTransportAction<Cr
                                                 IndexNameExpressionResolver indexNameExpressionResolver,
                                                 ClusterService clusterService, TransportGetAction getAction,
                                                 TransportFeatureStoreAction featureStoreAction) {
-        super(CreateModelFromSetAction.NAME, transportService, actionFilters, CreateModelFromSetRequest::new);
+        super(CreateModelFromSetAction.NAME, transportService, actionFilters,
+            CreateModelFromSetRequest::new, EsExecutors.DIRECT_EXECUTOR_SERVICE);
         this.clusterService = clusterService;
         this.getAction = getAction;
         this.featureStoreAction = featureStoreAction;

--- a/src/main/java/com/o19s/es/ltr/action/TransportLTRStatsAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportLTRStatsAction.java
@@ -33,8 +33,8 @@ public class TransportLTRStatsAction extends
                                    TransportService transportService,
                                    ActionFilters actionFilters,
                                    LTRStats ltrStats) {
-        super(LTRStatsAction.NAME, threadPool, clusterService, transportService,
-                actionFilters, LTRStatsNodesRequest::new, LTRStatsNodeRequest::new,
+        super(LTRStatsAction.NAME, clusterService, transportService,
+                actionFilters, LTRStatsNodeRequest::new,
                 threadPool.executor(ThreadPool.Names.MANAGEMENT));
         this.ltrStats = ltrStats;
     }

--- a/src/main/java/com/o19s/es/ltr/action/TransportListStoresAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportListStoresAction.java
@@ -32,6 +32,7 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.common.inject.Inject;
@@ -64,7 +65,7 @@ public class TransportListStoresAction extends TransportMasterNodeReadAction<Lis
                                      IndexNameExpressionResolver indexNameExpressionResolver, Client client) {
         super(ListStoresAction.NAME, transportService, clusterService, threadPool,
             actionFilters, ListStoresActionRequest::new, indexNameExpressionResolver, ListStoresActionResponse::new,
-                threadPool.executor(ThreadPool.Names.SAME));
+                EsExecutors.DIRECT_EXECUTOR_SERVICE);
         this.client = client;
     }
 

--- a/src/main/java/com/o19s/es/ltr/feature/FeatureValidation.java
+++ b/src/main/java/com/o19s/es/ltr/feature/FeatureValidation.java
@@ -60,7 +60,7 @@ public class FeatureValidation implements Writeable, ToXContentObject {
 
     public FeatureValidation(StreamInput input) throws IOException {
         this.index = input.readString();
-        this.params = input.readMap();
+        this.params = input.readGenericMap();
     }
 
     @Override

--- a/src/main/java/com/o19s/es/ltr/feature/store/ScriptFeature.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/ScriptFeature.java
@@ -319,7 +319,7 @@ public class ScriptFeature implements Feature {
 
             if (scoreMode.needsScores()) {
                 for (Term t : terms) {
-                    TermStates ctx = TermStates.build(searcher.getTopReaderContext(), t, true);
+                    TermStates ctx = TermStates.build(searcher, t, true);
                     if (ctx != null && ctx.docFreq() > 0) {
                         searcher.collectionStatistics(t.field());
                         searcher.termStatistics(t, ctx.docFreq(), ctx.totalTermFreq());

--- a/src/main/java/com/o19s/es/ltr/feature/store/index/IndexFeatureStore.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/index/IndexFeatureStore.java
@@ -181,7 +181,7 @@ public class IndexFeatureStore implements FeatureStore {
     public <E extends StorableElement> E getAndParse(String name, Class<E> eltClass, String type) throws IOException {
         GetResponse response = internalGet(generateId(type, name)).get();
         if (response.isExists()) {
-            return parse(eltClass, type, response.getSourceAsBytes());
+            return parse(eltClass, type, response.getSourceAsBytesRef());
         } else {
             return null;
         }

--- a/src/main/java/com/o19s/es/ltr/query/StoredLtrQueryBuilder.java
+++ b/src/main/java/com/o19s/es/ltr/query/StoredLtrQueryBuilder.java
@@ -90,7 +90,7 @@ public class StoredLtrQueryBuilder extends AbstractQueryBuilder<StoredLtrQueryBu
         modelName = input.readOptionalString();
         featureScoreCacheFlag = input.readOptionalBoolean();
         featureSetName = input.readOptionalString();
-        params = input.readMap();
+        params = input.readGenericMap();
         if (input.getTransportVersion().onOrAfter(TransportVersions.V_7_0_0)) {
             String[] activeFeat = input.readOptionalStringArray();
             activeFeatures = activeFeat == null ? null : Arrays.asList(activeFeat);

--- a/src/main/java/com/o19s/es/ltr/rest/RestSearchStoreElements.java
+++ b/src/main/java/com/o19s/es/ltr/rest/RestSearchStoreElements.java
@@ -3,7 +3,7 @@ package com.o19s.es.ltr.rest;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.action.RestChunkedToXContentListener;
+import org.elasticsearch.rest.action.RestRefCountedChunkedToXContentListener;
 
 import java.util.List;
 
@@ -51,7 +51,7 @@ public class RestSearchStoreElements extends FeatureStoreBaseRestHandler {
                 .setQuery(qb)
                 .setSize(size)
                 .setFrom(from)
-                .execute(new RestChunkedToXContentListener<>(channel));
+                .execute(new RestRefCountedChunkedToXContentListener<>(channel));
     }
 
 }

--- a/src/main/java/com/o19s/es/ltr/stats/suppliers/StoreStatsSupplier.java
+++ b/src/main/java/com/o19s/es/ltr/stats/suppliers/StoreStatsSupplier.java
@@ -108,6 +108,7 @@ public class StoreStatsSupplier implements Supplier<Map<String, Map<String, Obje
                             .forEach(bucket -> updateCount(bucket, storeStat));
                 }
             }
+            msr.decRef();
             return stats;
         } catch (InterruptedException | ExecutionException e) {
             LOG.error("Error retrieving store stats", e);

--- a/src/main/java/com/o19s/es/termstat/TermStatQuery.java
+++ b/src/main/java/com/o19s/es/termstat/TermStatQuery.java
@@ -106,7 +106,7 @@ public class TermStatQuery extends Query {
             // This is needed for proper DFS_QUERY_THEN_FETCH support
             if (scoreMode.needsScores()) {
                 for (Term t : terms) {
-                    TermStates ctx = TermStates.build(searcher.getTopReaderContext(), t, true);
+                    TermStates ctx = TermStates.build(searcher, t, true);
 
                     if (ctx != null && ctx.docFreq() > 0) {
                         searcher.collectionStatistics(t.field());

--- a/src/test/java/com/o19s/es/ltr/ShardStatsIT.java
+++ b/src/test/java/com/o19s/es/ltr/ShardStatsIT.java
@@ -3,7 +3,6 @@ package com.o19s.es.ltr;
 import com.o19s.es.TestExpressionsPlugin;
 import com.o19s.es.explore.ExplorerQueryBuilder;
 import com.o19s.es.termstat.TermStatQueryBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
@@ -14,7 +13,8 @@ import org.elasticsearch.test.ESIntegTestCase;
 import java.util.Arrays;
 import java.util.Collection;
 
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.equalTo;
 
 /*
@@ -60,14 +60,15 @@ public class ShardStatsIT extends ESIntegTestCase {
                 .query(q)
                 .statsType("min_raw_df");
 
-        final SearchResponse r = client().prepareSearch("idx")
-                .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
-                .setQuery(eq).get();
+        assertResponse(
+            client().prepareSearch("idx").setSearchType(SearchType.DFS_QUERY_THEN_FETCH).setQuery(eq),
+            r -> {
+                assertNoFailures(r);
 
-        assertSearchResponse(r);
-
-        SearchHits hits = r.getHits();
-        assertThat(hits.getAt(0).getScore(), equalTo(4.0f));
+                SearchHits hits = r.getHits();
+                assertThat(hits.getAt(0).getScore(), equalTo(4.0f));
+            }
+        );
     }
 
     public void testNonDfsExplorer() throws Exception {
@@ -79,14 +80,15 @@ public class ShardStatsIT extends ESIntegTestCase {
                 .query(q)
                 .statsType("min_raw_df");
 
-        final SearchResponse r = client().prepareSearch("idx")
-                .setSearchType(SearchType.QUERY_THEN_FETCH)
-                .setQuery(eq).get();
+        assertResponse(
+            client().prepareSearch("idx").setSearchType(SearchType.QUERY_THEN_FETCH).setQuery(eq),
+            r -> {
+                assertNoFailures(r);
 
-        assertSearchResponse(r);
-
-        SearchHits hits = r.getHits();
-        assertThat(hits.getAt(0).getScore(), equalTo(2.0f));
+                SearchHits hits = r.getHits();
+                assertThat(hits.getAt(0).getScore(), equalTo(2.0f));
+            }
+        );
     }
 
     public void testDfsTSQ() throws Exception {
@@ -99,15 +101,15 @@ public class ShardStatsIT extends ESIntegTestCase {
                 .terms(new String[]{"zzz"})
                 .fields(new String[]{"s"});
 
-        final SearchResponse r = client().prepareSearch("idx")
-                .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
-                .setQuery(tsq)
-                .get();
+        assertResponse(
+            client().prepareSearch("idx").setSearchType(SearchType.DFS_QUERY_THEN_FETCH).setQuery(tsq),
+            r -> {
+                assertNoFailures(r);
 
-        assertSearchResponse(r);
-
-        SearchHits hits = r.getHits();
-        assertThat(hits.getAt(0).getScore(), equalTo(4.0f));
+                SearchHits hits = r.getHits();
+                assertThat(hits.getAt(0).getScore(), equalTo(4.0f));
+            }
+        );
     }
 
     public void testNonDfsTSQ() throws Exception {
@@ -120,14 +122,14 @@ public class ShardStatsIT extends ESIntegTestCase {
                 .terms(new String[]{"zzz"})
                 .fields(new String[]{"s"});
 
-        final SearchResponse r = client().prepareSearch("idx")
-                .setSearchType(SearchType.QUERY_THEN_FETCH)
-                .setQuery(tsq)
-                .get();
+        assertResponse(
+            client().prepareSearch("idx").setSearchType(SearchType.QUERY_THEN_FETCH).setQuery(tsq),
+            r -> {
+                assertNoFailures(r);
 
-        assertSearchResponse(r);
-
-        SearchHits hits = r.getHits();
-        assertThat(hits.getAt(0).getScore(), equalTo(2.0f));
+                SearchHits hits = r.getHits();
+                assertThat(hits.getAt(0).getScore(), equalTo(2.0f));
+            }
+        );
     }
 }

--- a/src/test/java/com/o19s/es/ltr/logging/LoggingFetchSubPhaseTests.java
+++ b/src/test/java/com/o19s/es/ltr/logging/LoggingFetchSubPhaseTests.java
@@ -121,7 +121,7 @@ public class LoggingFetchSubPhaseTests extends LuceneTestCase {
         LoggingFetchSubPhaseProcessor processor = new LoggingFetchSubPhaseProcessor(() -> new Tuple<>(weight, loggers));
 
         SearchHit[] hits = preprocessRandomHits(processor);
-        for (SearchHit hit : hits) {
+        for (SearchHit hit : hits) try {
             assertTrue(docs.containsKey(hit.getId()));
             Document d = docs.get(hit.getId());
             assertTrue(hit.getFields().containsKey("_ltrlog"));
@@ -149,6 +149,8 @@ public class LoggingFetchSubPhaseTests extends LuceneTestCase {
             expectedScore = Math.log1p(expectedScore+1);
             assertEquals((float) expectedScore, (Float)log1.get(1).get("value"), Math.ulp((float)expectedScore));
             assertEquals((float) expectedScore, (Float)log1.get(1).get("value"), Math.ulp((float)expectedScore));
+        } finally {
+            hit.decRef();
         }
     }
 

--- a/src/test/java/com/o19s/es/ltr/logging/LoggingFetchSubPhaseTests.java
+++ b/src/test/java/com/o19s/es/ltr/logging/LoggingFetchSubPhaseTests.java
@@ -221,7 +221,8 @@ public class LoggingFetchSubPhaseTests extends LuceneTestCase {
                     "score",
                      FLOAT,
                      CoreValuesSourceType.NUMERIC,
-                     (dv, n) -> { throw new UnsupportedOperationException(); }));
+                     (dv, n) -> { throw new UnsupportedOperationException(); },
+                     false));
         return new FunctionScoreQuery(new MatchAllDocsQuery(),
                 fieldValueFactorFunction, CombineFunction.MULTIPLY, 0F, Float.MAX_VALUE);
     }


### PR DESCRIPTION
The plugin would no longer build for newer ES versions. I've worked through the errors and test failures to fix that. Changes included in this PR allow a clean `./gradlew clean check` build for Elasticsearch 8.14.0 (except for flakiness described in https://github.com/o19s/elasticsearch-learning-to-rank/issues/483).

All changes in this PR were made only to facilitate the ES version bump. Here's the list of upstream changes that necessitated changing code:

- https://github.com/elastic/elasticsearch/pull/102354
- https://github.com/elastic/elasticsearch/pull/102800
- https://github.com/apache/lucene/pull/12183
- https://github.com/elastic/elasticsearch/pull/104650
- https://github.com/elastic/elasticsearch/pull/104645
- https://github.com/elastic/elasticsearch/pull/100239 which was a follow-up to https://github.com/elastic/elasticsearch/pull/100162
- https://github.com/elastic/elasticsearch/pull/103304 which was a follow-up to https://github.com/elastic/elasticsearch/pull/100867
- https://github.com/elastic/elasticsearch/pull/104045
- https://github.com/elastic/elasticsearch/pull/102611
- https://github.com/elastic/elasticsearch/pull/105022
- https://github.com/elastic/elasticsearch/pull/103277
- https://github.com/elastic/elasticsearch/pull/101092
- https://github.com/elastic/elasticsearch/pull/102274 which was part of https://github.com/elastic/elasticsearch/issues/102030
- https://github.com/elastic/elasticsearch/pull/107249 which was a follow-up to https://github.com/elastic/elasticsearch/pull/106279
- https://github.com/elastic/elasticsearch/pull/106947