### PR TITLE
Update to Elasticsearch 9.4.1 / Lucene 10.4.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 ltrVersion = 1.5.13
-elasticsearchVersion = 9.3.5
-luceneVersion = 10.3.2
+elasticsearchVersion = 9.4.1
+luceneVersion = 10.4.0
 ow2Version = 8.0.1
 antlrVersion = 4.5.1-1

--- a/src/main/java/com/o19s/es/explore/ExplorerQueryBuilder.java
+++ b/src/main/java/com/o19s/es/explore/ExplorerQueryBuilder.java
@@ -16,6 +16,7 @@
 package com.o19s.es.explore;
 
 import org.apache.lucene.search.Query;
+import org.elasticsearch.search.internal.MaxClauseCountQueryVisitor;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.ParsingException;
@@ -99,8 +100,8 @@ public class ExplorerQueryBuilder extends AbstractQueryBuilder<ExplorerQueryBuil
     }
 
     @Override
-    protected Query doToQuery(SearchExecutionContext context) throws IOException {
-        return new ExplorerQuery(query.toQuery(context), type);
+    protected Query doToQuery(SearchExecutionContext context, MaxClauseCountQueryVisitor visitor) throws IOException {
+        return new ExplorerQuery(query.toQuery(context, visitor), type);
     }
 
     @Override

--- a/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
+++ b/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
@@ -77,13 +77,9 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.xcontent.ParseField;
-import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry.Entry;
-import org.elasticsearch.common.settings.ClusterSettings;
-import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.index.Index;
@@ -94,7 +90,6 @@ import org.elasticsearch.plugins.AnalysisPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.plugins.SearchPlugin;
-import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptEngine;
@@ -164,13 +159,7 @@ public class LtrQueryParserPlugin extends Plugin implements SearchPlugin, Script
     }
 
     @Override
