### PR TITLE
Update to Elasticsearch 9.2.4 / Lucene 10.3.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,3 +87,14 @@ java {
 // Set to false to not use elasticsearch checkstyle rules
 checkstyleMain.enabled = true
 checkstyleTest.enabled = true
+
+// Elasticsearch test-framework (9.x) can enable the entitlement agent via system properties.
+// When enabled, it needs either `es.entitlement.agentJar` or an ES-style `es.path.home` that
+// contains `lib/entitlement-agent/*.jar`. In this plugin repo, tests run without a distro
+// layout. If entitlements are enabled without the required wiring, ES test framework
+// bootstrap fails before any tests run. Default to disabling unless explicitly enabled.
+tasks.withType(Test).configureEach {
+  if (System.getProperty("es.entitlement.enableForTests") == null) {
+    systemProperty "es.entitlement.enableForTests", "false"
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-ltrVersion = 1.5.12
-elasticsearchVersion = 9.0.8
-luceneVersion = 10.1.0
+ltrVersion = 1.5.13
+elasticsearchVersion = 9.2.4
+luceneVersion = 10.3.2
 ow2Version = 8.0.1
 antlrVersion = 4.5.1-1

--- a/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
+++ b/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
@@ -70,8 +70,6 @@ import com.o19s.es.termstat.TermStatQueryBuilder;
 import org.apache.lucene.analysis.core.KeywordTokenizer;
 import org.apache.lucene.analysis.miscellaneous.LengthFilter;
 import org.apache.lucene.analysis.ngram.EdgeNGramTokenFilter;
-import org.elasticsearch.action.ActionRequest;
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -191,15 +189,15 @@ public class LtrQueryParserPlugin extends Plugin implements SearchPlugin, Script
     }
 
     @Override
-    public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
+    public List<ActionHandler> getActions() {
         return unmodifiableList(asList(
-                new ActionHandler<>(FeatureStoreAction.INSTANCE, TransportFeatureStoreAction.class),
-                new ActionHandler<>(CachesStatsAction.INSTANCE, TransportCacheStatsAction.class),
-                new ActionHandler<>(ClearCachesAction.INSTANCE, TransportClearCachesAction.class),
-                new ActionHandler<>(AddFeaturesToSetAction.INSTANCE, TransportAddFeatureToSetAction.class),
-                new ActionHandler<>(CreateModelFromSetAction.INSTANCE, TransportCreateModelFromSetAction.class),
-                new ActionHandler<>(ListStoresAction.INSTANCE, TransportListStoresAction.class),
-                new ActionHandler<>(LTRStatsAction.INSTANCE, TransportLTRStatsAction.class)));
+                new ActionHandler(FeatureStoreAction.INSTANCE, TransportFeatureStoreAction.class),
+                new ActionHandler(CachesStatsAction.INSTANCE, TransportCacheStatsAction.class),
+                new ActionHandler(ClearCachesAction.INSTANCE, TransportClearCachesAction.class),
+                new ActionHandler(AddFeaturesToSetAction.INSTANCE, TransportAddFeatureToSetAction.class),
+                new ActionHandler(CreateModelFromSetAction.INSTANCE, TransportCreateModelFromSetAction.class),
+                new ActionHandler(ListStoresAction.INSTANCE, TransportListStoresAction.class),
+                new ActionHandler(LTRStatsAction.INSTANCE, TransportLTRStatsAction.class)));
     }
 
     @Override

--- a/src/main/java/com/o19s/es/ltr/action/AddFeaturesToSetAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/AddFeaturesToSetAction.java
@@ -171,7 +171,6 @@ public class AddFeaturesToSetAction extends ActionType<AddFeaturesToSetResponse>
         private DocWriteResponse response;
 
         public AddFeaturesToSetResponse(StreamInput in) throws IOException {
-            super(in);
             response = new IndexResponse(in);
         }
 

