### PR TITLE
BUGFIX: Automatically reorder features in the xgboost raw model parser

### DIFF
--- a/src/main/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTree.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTree.java
@@ -136,6 +136,30 @@ public class NaiveAdditiveDecisionTree extends SparseLtrRanker implements Accoun
             return n.eval(scores);
         }
 
+        public Node getLeft() {
+            return this.left;
+        }
+
+        public Node getRight() {
+            return this.right;
+        }
+
+        public int getFeature() {
+            return this.feature;
+        }
+
+        public float getThreshold() {
+            return this.threshold;
+        }
+
+        public int getLeftNodeId() {
+            return this.leftNodeId;
+        }
+
+        public int getMissingNodeId() {
+            return this.missingNodeId;
+        }
+
         /**
          * Return the memory usage of this object in bytes. Negative values are illegal.
          */


### PR DESCRIPTION
A follow up to https://github.com/o19s/elasticsearch-learning-to-rank/pull/500 that fixes a drawback of the parser by rearranging the features in the model to match the order in the feature set.

Motivation: the model and feature set have names assigned to features, but when the evaluation is happening, the features are being referenced by their ordinal number.
So in the implementation the features had to be submitted in the same order as they are in the model in order to produce a correct evaluation.
This PR is supposed tries to fix that by aligning the features ordering in the trees when the model is loaded.
