### PR TITLE
Update for Elasticsearch v8.18.6 Compatibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 ltrVersion = 1.5.10
-elasticsearchVersion = 8.18.3
+elasticsearchVersion = 8.18.6
 luceneVersion = 9.12.1
 ow2Version = 8.0.1
 antlrVersion = 4.5.1-1


### PR DESCRIPTION
### Summary
- This PR updates the learning-to-rank plugin (v1.5.10-es8.18.3) to ensure compatibility with Elasticsearch v8.18.6.

### Changes
- Updated Elasticsearch version in gradle.properties
- Verified successful build with ./gradlew clean build