### PR TITLE
update to ES version 8.17.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 ltrVersion = 1.5.10
-elasticsearchVersion = 8.17.2
+elasticsearchVersion = 8.17.3
 luceneVersion = 9.12.0
 ow2Version = 8.0.1
 antlrVersion = 4.5.1-1


### PR DESCRIPTION
Update to ES version 8.17.3 because of the kibana vunerability.

- https://thehackernews.com/2025/03/elastic-releases-urgent-fix-for.html
- https://www.elastic.co/guide/en/elasticsearch/reference/current/release-notes-8.17.3.html