--- a/src/main/java/com/o19s/es/ltr/action/CreateModelFromSetAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/CreateModelFromSetAction.java
@@ -175,7 +175,6 @@ public class CreateModelFromSetAction extends ActionType<CreateModelFromSetRespo
         private DocWriteResponse response;
 
         public CreateModelFromSetResponse(StreamInput in) throws IOException {
-            super(in);
             int version = in.readVInt();
             assert version == VERSION;
             response = new IndexResponse(in);

--- a/src/main/java/com/o19s/es/ltr/action/FeatureStoreAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/FeatureStoreAction.java
@@ -168,7 +168,6 @@ public class FeatureStoreAction extends ActionType<FeatureStoreResponse> {
         private DocWriteResponse response;
 
         public FeatureStoreResponse(StreamInput in) throws IOException {
-            super(in);
             response = new IndexResponse(in);
         }
 

--- a/src/main/java/com/o19s/es/ltr/action/LTRStatsAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/LTRStatsAction.java
@@ -11,7 +11,7 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.transport.AbstractTransportRequest;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -39,7 +39,7 @@ public class LTRStatsAction extends ActionType<LTRStatsAction.LTRStatsNodesRespo
         }
     }
 
-    public static class LTRStatsNodeRequest extends TransportRequest {
+    public static class LTRStatsNodeRequest extends AbstractTransportRequest {
         private final LTRStatsNodesRequest nodesRequest;
 
         public LTRStatsNodeRequest(StreamInput in) throws IOException {

--- a/src/main/java/com/o19s/es/ltr/action/ListStoresAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/ListStoresAction.java
@@ -67,7 +67,6 @@ public class ListStoresAction extends ActionType<ListStoresActionResponse> {
         ListStoresActionResponse() {}
 
         ListStoresActionResponse(StreamInput in) throws IOException {
-            super(in);
             stores = in.readMap(StreamInput::readString, IndexStoreInfo::new);
         }
 

--- a/src/main/java/com/o19s/es/ltr/action/TransportCacheStatsAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportCacheStatsAction.java
@@ -30,7 +30,7 @@ import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.transport.AbstractTransportRequest;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.tasks.Task;
 
@@ -75,7 +75,7 @@ public class TransportCacheStatsAction extends TransportNodesAction<CachesStatsN
         return new CachesStatsNodeResponse(clusterService.localNode()).initFromCaches(caches);
     }
 
-    public static class CachesStatsNodeRequest extends TransportRequest {
+    public static class CachesStatsNodeRequest extends AbstractTransportRequest {
         public CachesStatsNodeRequest() {}
 
         public CachesStatsNodeRequest(StreamInput in) throws IOException {

--- a/src/main/java/com/o19s/es/ltr/action/TransportClearCachesAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportClearCachesAction.java
@@ -32,7 +32,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.transport.AbstractTransportRequest;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
@@ -65,7 +65,7 @@ public class TransportClearCachesAction extends TransportNodesAction<ClearCaches
 
     @Override
     protected ClearCachesNodeResponse newNodeResponse(StreamInput in, DiscoveryNode node) throws IOException {
-        return null; // TODO
+        return new ClearCachesNodeResponse(in);
     }
 
     @Override
@@ -90,7 +90,7 @@ public class TransportClearCachesAction extends TransportNodesAction<ClearCaches
         return new ClearCachesNodeResponse(clusterService.localNode());
     }
 
-    public static class ClearCachesNodeRequest extends TransportRequest {
+    public static class ClearCachesNodeRequest extends AbstractTransportRequest {
         private ClearCachesNodesRequest request;
 
         public ClearCachesNodeRequest() {}

--- a/src/main/java/com/o19s/es/ltr/action/TransportListStoresAction.java
+++ b/src/main/java/com/o19s/es/ltr/action/TransportListStoresAction.java
@@ -84,7 +84,7 @@ public class TransportListStoresAction
         final List<Tuple<String, Integer>> versions = new ArrayList<>();
         Stream.of(names)
                 .filter(IndexFeatureStore::isIndexStore)
-                .map((s) -> clusterService.state().metadata().getIndices().get(s))
+                .map((s) -> clusterService.state().metadata().getProject().index(s))
                 .filter(Objects::nonNull)
                 .filter((im) -> STORE_VERSION_PROP.exists(im.getSettings()))
                 .forEach((m) -> {
@@ -133,7 +133,7 @@ public class TransportListStoresAction
         if (!IndexFeatureStore.isIndexStore(s)) {
             return null;
         }
-        IndexMetadata index = clusterService.state().metadata().getIndices().get(s);
+        IndexMetadata index = clusterService.state().metadata().getProject().index(s);
 
         if (index != null && STORE_VERSION_PROP.exists(index.getSettings())) {
             return new Tuple<>(index.getIndex().getName(), STORE_VERSION_PROP.get(index.getSettings()));

--- a/src/main/java/com/o19s/es/ltr/logging/LoggingFetchSubPhase.java
+++ b/src/main/java/com/o19s/es/ltr/logging/LoggingFetchSubPhase.java
@@ -240,7 +240,7 @@ public class LoggingFetchSubPhase implements FetchSubPhase {
             DocumentField logs = hit.getFields().get(FIELD_NAME);
             if (logs == null) {
                 logs = newLogField();
-                hit.setDocumentField(FIELD_NAME, logs);
+                hit.setDocumentField(logs);
             }
             Map<String, List<Map<String, Object>>> entries = logs.getValue();
             rebuild();

--- a/src/main/java/com/o19s/es/ltr/query/RankerQuery.java
+++ b/src/main/java/com/o19s/es/ltr/query/RankerQuery.java
@@ -367,7 +367,7 @@ public class RankerQuery extends Query {
         @Override
         public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
             List<Scorer> scorers = new ArrayList<>(weights.size());
-            DisiPriorityQueue disiPriorityQueue = new DisiPriorityQueue(weights.size());
+            DisiPriorityQueue disiPriorityQueue = DisiPriorityQueue.ofMaxSize(weights.size());
             for (Weight weight : weights) {
                 Scorer scorer = weight.scorer(context);
                 if (scorer == null) {

--- a/src/main/java/com/o19s/es/ltr/stats/suppliers/PluginHealthStatusSupplier.java
+++ b/src/main/java/com/o19s/es/ltr/stats/suppliers/PluginHealthStatusSupplier.java
@@ -58,7 +58,7 @@ public class PluginHealthStatusSupplier implements Supplier<String> {
 
     public String getLtrStoreHealthStatus(String storeName) {
         ClusterIndexHealth indexHealth = new ClusterIndexHealth(
-                clusterService.state().metadata().index(storeName),
+                clusterService.state().metadata().getProject().index(storeName),
                 clusterService.state().getRoutingTable().index(storeName)
         );
 

--- a/src/main/java/com/o19s/es/ltr/stats/suppliers/StoreStatsSupplier.java
+++ b/src/main/java/com/o19s/es/ltr/stats/suppliers/StoreStatsSupplier.java
@@ -74,7 +74,7 @@ public class StoreStatsSupplier implements Supplier<Map<String, Map<String, Obje
         List<String> indices = new ArrayList<>();
         Stream.of(names)
                 .filter(IndexFeatureStore::isIndexStore)
-                .map(s -> clusterService.state().metadata().index(s))
+                .map(s -> clusterService.state().metadata().getProject().index(s))
                 .filter(Objects::nonNull)
                 .map(IndexMetadata::getIndex)
                 .map(Index::getName)
@@ -139,7 +139,7 @@ public class StoreStatsSupplier implements Supplier<Map<String, Map<String, Obje
     public String getLtrStoreHealthStatus(String storeName) {
         ClusterIndexHealth indexHealth =
                 new ClusterIndexHealth(
-                        clusterService.state().metadata().index(storeName),
+                        clusterService.state().metadata().getProject().index(storeName),
                         clusterService.state().getRoutingTable().index(storeName));
 
         return indexHealth.getStatus().name().toLowerCase(Locale.ROOT);

--- a/src/test/java/com/o19s/es/ltr/feature/store/StoredLtrModelParserTests.java
+++ b/src/test/java/com/o19s/es/ltr/feature/store/StoredLtrModelParserTests.java
@@ -320,7 +320,7 @@ public class StoredLtrModelParserTests extends LuceneTestCase {
         String base64Encoded = "C21vZGVsL2R1bW15EmNvbXBsZXRlbHkgaWdub3JlZAE=";
         byte[] bytes = Base64.getDecoder().decode(base64Encoded);
         StreamInput input = ByteBufferStreamInput.wrap(bytes, 0, bytes.length);
-        input.setTransportVersion(TransportVersions.V_7_6_0);
+        input.setTransportVersion(TransportVersions.V_7_0_0);
 
         StoredLtrModel.LtrModelDefinition modelUnserialized = new StoredLtrModel.LtrModelDefinition(input);
         assertEquals(modelUnserialized.getDefinition(), "completely ignored");

--- a/src/test/java/com/o19s/es/ltr/stats/suppliers/PluginHealthStatusSupplierTests.java
+++ b/src/test/java/com/o19s/es/ltr/stats/suppliers/PluginHealthStatusSupplierTests.java
@@ -1,6 +1,7 @@
 package com.o19s.es.ltr.stats.suppliers;
 
 import com.o19s.es.ltr.feature.store.index.IndexFeatureStore;
+import org.elasticsearch.cluster.project.DefaultProjectResolver;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -14,8 +15,14 @@ public class PluginHealthStatusSupplierTests extends ESIntegTestCase {
     @Before
     public void setup() {
         pluginHealthStatusSupplier =
-                new PluginHealthStatusSupplier(clusterService(), new IndexNameExpressionResolver(new ThreadContext(Settings.EMPTY),
-                        EmptySystemIndices.INSTANCE));
+                new PluginHealthStatusSupplier(
+                        clusterService(),
+                        new IndexNameExpressionResolver(
+                                new ThreadContext(Settings.EMPTY),
+                                EmptySystemIndices.INSTANCE,
+                                DefaultProjectResolver.INSTANCE
+                        )
+                );
     }
 
     public void testPluginHealthStatusNoLtrStore() {


### PR DESCRIPTION
This change bumps the plugin’s build target from Elasticsearch 9.0.8 to 9.2.4 (and Lucene 10.1.0 -> 10.3.2) so the plugin can be installed on and run against ES 9.2.4 (plugins must match ES major.minor.patch).

- Elasticsearch plugins are binary/version coupled; building against 9.0.8 will not load on 9.2.4.
- ES 9.2.x + Lucene 10.3.x introduced API and serialization changes that required code updates.

- Version bump:
  - `gradle.properties`: `elasticsearchVersion=9.2.4`, `luceneVersion=10.3.2`
- ES API compatibility updates:
  - `ActionPlugin.ActionHandler` is non-generic in ES 9.2; update `LtrQueryParserPlugin#getActions()` to use the new signature/type.
  - Transport request type changes: node-level requests now extend `AbstractTransportRequest` where ES 9.2 no longer uses `TransportRequest` as a base class for these usages.
  - Response stream constructors: remove `super(StreamInput)` calls from direct `ActionResponse` subcsses because ES 9.2’s `ActionResponse` no longer has a `StreamInput` constructor (node/node(s) responses continue to call `super(in)` via `BaseNodeResponse`/`BaseNodesResponse`).
  - Metadata API: adapt index lookups to project-scoped metadata (`metadata().getProject().index(...)`) to match ES 9.x model changes.
  - SearchHit API: update document field logging to the new `SearchHit#setDocumentField(DocumentField)` signature.
  - Lucene API: replace `new DisiPriorityQueue(size)` with `DisiPriorityQueue.ofMaxSize(size)` for Lucene 10.3.
  - Tests: update removed constants/constructors (e.g., TransportVersions constant removal; IndexNameExpressionResolver constructor parameter changes).
- Fix a latent deserialization bug exposed by the upgrade:
  - `TransportClearCachesAction#newNodeResponse(...)` now returns `new ClearCachesNodeResponse(in)` instead of `null`, which is required for proper node response deserialization under ES 9.2.

- ES 9.x test framework can optionly enable entitlement instrumentation during `ESTestCase` bootstrap via system properties.
- In this plugin repo’s Gradle unit-test JVM (`./gradlew test`), enabling entitlements without a full ES distro-style bootstrap can fail before tests run.
- We therefore default `es.entitlement.enableForTests=false` for Gradle `Test` tasks *only when the property is not already set*, preserving an opt-in path (`-Des.entitlement.enableForTests=true`) for environments that can correctly provide the required entitlement bootstrap wiring.
- This does not affect plugin runtime behavior in a real Elasticsearch distribution; it only affects the unit-test JVM bootstrap path.

- Ran with JDK 21:
  - `./gradlew test`
  - `./gradlew clean test`
  - `./gradlew clean check` (includes unit tests, `javaRestTest`, `yamlRestTest`, checkstyle, and packaging checks)