### PR TITLE
Include cache sizes equal to max when testing

### DIFF
--- a/src/javaRestTest/java/com/o19s/es/ltr/NodeSettingsIT.java
+++ b/src/javaRestTest/java/com/o19s/es/ltr/NodeSettingsIT.java
@@ -64,7 +64,7 @@ public class NodeSettingsIT extends BaseIntegrationTest {
             cached.loadModel(compiled.name());
             caches.modelCache().refresh();
             assertThat(caches.modelCache().weight(), allOf(lessThan(maxMemSize), greaterThanOrEqualTo(lastAddedSize)));
-        } while (totalAdded < maxMemSize);
+        } while (totalAdded <= maxMemSize);
         assertThat(totalAdded, greaterThan(maxMemSize));
         assertThat(caches.modelCache().weight(), greaterThan(0L));
         Thread.sleep(expireAfterWrite * 2);


### PR DESCRIPTION
The current test loop fills the cache while it's less than the max, and then there are assertions that require the added amount to be greater than. When we happen to add exactly enough to the cache to equal the maximum then the loop exits but the assertions that the size is greater than the maximum are not valid.

The change just adds the equal condition to the loop so that when it exits we are sure that the amount added is greater than the maximum.

See https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/248