### PR TITLE
Add Sonatype user access token information to publish process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
         SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
         SONATYPE_PASS: ${{ secrets.SONATYPE_PASS }}
         GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+        GPG_SIGNING_PASS: ${{ secrets.GPG_SIGNING_PASS }}
         OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
         OSSRH_TOKEN_PASSSWORD: ${{ secrets.OSSRH_TOKEN_PASSSWORD }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,5 +51,7 @@ jobs:
         SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
         SONATYPE_PASS: ${{ secrets.SONATYPE_PASS }}
         GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-        GPG_SIGNING_PASS: ${{ secrets.GPG_SIGNING_PASS }}
+        OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+        OSSRH_TOKEN_PASSSWORD: ${{ secrets.OSSRH_TOKEN_PASSSWORD }}
+
       run: ./gradlew publish

--- a/build.gradle
+++ b/build.gradle
@@ -69,15 +69,13 @@ esplugin {
 // In this section you declare the dependencies for your production and test code
 // Elasticsearch dependency is included due to the build-tools, test-framework as well
 repositories {
-  mavenCentral()
-  mavenLocal()
-  // user access token is necessary to publish to Maven
-  maven {
+  mavenCentral{
     credentials {
       username = findProperty("OSSRH_TOKEN") as String
       password = findProperty("OSSRH_TOKEN_PASSSWORD") as String
     }
   }
+  mavenLocal()
   jcenter {
     url "https://jcenter.bintray.com/"
     metadataSources{

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,13 @@ esplugin {
 repositories {
   mavenCentral()
   mavenLocal()
+  // user access token is necessary to publish to Maven
+  maven {
+    credentials {
+      username = findProperty("OSSRH_TOKEN") as String
+      password = findProperty("OSSRH_TOKEN_PASSSWORD") as String
+    }
+  }
   jcenter {
     url "https://jcenter.bintray.com/"
     metadataSources{

--- a/build.gradle
+++ b/build.gradle
@@ -69,12 +69,7 @@ esplugin {
 // In this section you declare the dependencies for your production and test code
 // Elasticsearch dependency is included due to the build-tools, test-framework as well
 repositories {
-  mavenCentral{
-    credentials {
-      username = findProperty("OSSRH_TOKEN") as String
-      password = findProperty("OSSRH_TOKEN_PASSSWORD") as String
-    }
-  }
+  mavenCentral()
   mavenLocal()
   jcenter {
     url "https://jcenter.bintray.com/"

--- a/publish/build.gradle
+++ b/publish/build.gradle
@@ -42,8 +42,8 @@ publishing {
       url = System.getenv('SONATYPE_REPO_URL')
 
         credentials {
-          username = System.getenv('SONATYPE_USER')
-          password = System.getenv('SONATYPE_PASS')
+          username = System.getenv('OSSRH_TOKEN')
+          password = System.getenv('OSSRH_TOKEN_PASSSWORD')
         }
     }
   }


### PR DESCRIPTION
Trying to resolve publishing errors.

Reference:
https://community.sonatype.com/t/401-content-access-is-protected-by-token-authentication-failure-while-performing-maven-release/12741/6