### PR TITLE
Update for compatibility with Elasticsearch v8.18.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 ltrVersion = 1.5.10
-elasticsearchVersion = 8.17.3
-luceneVersion = 9.12.0
+elasticsearchVersion = 8.18.3
+luceneVersion = 9.12.1
 ow2Version = 8.0.1
 antlrVersion = 4.5.1-1

--- a/src/main/java/com/o19s/es/ltr/action/TransportListStoresAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportListStoresAction.java
@@ -59,15 +59,17 @@ import static org.elasticsearch.core.Tuple.tuple;
 
 public class TransportListStoresAction extends TransportMasterNodeReadAction<ListStoresActionRequest, ListStoresActionResponse> {
     private final Client client;
+    private final IndexNameExpressionResolver indexNameExpressionResolver;
 
     @Inject
     public TransportListStoresAction(TransportService transportService,
                                      ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters,
                                      IndexNameExpressionResolver indexNameExpressionResolver, Client client) {
         super(ListStoresAction.NAME, transportService, clusterService, threadPool,
-            actionFilters, ListStoresActionRequest::new, indexNameExpressionResolver, ListStoresActionResponse::new,
+            actionFilters, ListStoresActionRequest::new, ListStoresActionResponse::new,
                 EsExecutors.DIRECT_EXECUTOR_SERVICE);
         this.client = client;
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
     }
 
     @Override

--- a/src/test/java/com/o19s/es/TestExpressionsPlugin.java
+++ b/src/test/java/com/o19s/es/TestExpressionsPlugin.java
@@ -13,7 +13,6 @@ import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.script.DoubleValuesScript;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptEngine;
-import org.elasticsearch.test.PrivilegedOperations;
 
 import java.text.ParseException;
 import java.util.Collection;
@@ -44,9 +43,7 @@ public class TestExpressionsPlugin extends Plugin implements ScriptPlugin {
 
         @Override
         public <T> T compile(String scriptName, String scriptSource, ScriptContext<T> context, Map<String, String> params) {
-            return PrivilegedOperations.supplierWithCreateClassLoader(
-                    () -> compileInternal(scriptSource, context)
-            );
+            return compileInternal(scriptSource, context);
         }
 
         public <T> T compileInternal(String scriptSource, ScriptContext<T> context) {


### PR DESCRIPTION
### Summary

This PR updates the v1.5.10-es8.17.3 release of the learning-to-rank plugin for compatibility with **Elasticsearch v8.18.3**.

### Changes

- Bump ES and Lucene ([ref](https://github.com/elastic/elasticsearch/blob/v8.18.3/build-tools-internal/version.properties#L2C21-L2C27)) versions in `gradle.properties`
- Resolve test failures that arose post version bumps
- Verified build via `./gradlew clean build`