### PR TITLE
Support Elasticsearch 9.3.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ allprojects {
     implementation "org.ow2.asm:asm:${ow2Version}"
     implementation "org.ow2.asm:asm-commons:${ow2Version}"
     implementation "org.ow2.asm:asm-tree:${ow2Version}"
-    implementation 'com.o19s:RankyMcRankFace:0.1.1'
+    implementation 'com.o19s:RankyMcRankFace:0.3.0'
     implementation "com.github.spullara.mustache.java:compiler:0.9.3"
 
     runtimeOnly 'org.locationtech.spatial4j:spatial4j:0.7'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 ltrVersion = 1.5.13
-elasticsearchVersion = 9.3.2
+elasticsearchVersion = 9.3.5
 luceneVersion = 10.3.2
 ow2Version = 8.0.1
 antlrVersion = 4.5.1-1

--- a/src/main/java/com/o19s/es/template/mustache/MustacheUtils.java
+++ b/src/main/java/com/o19s/es/template/mustache/MustacheUtils.java
@@ -21,20 +21,15 @@ import com.github.mustachejava.MustacheException;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.util.Supplier;
-import org.elasticsearch.SpecialPermission;
 import org.apache.logging.log4j.LogManager;
-
 
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Map;
 
 public class MustacheUtils {
     public static final String TEMPLATE_LANGUAGE = "mustache";
     private static final Logger logger = LogManager.getLogger(MustacheUtils.class);
-    private static final SpecialPermission SPECIAL_PERMS = new SpecialPermission();
     /**
      * We store templates internally always as json
      */
@@ -52,20 +47,11 @@ public class MustacheUtils {
     public static String execute(Mustache template, Map<String, Object> params) {
         final StringWriter writer = new StringWriter();
         try {
-            // crazy reflection here
-            SecurityManager sm = System.getSecurityManager();
-            if (sm != null) {
-                sm.checkPermission(SPECIAL_PERMS);
-            }
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                template.execute(writer, params);
-                return null;
-            });
+            template.execute(writer, params);
         } catch (Exception e) {
             logger.error((Supplier<?>) () -> new ParameterizedMessage("Error running {}", template), e);
             throw new IllegalArgumentException("Error running " + template, e);
         }
         return writer.toString();
-
     }
 }


### PR DESCRIPTION
**Support ES 9.3.5** 
`SpecialPermission` was removed because Java's SecurityManager was deprecated and removed.
This PR strips out the entire security-manager ceremony in `execute()`and calls `template.execute()` directly.

**Update RankyMcRankFace**
Fixes security vulnerability by disabling external XML entity (XXE) loading in the RankLib XML parser (the EnsembleParser used for random forest/MART models)