-    public List<RestHandler> getRestHandlers(Settings settings,
-                                             NamedWriteableRegistry namedWriteableRegistry,
-                                             RestController restController,
-                                             ClusterSettings clusterSettings,
-                                             IndexScopedSettings indexScopedSettings,
-                                             SettingsFilter settingsFilter,
-                                             IndexNameExpressionResolver indexNameExpressionResolver,
+    public List<RestHandler> getRestHandlers(ActionPlugin.RestHandlersServices restHandlersServices,
                                              Supplier<DiscoveryNodes> nodesInCluster,
                                              Predicate<NodeFeature> clusterSupportsFeature) {
         List<RestHandler> list = new ArrayList<>();

--- a/src/main/java/com/o19s/es/ltr/query/LtrQueryBuilder.java
+++ b/src/main/java/com/o19s/es/ltr/query/LtrQueryBuilder.java
@@ -24,6 +24,7 @@ import com.o19s.es.ltr.ranker.LtrRanker;
 import com.o19s.es.ltr.ranker.ranklib.RankLibScriptEngine;
 import com.o19s.es.ltr.utils.AbstractQueryBuilderUtils;
 import org.apache.lucene.search.Query;
+import org.elasticsearch.search.internal.MaxClauseCountQueryVisitor;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.ParsingException;
@@ -123,10 +124,10 @@ public class LtrQueryBuilder extends AbstractQueryBuilder<LtrQueryBuilder> {
     }
 
     @Override
-    protected Query doToQuery(SearchExecutionContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context, MaxClauseCountQueryVisitor visitor) throws IOException {
         List<PrebuiltFeature> features = new ArrayList<>(_features.size());
         for (QueryBuilder builder : _features) {
-            features.add(new PrebuiltFeature(builder.queryName(), builder.toQuery(context)));
+            features.add(new PrebuiltFeature(builder.queryName(), builder.toQuery(context, visitor)));
         }
         features = Collections.unmodifiableList(features);
 

--- a/src/main/java/com/o19s/es/ltr/query/StoredLtrQueryBuilder.java
+++ b/src/main/java/com/o19s/es/ltr/query/StoredLtrQueryBuilder.java
@@ -24,6 +24,7 @@ import com.o19s.es.ltr.feature.store.index.IndexFeatureStore;
 import com.o19s.es.ltr.ranker.linear.LinearRanker;
 import com.o19s.es.ltr.utils.FeatureStoreLoader;
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.search.internal.MaxClauseCountQueryVisitor;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.NamedWriteable;
@@ -159,15 +160,16 @@ public class StoredLtrQueryBuilder extends AbstractQueryBuilder<StoredLtrQueryBu
     }
 
     @Override
-    protected RankerQuery doToQuery(SearchExecutionContext context) throws IOException {
+    protected RankerQuery doToQuery(SearchExecutionContext context, MaxClauseCountQueryVisitor visitor) throws IOException {
         String indexName = storeName != null ? IndexFeatureStore.indexName(storeName) : IndexFeatureStore.DEFAULT_STORE;
         FeatureStore store = storeLoader.load(indexName, context::getClient);
+        RankerQuery rankerQuery;
         LtrQueryContext ltrQueryContext = new LtrQueryContext(context,
                 activeFeatures == null ? Collections.emptySet() : new HashSet<>(activeFeatures));
         if (modelName != null) {
             CompiledLtrModel model = store.loadModel(modelName);
             validateActiveFeatures(model.featureSet(), ltrQueryContext);
-            return RankerQuery.build(model, ltrQueryContext, params, featureScoreCacheFlag);
+            rankerQuery = RankerQuery.build(model, ltrQueryContext, params, featureScoreCacheFlag);
         } else {
             assert featureSetName != null;
             FeatureSet set = store.loadSet(featureSetName);
@@ -176,8 +178,12 @@ public class StoredLtrQueryBuilder extends AbstractQueryBuilder<StoredLtrQueryBu
             LinearRanker ranker = new LinearRanker(weights);
             CompiledLtrModel model = new CompiledLtrModel("linear", set, ranker);
             validateActiveFeatures(model.featureSet(), ltrQueryContext);
-            return RankerQuery.build(model, ltrQueryContext, params, featureScoreCacheFlag);
+            rankerQuery = RankerQuery.build(model, ltrQueryContext, params, featureScoreCacheFlag);
         }
+        if (visitor != null) {
+            rankerQuery.visit(visitor);
+        }
+        return rankerQuery;
     }
 
     @Override

--- a/src/main/java/com/o19s/es/ltr/query/ValidatingLtrQueryBuilder.java
+++ b/src/main/java/com/o19s/es/ltr/query/ValidatingLtrQueryBuilder.java
@@ -30,6 +30,7 @@ import com.o19s.es.ltr.ranker.linear.LinearRanker;
 import com.o19s.es.ltr.ranker.parser.LtrRankerParserFactory;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
+import org.elasticsearch.search.internal.MaxClauseCountQueryVisitor;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.ParsingException;
@@ -159,9 +160,10 @@ public class ValidatingLtrQueryBuilder extends AbstractQueryBuilder<ValidatingLt
     }
 
     @Override
-    protected Query doToQuery(SearchExecutionContext searchExecutionContext) throws IOException {
+    protected Query doToQuery(SearchExecutionContext searchExecutionContext, MaxClauseCountQueryVisitor visitor) throws IOException {
         //TODO: should we be passing activeFeatures here?
         LtrQueryContext context = new LtrQueryContext(searchExecutionContext);
+        Query result;
         if (StoredFeature.TYPE.equals(element.type())) {
             Feature feature = ((StoredFeature) element).optimize();
             if (feature instanceof PrecompiledExpressionFeature) {
@@ -169,18 +171,22 @@ public class ValidatingLtrQueryBuilder extends AbstractQueryBuilder<ValidatingLt
                 return new MatchAllDocsQuery();
             }
             //TODO: support activeFeatures in Validating queries
-            return feature.doToQuery(context, null, validation.getParams());
+            result = feature.doToQuery(context, null, validation.getParams());
         } else if (StoredFeatureSet.TYPE.equals(element.type())) {
             FeatureSet set = ((StoredFeatureSet) element).optimize();
             LinearRanker ranker = new LinearRanker(new float[set.size()]);
             CompiledLtrModel model = new CompiledLtrModel("validation", set, ranker);
-            return RankerQuery.build(model, context, validation.getParams(), false);
+            result = RankerQuery.build(model, context, validation.getParams(), false);
         } else if (StoredLtrModel.TYPE.equals(element.type())) {
             CompiledLtrModel model = ((StoredLtrModel) element).compile(factory);
-            return RankerQuery.build(model, context, validation.getParams(), false);
+            result = RankerQuery.build(model, context, validation.getParams(), false);
         } else {
             throw new QueryShardException(searchExecutionContext, "Unknown element type [" + element.type() + "]");
         }
+        if (visitor != null) {
+            result.visit(visitor);
+        }
+        return result;
     }
 
     @Override

--- a/src/main/java/com/o19s/es/termstat/TermStatQueryBuilder.java
+++ b/src/main/java/com/o19s/es/termstat/TermStatQueryBuilder.java
@@ -8,6 +8,7 @@ import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.TermToBytesRefAttribute;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
+import org.elasticsearch.search.internal.MaxClauseCountQueryVisitor;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.ParsingException;
@@ -134,7 +135,7 @@ public class TermStatQueryBuilder extends AbstractQueryBuilder<TermStatQueryBuil
     }
 
     @Override
-    protected Query doToQuery(SearchExecutionContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context, MaxClauseCountQueryVisitor visitor) throws IOException {
         var compiledExpression = Scripting.compile(expr);
         AggrType aggrType = AggrType.valueOf(aggr.toUpperCase(Locale.getDefault()));
         AggrType posAggrType = AggrType.valueOf(pos_aggr.toUpperCase(Locale.getDefault()));
@@ -166,7 +167,11 @@ public class TermStatQueryBuilder extends AbstractQueryBuilder<TermStatQueryBuil
             }
         }
 
-        return new TermStatQuery(compiledExpression, aggrType, posAggrType, termSet);
+
+        Query result = new TermStatQuery(compiledExpression, aggrType, posAggrType, termSet);
+        if (visitor != null)
+            result.visit(visitor);
+        return result;
     }
 
     private Analyzer getAnalyzerForField(SearchExecutionContext context, String fieldName) {

--- a/src/test/java/com/o19s/es/ltr/query/StoredLtrQueryBuilderTests.java
+++ b/src/test/java/com/o19s/es/ltr/query/StoredLtrQueryBuilderTests.java
@@ -175,7 +175,7 @@ public class StoredLtrQueryBuilderTests extends AbstractQueryTestCase<StoredLtrQ
             builder.activeFeatures(Arrays.asList("match1", "match2"));
         }
 
-        RankerQuery rankerQuery = builder.doToQuery(createSearchExecutionContext());
+        RankerQuery rankerQuery = builder.doToQuery(createSearchExecutionContext(), null);
         List<Query> queries = rankerQuery.stream().collect(Collectors.toList());
         assertEquals(clazz, queries.get(2).getClass());
     }


### PR DESCRIPTION
Bump elasticsearchVersion to 9.4.2, luceneVersion to 10.4.0
Update doToQuery signatures to new two-arg form (SearchExecutionContext, MaxClauseCountQueryVisitor)
Update getRestHandlers signature to new ActionPlugin.RestHandlersServices form